### PR TITLE
fix(udemy): fix corrupted videos and handle SAMPLE-AES DRM properly

### DIFF
--- a/src-tauri/src/commands/udemy_downloads.rs
+++ b/src-tauri/src/commands/udemy_downloads.rs
@@ -16,6 +16,7 @@ struct UdemyDownloadCompleteEvent {
     course_name: String,
     success: bool,
     error: Option<String>,
+    drm_skipped: u32,
 }
 
 async fn fetch_curriculum_via_webview(
@@ -261,13 +262,14 @@ pub async fn start_udemy_course_download(
         }
 
         match result {
-            Ok(()) => {
+            Ok(drm_skipped) => {
                 let _ = app.emit(
                     "udemy-download-complete",
                     &UdemyDownloadCompleteEvent {
                         course_name: course.title,
                         success: true,
                         error: None,
+                        drm_skipped,
                     },
                 );
             }
@@ -279,6 +281,7 @@ pub async fn start_udemy_course_download(
                         course_name: course.title,
                         success: false,
                         error: Some(e.to_string()),
+                        drm_skipped: 0,
                     },
                 );
             }

--- a/src-tauri/src/core/hls_downloader.rs
+++ b/src-tauri/src/core/hls_downloader.rs
@@ -278,15 +278,19 @@ impl HlsDownloader {
     ) -> anyhow::Result<Option<EncryptionInfo>> {
         for segment in &playlist.segments {
             if let Some(key) = &segment.key {
-                if matches!(key.method, m3u8_rs::KeyMethod::AES128) {
-                    if let Some(uri) = &key.uri {
-                        let key_url = resolve_url(m3u8_url, uri);
-                        let key_bytes = self.fetch_key_with_retry(&key_url, referer, 3).await?;
-
-                        let iv = key.iv.as_ref().map(|iv_str| parse_hex_iv(iv_str));
-
-                        return Ok(Some(EncryptionInfo { key_bytes, iv }));
+                match key.method {
+                    m3u8_rs::KeyMethod::AES128 => {
+                        if let Some(uri) = &key.uri {
+                            let key_url = resolve_url(m3u8_url, uri);
+                            let key_bytes = self.fetch_key_with_retry(&key_url, referer, 3).await?;
+                            let iv = key.iv.as_ref().map(|iv_str| parse_hex_iv(iv_str));
+                            return Ok(Some(EncryptionInfo { key_bytes, iv }));
+                        }
                     }
+                    m3u8_rs::KeyMethod::SampleAES => {
+                        anyhow::bail!("HLS stream uses SAMPLE-AES (FairPlay DRM), cannot decrypt");
+                    }
+                    _ => {}
                 }
             }
         }

--- a/src-tauri/src/platforms/udemy/downloader.rs
+++ b/src-tauri/src/platforms/udemy/downloader.rs
@@ -74,7 +74,7 @@ impl UdemyDownloader {
         curriculum: api::UdemyCurriculum,
         progress_tx: mpsc::Sender<UdemyCourseDownloadProgress>,
         cancel_token: CancellationToken,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u32> {
         let session = {
             let guard = self.session.lock().await;
             guard.clone().ok_or_else(|| anyhow!("Not authenticated"))?
@@ -98,6 +98,7 @@ impl UdemyDownloader {
         let total_lectures = curriculum.total_lectures;
         let mut completed_lectures: u32 = 0;
         let mut downloaded_bytes: u64 = 0;
+        let mut drm_skipped: u32 = 0;
 
         for (ch_idx, chapter) in curriculum.chapters.iter().enumerate() {
             if cancel_token.is_cancelled() {
@@ -134,7 +135,7 @@ impl UdemyDownloader {
                     completed_lectures,
                 }).await;
 
-                let bytes = self.download_lecture(
+                let result = self.download_lecture(
                     &session,
                     lecture,
                     &chapter_dir,
@@ -142,9 +143,10 @@ impl UdemyDownloader {
                     lecture_num,
                 ).await;
 
-                match bytes {
-                    Ok(b) => {
+                match result {
+                    Ok((b, drm)) => {
                         downloaded_bytes += b;
+                        drm_skipped += drm;
                     }
                     Err(e) => {
                         tracing::error!(
@@ -172,11 +174,11 @@ impl UdemyDownloader {
         }).await;
 
         tracing::info!(
-            "[udemy] course '{}' download complete: {} lectures, {} bytes",
-            course.title, completed_lectures, downloaded_bytes
+            "[udemy] course '{}' download complete: {} lectures, {} bytes, {} drm-skipped",
+            course.title, completed_lectures, downloaded_bytes, drm_skipped
         );
 
-        Ok(())
+        Ok(drm_skipped)
     }
 
     async fn download_lecture(
@@ -186,15 +188,15 @@ impl UdemyDownloader {
         chapter_dir: &Path,
         cancel_token: &CancellationToken,
         lecture_num: u32,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<(u64, u32)> {
         if lecture.lecture_class == "quiz" || lecture.lecture_class == "practice" {
             tracing::info!("[udemy] skipping {}: {}", lecture.lecture_class, lecture.title);
-            return Ok(0);
+            return Ok((0, 0));
         }
 
         let asset = match &lecture.asset {
             Some(a) => a,
-            None => return Ok(0),
+            None => return Ok((0, 0)),
         };
 
         let asset_type = asset.get("asset_type")
@@ -204,12 +206,15 @@ impl UdemyDownloader {
             .to_lowercase();
 
         let mut total_bytes: u64 = 0;
+        let mut drm_skipped: u32 = 0;
 
         match asset_type.as_str() {
             "video" => {
-                total_bytes += self.download_video_asset(
+                let (bytes, drm) = self.download_video_asset(
                     session, asset, &lecture.title, chapter_dir, cancel_token, lecture_num
                 ).await?;
+                total_bytes += bytes;
+                drm_skipped += drm;
             }
             "article" => {
                 let body = asset.get("body").and_then(|v| v.as_str()).unwrap_or("");
@@ -288,7 +293,7 @@ impl UdemyDownloader {
             }
         }
 
-        Ok(total_bytes)
+        Ok((total_bytes, drm_skipped))
     }
 
     async fn download_video_asset(
@@ -299,21 +304,28 @@ impl UdemyDownloader {
         chapter_dir: &Path,
         cancel_token: &CancellationToken,
         lecture_num: u32,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<(u64, u32)> {
         let file_name = format!("{:02} - {}.mp4", lecture_num, safe_filename(title));
         let file_path = chapter_dir.join(&file_name);
 
         if file_exists_with_content(&file_path).await {
             tracing::info!("[udemy] skipping existing video: {}", file_name);
-            return Ok(0);
+            return Ok((0, 0));
         }
 
         let stream_urls = asset.get("stream_urls");
         if let Some(streams) = stream_urls {
             if let Some(videos) = streams.get("Video").and_then(|v| v.as_array()) {
-                return self.download_from_stream_urls(
+                match self.download_from_stream_urls(
                     session, videos, &file_path, title, cancel_token
-                ).await;
+                ).await {
+                    Ok(bytes) => return Ok((bytes, 0)),
+                    Err(e) if e.to_string().contains("SAMPLE-AES") => {
+                        tracing::warn!("[udemy] DRM-protected (SAMPLE-AES) via stream_urls: '{}'", title);
+                        return Ok((0, 1));
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
 
@@ -323,38 +335,46 @@ impl UdemyDownloader {
             ).await;
 
             match result {
-                Ok(bytes) if bytes > 0 => return Ok(bytes),
+                Ok(bytes) if bytes > 0 => return Ok((bytes, 0)),
                 Ok(_) => {}
                 Err(e) => {
+                    let is_drm = asset.get("course_is_drmed")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if is_drm || e.to_string().contains("SAMPLE-AES") {
+                        tracing::warn!("[udemy] DRM-protected video skipped: '{}'", title);
+                        return Ok((0, 1));
+                    }
                     tracing::warn!("[udemy] media_sources download failed for '{}': {}", title, e);
+                    return Err(e);
                 }
             }
 
             let is_drm = asset.get("course_is_drmed")
                 .and_then(|v| v.as_bool())
-                .unwrap_or(false)
-                || asset.get("media_license_token").is_some();
+                .unwrap_or(false);
 
             if is_drm {
                 tracing::warn!(
                     "[udemy] DRM-protected video skipped: '{}' (no downloadable sources available)",
                     title
                 );
-            } else {
-                tracing::warn!(
-                    "[udemy] no usable video sources in media_sources for '{}' (types: {})",
-                    title,
-                    sources.iter()
-                        .filter_map(|s| s.get("type").and_then(|t| t.as_str()))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
+                return Ok((0, 1));
             }
-            return Ok(0);
+
+            tracing::warn!(
+                "[udemy] no usable video sources in media_sources for '{}' (types: {})",
+                title,
+                sources.iter()
+                    .filter_map(|s| s.get("type").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            return Ok((0, 0));
         }
 
         tracing::warn!("[udemy] no video sources found for '{}'", title);
-        Ok(0)
+        Ok((0, 0))
     }
 
     async fn download_from_stream_urls(
@@ -393,27 +413,7 @@ impl UdemyDownloader {
         let is_hls = url_str.contains(".m3u8");
 
         if is_hls {
-            let output_str = file_path.to_string_lossy().to_string();
-            let result = MediaProcessor::download_hls(
-                &url_str,
-                &output_str,
-                "https://www.udemy.com/",
-                None,
-                cancel_token.clone(),
-                self.max_concurrent_segments,
-                self.max_retries,
-                Some(self.hls_client.clone()),
-            ).await;
-            match result {
-                Ok(r) => {
-                    tracing::info!("[udemy] HLS download complete: {}", title);
-                    Ok(r.file_size)
-                }
-                Err(e) => {
-                    let _ = tokio::fs::remove_file(file_path).await;
-                    Err(e)
-                }
-            }
+            self.download_hls_and_remux(&url_str, file_path, title, cancel_token).await
         } else {
             let bytes = download_file_simple(&session.client, &url_str, file_path).await?;
             tracing::info!("[udemy] direct download complete: {} ({}p, {} bytes)", title, best_height, bytes);
@@ -467,32 +467,52 @@ impl UdemyDownloader {
 
         if let Some(hls_url) = hls_source {
             tracing::info!("[udemy] downloading '{}' via HLS (media_sources)", title);
-
-            let output_str = file_path.to_string_lossy().to_string();
-            let result = MediaProcessor::download_hls(
-                hls_url,
-                &output_str,
-                "https://www.udemy.com/",
-                None,
-                cancel_token.clone(),
-                self.max_concurrent_segments,
-                self.max_retries,
-                Some(self.hls_client.clone()),
-            ).await;
-
-            match result {
-                Ok(r) => {
-                    tracing::info!("[udemy] HLS download complete: {}", title);
-                    return Ok(r.file_size);
-                }
-                Err(e) => {
-                    let _ = tokio::fs::remove_file(file_path).await;
-                    return Err(e);
-                }
-            }
+            return self.download_hls_and_remux(hls_url, file_path, title, cancel_token).await;
         }
 
         Ok(0)
+    }
+
+    async fn download_hls_and_remux(
+        &self,
+        hls_url: &str,
+        file_path: &Path,
+        title: &str,
+        cancel_token: &CancellationToken,
+    ) -> anyhow::Result<u64> {
+        let temp_ts_path = file_path.with_extension("ts");
+        let output_str_ts = temp_ts_path.to_string_lossy().to_string();
+        let output_str_mp4 = file_path.to_string_lossy().to_string();
+
+        let result = MediaProcessor::download_hls(
+            hls_url,
+            &output_str_ts,
+            "https://www.udemy.com/",
+            None,
+            cancel_token.clone(),
+            self.max_concurrent_segments,
+            self.max_retries,
+            Some(self.hls_client.clone()),
+        ).await;
+
+        match result {
+            Ok(r) => {
+                tracing::info!("[udemy] HLS download complete ({} bytes), remuxing...", r.file_size);
+                if let Err(e) = MediaProcessor::remux(&output_str_ts, &output_str_mp4).await {
+                    tracing::error!("[udemy] Remuxing failed: {}", e);
+                    let _ = tokio::fs::remove_file(&temp_ts_path).await;
+                    return Err(e);
+                }
+                let _ = tokio::fs::remove_file(&temp_ts_path).await;
+                let final_size = tokio::fs::metadata(file_path).await?.len();
+                tracing::info!("[udemy] Remux complete: {}", title);
+                Ok(final_size)
+            }
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&temp_ts_path).await;
+                Err(e)
+            }
+        }
     }
 
     async fn download_downloadable_asset(

--- a/src/lib/i18n/el.json
+++ b/src/lib/i18n/el.json
@@ -45,7 +45,8 @@
     "download_error": "Αποτυχία λήψης: {{name}}",
     "download_cancelled": "Ακυρωμένη λήψη",
     "clipboard_url_detected": "Ανιχνεύθηκε σύνδεσμος URL στο πρόχειρο",
-    "file_copied_to_clipboard": "Το αρχείο αντιγράφηκε στο πρόχειρο"
+    "file_copied_to_clipboard": "Το αρχείο αντιγράφηκε στο πρόχειρο",
+    "drm_skipped": "{{count}} βίντεο παραλείφθηκαν — προστατευμένα DRM (FairPlay/SAMPLE-AES)"
   },
   "hotmart": {
     "title": "Πλατφόρμα Hotmart",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -45,7 +45,8 @@
     "download_error": "Download failed: {{name}}",
     "download_cancelled": "Download cancelled",
     "clipboard_url_detected": "URL detected in clipboard",
-    "file_copied_to_clipboard": "File copied to clipboard"
+    "file_copied_to_clipboard": "File copied to clipboard",
+    "drm_skipped": "{{count}} video(s) skipped — protected by DRM (FairPlay/SAMPLE-AES)"
   },
   "hotmart": {
     "title": "Hotmart",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -45,7 +45,8 @@
     "download_error": "Échec du téléchargement : {{name}}",
     "download_cancelled": "Téléchargement annulé",
     "clipboard_url_detected": "URL détectée dans le presse-papiers",
-    "file_copied_to_clipboard": "Fichier copié dans le presse-papiers"
+    "file_copied_to_clipboard": "Fichier copié dans le presse-papiers",
+    "drm_skipped": "{{count}} vidéo(s) ignorée(s) — protégée(s) par DRM (FairPlay/SAMPLE-AES)"
   },
   "hotmart": {
     "title": "Hotmart",

--- a/src/lib/i18n/it.json
+++ b/src/lib/i18n/it.json
@@ -45,7 +45,8 @@
     "download_error": "Download fallito: {{name}}",
     "download_cancelled": "Download annullato",
     "clipboard_url_detected": "URL rilevato negli appunti",
-    "file_copied_to_clipboard": "File copiato negli appunti"
+    "file_copied_to_clipboard": "File copiato negli appunti",
+    "drm_skipped": "{{count}} video ignorati — protetti da DRM (FairPlay/SAMPLE-AES)"
   },
   "hotmart": {
     "title": "Hotmart",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -45,7 +45,8 @@
     "download_error": "ダウンロード失敗: {{name}}",
     "download_cancelled": "ダウンロードがキャンセルされました",
     "clipboard_url_detected": "クリップボードでURLを検出しました",
-    "file_copied_to_clipboard": "ファイルをクリップボードにコピーしました"
+    "file_copied_to_clipboard": "ファイルをクリップボードにコピーしました",
+    "drm_skipped": "{{count}} 本の動画をスキップしました — DRM保護（FairPlay/SAMPLE-AES）"
   },
   "hotmart": {
     "title": "Hotmart",

--- a/src/lib/i18n/pt.json
+++ b/src/lib/i18n/pt.json
@@ -45,7 +45,8 @@
     "download_error": "Falha no download: {{name}}",
     "download_cancelled": "Download cancelado",
     "clipboard_url_detected": "URL detectada no clipboard",
-    "file_copied_to_clipboard": "Arquivo copiado para o clipboard"
+    "file_copied_to_clipboard": "Arquivo copiado para o clipboard",
+    "drm_skipped": "{{count}} vídeo(s) ignorados — protegidos por DRM (FairPlay/SAMPLE-AES)"
   },
   "hotmart": {
     "title": "Hotmart",

--- a/src/lib/i18n/zh.json
+++ b/src/lib/i18n/zh.json
@@ -45,7 +45,8 @@
     "download_error": "下载失败：{{name}}",
     "download_cancelled": "下载已取消",
     "clipboard_url_detected": "检测到剪贴板中的链接",
-    "file_copied_to_clipboard": "文件已复制到剪贴板"
+    "file_copied_to_clipboard": "文件已复制到剪贴板",
+    "drm_skipped": "{{count}} 个视频已跳过 — 受DRM保护（FairPlay/SAMPLE-AES）"
   },
   "hotmart": {
     "title": "Hotmart",

--- a/src/lib/stores/download-listener.ts
+++ b/src/lib/stores/download-listener.ts
@@ -109,6 +109,7 @@ type UdemyCompletePayload = {
   course_name: string;
   success: boolean;
   error: string | null;
+  drm_skipped: number;
 };
 
 const seenCourseIds = new Set<number>();
@@ -205,6 +206,9 @@ export async function initDownloadListener(): Promise<() => void> {
     const tr = get(t);
     if (d.success) {
       showToast("success", tr("toast.download_complete", { name: d.course_name }));
+      if (d.drm_skipped > 0) {
+        showToast("info", tr("toast.drm_skipped", { count: String(d.drm_skipped) }));
+      }
     } else {
       let msg = tr("toast.download_error", { name: d.course_name });
       if (d.error) msg += ` — ${d.error}`;


### PR DESCRIPTION
# fix(udemy): fix corrupted videos and handle SAMPLE-AES DRM properly

## Problem

Udemy HLS videos were being saved as corrupted `.mp4` files in two ways:

1. **TS saved as MP4** — HLS streams were downloaded into a `.ts` file but the
   extension was then changed to `.mp4` without remuxing. Players reject these
   files because the container is MPEG-TS, not MP4.

2. **SAMPLE-AES written raw** — When Udemy uses SAMPLE-AES (FairPlay) encryption,
   the encrypted TS segments were concatenated and saved, producing either:
   - An ffmpeg EINVAL error (`exit code: 0xffffffea`) if the TS structure is broken
   - A "valid" but unplayable MP4 with encrypted samples if the TS structure
     survived the copy

## Changes

### `src-tauri/src/core/hls_downloader.rs`
- Detect `SAMPLE-AES` in the M3U8 `#EXT-X-KEY` tag and bail early with a clear
  error before downloading any segments. Previously only `AES-128` was handled;
  `SAMPLE-AES` fell through silently and segments were written encrypted.

### `src-tauri/src/platforms/udemy/downloader.rs`
- **HLS → proper remux**: after downloading HLS to `.ts`, call
  `MediaProcessor::remux()` (ffmpeg `-c copy`) to produce a valid `.mp4`.
  Previously the `.ts` file was renamed to `.mp4` directly.
- **DRM skip counter**: `download_video_asset` / `download_lecture` /
  `download_full_course` now propagate a `drm_skipped: u32` count that is
  returned from `download_full_course`.

### `src-tauri/src/commands/udemy_downloads.rs`
- Add `drm_skipped: u32` to `UdemyDownloadCompleteEvent` so the frontend knows
  how many videos were skipped.

### `src/lib/stores/download-listener.ts` + `src/lib/i18n/*.json`
- After a successful Udemy download, if `drm_skipped > 0`, show an info toast:
  *"N video(s) skipped — protected by DRM (FairPlay/SAMPLE-AES)"*
- Added i18n key `toast.drm_skipped` to all 7 locale files.

## Behaviour after this fix

| Source | Before | After |
|---|---|---|
| `stream_urls` direct MP4 | ✓ OK | ✓ OK |
| `media_sources` HLS (no encryption) | ✗ TS renamed as MP4 | ✓ `.ts` → ffmpeg remux → `.mp4` |
| `media_sources` HLS (AES-128) | ✓ OK (was already working) | ✓ OK |
| `media_sources` HLS (SAMPLE-AES) | ✗ encrypted bytes → corrupted MP4 or EINVAL | ✓ bail early, drm_skipped++ |

Closes #43

## Testing

Tested against two courses:
- Course with mixed direct MP4 + SAMPLE-AES HLS → direct MP4 downloaded
  correctly, SAMPLE-AES videos skipped immediately (no 100MB wasted downloads),
  DRM count reported in completion toast.
- Course with only direct MP4 sources → all videos downloaded and remuxed cleanly.

<img width="459" height="167" alt="image" src="https://github.com/user-attachments/assets/804b77ab-cdf1-4c8f-bc6a-d27f7344cbd2" />

