### PR TITLE
fix(telegram): preserve active session on redundant QR login

### DIFF
--- a/src-tauri/src/platforms/telegram/auth.rs
+++ b/src-tauri/src/platforms/telegram/auth.rs
@@ -257,8 +257,28 @@ async fn handle_migrate(
 
 pub async fn qr_login_start(handle: &TelegramSessionHandle) -> anyhow::Result<QrLoginResult> {
     tracing::info!("[tg-qr] qr_login_start: creating client");
-    let mut guard = handle.lock().await;
+    let existing_client = {
+        let guard = handle.lock().await;
+        guard.client.clone()
+    };
 
+    if let Some(client) = existing_client {
+        if client.is_authorized().await.unwrap_or(false) {
+            let phone = client
+                .get_me()
+                .await
+                .ok()
+                .and_then(|me| me.phone().map(str::to_string))
+                .unwrap_or_default();
+            let mut guard = handle.lock().await;
+            if !phone.is_empty() {
+                guard.phone = phone;
+            }
+            return Err(anyhow!("already_authenticated"));
+        }
+    }
+
+    let mut guard = handle.lock().await;
     if let Some(old_client) = guard.client.take() {
         old_client.disconnect();
     }


### PR DESCRIPTION
# fix(telegram): preserve active session on redundant QR login

## Problem

`qr_login_start()` unconditionally disconnected and replaced the global Telegram client, even when the session was already authenticated. If the UI triggered a QR login flow while downloads were in-flight, the old client was invalidated — causing `AUTH_KEY_UNREGISTERED` errors or silent download failures.

## Root Cause

`qr_login_start` (`auth.rs:258`) immediately acquired the session lock and called `guard.client.take()` + `old_client.disconnect()` without checking whether the existing client was already authorized. Any in-flight `upload.GetFile` or `iter_download` calls on the old client would fail after disconnect.

## Changes

### `src-tauri/src/platforms/telegram/auth.rs`

Added an early-return guard before the client replacement logic in `qr_login_start()`:

1. Clones the existing client reference (outside the lock to avoid holding it during async calls)
2. Calls `client.is_authorized().await` to check if the session is live
3. If authorized, fetches the phone number via `get_me()` and updates the session state
4. Returns `Err("already_authenticated")` — preserving the active client and all in-flight downloads

The `already_authenticated` error string was already handled by the frontend (the `LoginToken::Success` arm at `auth.rs:279` used the same pattern pre-existing), so no frontend changes are needed.

Minor TOCTOU between the `is_authorized()` check and re-acquiring the lock — benign for this use case since authorization state doesn't flip spontaneously.

## Behaviour after this fix

| Scenario | Before | After |
|---|---|---|
| QR login while already authenticated | Active client disconnected, in-flight downloads break | Existing client preserved, returns `already_authenticated` |
| QR login when not authenticated | Creates new client normally | Creates new client normally (unchanged) |
| QR login after session expiry | Creates new client normally | `is_authorized()` returns false, creates new client normally |

Closes #46

## Testing

- `cargo check` passes cleanly
- QR login on an already-authenticated session returns immediately without disconnecting the active client
