### PR TITLE
fix(deps): prefer managed binaries and resolve system tool paths

### DIFF
--- a/src-tauri/src/core/dependencies.rs
+++ b/src-tauri/src/core/dependencies.rs
@@ -146,6 +146,19 @@ pub async fn check_version(tool: &str) -> Option<String> {
 }
 
 pub async fn ensure_ffmpeg() -> anyhow::Result<PathBuf> {
+    // Always ensure the managed binary exists — the standalone yt-dlp.exe
+    // cannot discover system FFmpeg from PATH. A managed copy in the same
+    // bin dir is always found via --ffmpeg-location.
+    if !is_flatpak() {
+        let managed = managed_bin_dir().map(|d| d.join(bin_name("ffmpeg")));
+        if managed.as_ref().map_or(true, |p| !p.exists()) {
+            if let Ok(path) = download_ffmpeg().await {
+                crate::core::ytdlp::reset_ffmpeg_location_cache();
+                return Ok(path);
+            }
+        }
+    }
+
     if let Some(path) = find_tool("ffmpeg").await {
         return Ok(path);
     }

--- a/src-tauri/src/core/dependencies.rs
+++ b/src-tauri/src/core/dependencies.rs
@@ -35,6 +35,29 @@ pub async fn find_tool(tool: &str) -> Option<PathBuf> {
         }
     }
 
+    // Check managed bin dir first — managed binaries are known-good
+    // (e.g. yt-dlp bundles yt-dlp-ejs, correct ffmpeg version, etc.).
+    let managed = managed_bin_dir().map(|d| d.join(&name));
+    if let Some(ref managed_path) = managed {
+        if managed_path.exists() {
+            if let Ok(status) = crate::core::process::command(managed_path)
+                .arg(version_flag)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .await
+            {
+                if status.success() {
+                    tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
+                    return Some(managed_path.clone());
+                }
+            }
+            tracing::warn!("find_tool({}): binary exists at {} but failed to execute", tool, managed_path.display());
+        }
+    }
+
+    // Fall back to system PATH. Resolve to an absolute path so callers
+    // (e.g. find_ffmpeg_location) can derive the parent directory.
     if let Ok(status) = crate::core::process::command(&name)
         .arg(version_flag)
         .stdout(Stdio::null())
@@ -43,30 +66,36 @@ pub async fn find_tool(tool: &str) -> Option<PathBuf> {
         .await
     {
         if status.success() {
+            let abs = resolve_absolute_path(&name);
             tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
-            return Some(PathBuf::from(&name));
+            return Some(abs);
         }
-    }
-
-    let managed = managed_bin_dir()?.join(&name);
-    if managed.exists() {
-        if let Ok(status) = crate::core::process::command(&managed)
-            .arg(version_flag)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-        {
-            if status.success() {
-                tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
-                return Some(managed);
-            }
-        }
-        tracing::warn!("find_tool({}): binary exists at {} but failed to execute", tool, managed.display());
     }
 
     tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
     None
+}
+
+/// Resolve a bare binary name to its absolute path via `where` (Windows)
+/// or `which` (Unix). Returns the original name as fallback.
+fn resolve_absolute_path(bin_name: &str) -> PathBuf {
+    let finder = if cfg!(target_os = "windows") { "where" } else { "which" };
+    if let Ok(output) = std::process::Command::new(finder)
+        .arg(bin_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+    {
+        if output.status.success() {
+            if let Some(line) = String::from_utf8_lossy(&output.stdout).lines().next() {
+                let path = line.trim();
+                if !path.is_empty() {
+                    return PathBuf::from(path);
+                }
+            }
+        }
+    }
+    PathBuf::from(bin_name)
 }
 
 fn version_flag_for(tool: &str) -> &'static str {

--- a/src-tauri/src/core/ytdlp.rs
+++ b/src-tauri/src/core/ytdlp.rs
@@ -145,6 +145,17 @@ pub async fn find_ytdlp() -> Option<PathBuf> {
         }
     }
 
+    // Prefer the managed binary — it bundles yt-dlp-ejs (required for
+    // YouTube nsig challenge). System-installed yt-dlp (e.g. dnf, apt)
+    // often lacks this plugin, causing "Requested format is not available".
+    let managed = managed_ytdlp_path()?;
+    if managed.exists() {
+        tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
+        return Some(managed);
+    }
+
+    // Fall back to system PATH. Resolve to an absolute path so the cache
+    // check (`path.exists()`) works — a bare "yt-dlp" would always fail.
     if let Ok(output) = crate::core::process::command(bin_name)
         .arg("--version")
         .stdout(Stdio::null())
@@ -153,19 +164,36 @@ pub async fn find_ytdlp() -> Option<PathBuf> {
         .await
     {
         if output.success() {
+            let abs = resolve_absolute_path(bin_name);
             tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
-            return Some(PathBuf::from(bin_name));
+            return Some(abs);
         }
-    }
-
-    let managed = managed_ytdlp_path()?;
-    if managed.exists() {
-        tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
-        return Some(managed);
     }
 
     tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
     None
+}
+
+/// Resolve a bare binary name to its absolute path via `where` (Windows)
+/// or `which` (Unix). Returns the original name as fallback.
+fn resolve_absolute_path(bin_name: &str) -> PathBuf {
+    let finder = if cfg!(target_os = "windows") { "where" } else { "which" };
+    if let Ok(output) = std::process::Command::new(finder)
+        .arg(bin_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+    {
+        if output.status.success() {
+            if let Some(line) = String::from_utf8_lossy(&output.stdout).lines().next() {
+                let path = line.trim();
+                if !path.is_empty() {
+                    return PathBuf::from(path);
+                }
+            }
+        }
+    }
+    PathBuf::from(bin_name)
 }
 
 pub async fn find_ytdlp_cached() -> Option<PathBuf> {

--- a/src-tauri/src/core/ytdlp.rs
+++ b/src-tauri/src/core/ytdlp.rs
@@ -231,12 +231,33 @@ fn managed_ytdlp_path() -> Option<PathBuf> {
 
 pub async fn ensure_ytdlp() -> anyhow::Result<PathBuf> {
     let _timer_start = std::time::Instant::now();
+
+    // Always ensure the managed binary exists — it bundles yt-dlp-ejs and
+    // works reliably with --js-runtimes and --ffmpeg-location. System yt-dlp
+    // (dnf, pip, standalone) often lacks plugins or can't find tools.
+    if !crate::core::dependencies::is_flatpak() {
+        let managed = managed_ytdlp_path();
+        if managed.as_ref().map_or(true, |p| !p.exists()) {
+            tracing::info!("[ytdlp] managed binary missing, downloading...");
+            match download_ytdlp_binary().await {
+                Ok(path) => {
+                    reset_ytdlp_cache();
+                    tokio::spawn(async { crate::core::dependencies::ensure_js_runtime().await; });
+                    tracing::debug!("[perf] ensure_ytdlp took {:?}", _timer_start.elapsed());
+                    return Ok(path);
+                }
+                Err(e) => {
+                    tracing::warn!("[ytdlp] failed to download managed binary, falling back to system: {}", e);
+                }
+            }
+        }
+    }
+
     if let Some(path) = find_ytdlp_cached().await {
         let path_clone = path.clone();
         tokio::spawn(async move {
             check_ytdlp_freshness(&path_clone).await;
         });
-        // Ensure a JS runtime is available in the background (for YouTube nsig).
         tokio::spawn(async { crate::core::dependencies::ensure_js_runtime().await; });
         tracing::debug!("[perf] ensure_ytdlp took {:?}", _timer_start.elapsed());
         return Ok(path);
@@ -249,7 +270,6 @@ pub async fn ensure_ytdlp() -> anyhow::Result<PathBuf> {
 
     let path = download_ytdlp_binary().await?;
     reset_ytdlp_cache();
-    // Ensure a JS runtime is available in the background (for YouTube nsig).
     tokio::spawn(async { crate::core::dependencies::ensure_js_runtime().await; });
     tracing::debug!("[perf] ensure_ytdlp took {:?}", _timer_start.elapsed());
     Ok(path)
@@ -1087,8 +1107,13 @@ pub async fn download_video(
         .map(|p| p.to_path_buf())
         .or_else(|| global_cookie_file.map(std::path::PathBuf::from))
         .or(ext_cookies);
+    let js_args = js_runtime_args();
+    tracing::info!(
+        "[yt-dlp] format={} ffmpeg={} ffmpeg_loc={:?} cookies={:?} browser_cookies={:?} js={:?}",
+        &format_selector, ffmpeg_available, &ffmpeg_location, &effective_cookie_file, &browser_cookies, &js_args
+    );
     let mut base_args = vec!["-f".to_string(), format_selector];
-    base_args.extend(js_runtime_args());
+    base_args.extend(js_args);
 
     if format_id.is_none() {
         base_args.push("-S".to_string());
@@ -1281,6 +1306,7 @@ pub async fn download_video(
         args.extend(extra_args.iter().cloned());
         args.push(url.to_string());
 
+        tracing::info!("[yt-dlp] full args: {:?}", &args);
         let mut child = crate::core::process::command(ytdlp)
             .args(&args)
             .stdout(Stdio::piped())

--- a/src-tauri/src/core/ytdlp.rs
+++ b/src-tauri/src/core/ytdlp.rs
@@ -1115,13 +1115,9 @@ pub async fn download_video(
     let mut base_args = vec!["-f".to_string(), format_selector];
     base_args.extend(js_args);
 
-    if format_id.is_none() {
+    if format_id.is_none() && mode == "audio" {
         base_args.push("-S".to_string());
-        if mode == "audio" {
-            base_args.push("+codec:aac:m4a".to_string());
-        } else {
-            base_args.push("+codec:avc:m4a".to_string());
-        }
+        base_args.push("+codec:aac:m4a".to_string());
     }
 
     if format_id.is_none() && mode != "audio" && ffmpeg_available {

--- a/src-tauri/src/core/ytdlp.rs
+++ b/src-tauri/src/core/ytdlp.rs
@@ -1107,13 +1107,8 @@ pub async fn download_video(
         .map(|p| p.to_path_buf())
         .or_else(|| global_cookie_file.map(std::path::PathBuf::from))
         .or(ext_cookies);
-    let js_args = js_runtime_args();
-    tracing::info!(
-        "[yt-dlp] format={} ffmpeg={} ffmpeg_loc={:?} cookies={:?} browser_cookies={:?} js={:?}",
-        &format_selector, ffmpeg_available, &ffmpeg_location, &effective_cookie_file, &browser_cookies, &js_args
-    );
     let mut base_args = vec!["-f".to_string(), format_selector];
-    base_args.extend(js_args);
+    base_args.extend(js_runtime_args());
 
     if format_id.is_none() && mode == "audio" {
         base_args.push("-S".to_string());
@@ -1302,7 +1297,6 @@ pub async fn download_video(
         args.extend(extra_args.iter().cloned());
         args.push(url.to_string());
 
-        tracing::info!("[yt-dlp] full args: {:?}", &args);
         let mut child = crate::core::process::command(ytdlp)
             .args(&args)
             .stdout(Stdio::piped())


### PR DESCRIPTION
## fix(deps): prefer managed binaries and resolve system tool paths

### Summary

Fixes four issues where system-installed yt-dlp and FFmpeg were either incompatible or invisible to the standalone `yt-dlp.exe`, causing YouTube downloads to fail with "Requested format is not available" or silently fall back to 360p.

### Problems solved

1. **System yt-dlp missing `yt-dlp-ejs` (Linux)** — On Fedora/Debian, `yt-dlp` installed via package manager lacks the `yt-dlp-ejs` plugin required for YouTube's nsig challenge. OmniGet used the system binary first, so `--js-runtimes` had no effect. Now the managed binary (which bundles `yt-dlp-ejs`) is preferred.

2. **FFmpeg invisible to yt-dlp (Windows)** — `find_tool()` returned bare names like `"ffmpeg.exe"` instead of absolute paths. `find_ffmpeg_location()` called `.parent()` on this, got an empty string, and never passed `--ffmpeg-location` to yt-dlp. The standalone binary couldn't find FFmpeg on its own, so it silently fell back to 360p combined formats instead of merging best video + best audio.

3. **`find_ytdlp()` cache invalidation loop** — The cached path `"yt-dlp"` (relative) always failed `path.exists()`, triggering a full rediscovery on every call and spamming `[ytdlp] cached path no longer exists: yt-dlp` in logs.

4. **`-S "+codec:avc:m4a"` forced 360p downloads** — The sort preference prepended codec priority before resolution, making format 18 (360p, the only combined avc+m4a format) beat separate 1080p+ streams that need merging. Removed for video mode — the format selector `bv*+ba[ext=m4a]` already handles audio preference, and yt-dlp's default sort prioritizes quality.

### Changes

**`src-tauri/src/core/ytdlp.rs`**

- `find_ytdlp()` now checks the managed bin dir **before** the system PATH
- System PATH fallback resolves to an absolute path via `where`/`which` (new `resolve_absolute_path()` helper)
- Cache stores absolute paths, so `path.exists()` works correctly
- `ensure_ytdlp()` always downloads the managed binary if missing, even when system yt-dlp exists — guarantees `yt-dlp-ejs` is bundled
- Removed `-S "+codec:avc:m4a"` for video mode — was forcing 360p. Audio mode keeps `-S "+codec:aac:m4a"`

**`src-tauri/src/core/dependencies.rs`**

- `find_tool()` now checks the managed bin dir **before** the system PATH (same pattern)
- System PATH fallback resolves to absolute paths via `resolve_absolute_path()`
- `ensure_ffmpeg()` always downloads the managed binary if missing, even when system FFmpeg exists
- `ensure_js_runtime()` auto-downloads Deno if no JS runtime is found

### How it works

Before:
```bash
find_tool("ffmpeg")
  → tries "ffmpeg.exe" in PATH → found → returns PathBuf("ffmpeg.exe")
  → find_ffmpeg_location() → .parent() → "" → None
  → --ffmpeg-location never passed to yt-dlp
  → yt-dlp can't find ffmpeg → falls back to 360p
```

After:
```bash
find_tool("ffmpeg")
  → checks {app_data_dir}/bin/ffmpeg.exe → found → returns absolute path
  → OR: tries PATH → found → where ffmpeg.exe → "C:\ProgramData\chocolatey\bin\ffmpeg.exe"
  → find_ffmpeg_location() → .parent() → "C:\ProgramData\chocolatey\bin"
  → --ffmpeg-location passed to yt-dlp → merge works → 1080p+
```

### Test plan

- [x] `cargo check` passes
- [x] 82 Rust tests pass
- [x] Managed yt-dlp + FFmpeg + Deno auto-downloaded when bin dir is empty
- [x] `cached path no longer exists` warning no longer appears in logs
- [x] Windows: YouTube download produces 1080p+ output with video+audio merge
- [x] Linux: YouTube download uses managed yt-dlp binary (not system), no nsig error


Closes #55 
