### PR TITLE
fix(telegram): return 2FA hint when QR login triggers DC migration

### DIFF
--- a/src-tauri/src/platforms/telegram/auth.rs
+++ b/src-tauri/src/platforms/telegram/auth.rs
@@ -307,7 +307,7 @@ pub async fn qr_login_start(handle: &TelegramSessionHandle) -> anyhow::Result<Qr
             match handle_migrate(handle, &client, migrate).await? {
                 MigrateResult::NewToken(token_data) => token_to_qr(&token_data),
                 MigrateResult::Success { .. } => Err(anyhow!("already_authenticated")),
-                MigrateResult::PasswordRequired { .. } => Err(anyhow!("already_authenticated")),
+                MigrateResult::PasswordRequired { hint } => Err(anyhow!("password_required:{}", hint)),
             }
         }
     }


### PR DESCRIPTION
## fix(telegram): return 2FA hint when QR login triggers DC migration

### Summary

Fixes a bug where Telegram users with 2FA enabled got stuck during QR login when it triggered a DC migration. The password hint was silently discarded and the frontend received `"already_authenticated"` instead of routing to the 2FA prompt.

### Root cause

In `qr_login_start()`, the `MigrateTo` → `PasswordRequired` branch discarded the hint and returned the wrong error:

```rust
// Before
MigrateResult::PasswordRequired { .. } => Err(anyhow!("already_authenticated")),

// After
MigrateResult::PasswordRequired { hint } => Err(anyhow!("password_required:{}", hint)),
```

The same variant was already handled correctly in `qr_login_poll()` (line 365). The frontend already parses `"password_required:{hint}"` to show the 2FA prompt — no frontend changes needed.

### Test plan

- [x] `cargo check` passes
- [ ] QR login with 2FA account that triggers DC migration shows 2FA prompt (requires specific DC routing, not easily reproducible on demand)

Closes #50
