### PR TITLE
fix(ytdlp): resolve YouTube 360p quality and system tool detection issues

### DIFF
--- a/src-tauri/omniget-core/src/core/dependencies.rs
+++ b/src-tauri/omniget-core/src/core/dependencies.rs
@@ -34,6 +34,37 @@ pub async fn find_tool(tool: &str) -> Option<PathBuf> {
         }
     }
 
+    // Check managed bin dir first — managed binaries are known-good.
+    let managed = managed_bin_dir().map(|d| d.join(&name));
+    if let Some(ref managed_path) = managed {
+        if managed_path.exists() {
+            let check = {
+                let managed = managed_path.clone();
+                let vf = version_flag.to_string();
+                tokio::task::spawn_blocking(move || {
+                    crate::core::process::std_command(&managed)
+                        .arg(&vf)
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status()
+                        .ok()
+                        .filter(|s| s.success())
+                })
+                .await
+                .ok()
+                .flatten()
+            };
+
+            if check.is_some() {
+                tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
+                return Some(managed_path.clone());
+            }
+            tracing::warn!("find_tool({}): binary exists at {} but failed to execute", tool, managed_path.display());
+        }
+    }
+
+    // Fall back to system PATH. Resolve to an absolute path so callers
+    // (e.g. find_ffmpeg_location) can derive the parent directory.
     let result = {
         let name = name.clone();
         let vf = version_flag.to_string();
@@ -45,7 +76,6 @@ pub async fn find_tool(tool: &str) -> Option<PathBuf> {
                 .status()
                 .ok()
                 .filter(|s| s.success())
-                .map(|_| PathBuf::from(&name))
         })
         .await
         .ok()
@@ -53,38 +83,35 @@ pub async fn find_tool(tool: &str) -> Option<PathBuf> {
     };
 
     if result.is_some() {
+        let abs = resolve_absolute_path(&name);
         tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
-        return result;
-    }
-
-    let managed = managed_bin_dir()?.join(&name);
-    if managed.exists() {
-        let check = {
-            let managed = managed.clone();
-            let vf = version_flag.to_string();
-            tokio::task::spawn_blocking(move || {
-                crate::core::process::std_command(&managed)
-                    .arg(&vf)
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status()
-                    .ok()
-                    .filter(|s| s.success())
-            })
-            .await
-            .ok()
-            .flatten()
-        };
-
-        if check.is_some() {
-            tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
-            return Some(managed);
-        }
-        tracing::warn!("find_tool({}): binary exists at {} but failed to execute", tool, managed.display());
+        return Some(abs);
     }
 
     tracing::debug!("[perf] find_tool({}) took {:?}", tool, _timer_start.elapsed());
     None
+}
+
+/// Resolve a bare binary name to its absolute path via `where` (Windows)
+/// or `which` (Unix). Returns the original name as fallback.
+fn resolve_absolute_path(bin_name: &str) -> PathBuf {
+    let finder = if cfg!(target_os = "windows") { "where" } else { "which" };
+    if let Ok(output) = std::process::Command::new(finder)
+        .arg(bin_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+    {
+        if output.status.success() {
+            if let Some(line) = String::from_utf8_lossy(&output.stdout).lines().next() {
+                let path = line.trim();
+                if !path.is_empty() {
+                    return PathBuf::from(path);
+                }
+            }
+        }
+    }
+    PathBuf::from(bin_name)
 }
 
 fn version_flag_for(tool: &str) -> &'static str {
@@ -142,6 +169,18 @@ pub async fn check_version(tool: &str) -> Option<String> {
 }
 
 pub async fn ensure_ffmpeg() -> anyhow::Result<PathBuf> {
+    // Always ensure the managed binary exists — the standalone yt-dlp.exe
+    // cannot discover system FFmpeg from PATH.
+    if !is_flatpak() {
+        let managed = managed_bin_dir().map(|d| d.join(bin_name("ffmpeg")));
+        if managed.as_ref().map_or(true, |p| !p.exists()) {
+            if let Ok(path) = download_ffmpeg().await {
+                crate::core::ytdlp::reset_ffmpeg_location_cache();
+                return Ok(path);
+            }
+        }
+    }
+
     if let Some(path) = find_tool("ffmpeg").await {
         return Ok(path);
     }

--- a/src-tauri/omniget-core/src/core/ytdlp.rs
+++ b/src-tauri/omniget-core/src/core/ytdlp.rs
@@ -224,6 +224,17 @@ pub async fn find_ytdlp() -> Option<PathBuf> {
         }
     }
 
+    // Prefer the managed binary — it bundles yt-dlp-ejs (required for
+    // YouTube nsig challenge). System-installed yt-dlp (dnf, apt) often
+    // lacks this plugin, causing "Requested format is not available".
+    let managed = managed_ytdlp_path()?;
+    if managed.exists() {
+        tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
+        return Some(managed);
+    }
+
+    // Fall back to system PATH. Resolve to an absolute path so the cache
+    // check (`path.exists()`) works — a bare "yt-dlp" would always fail.
     let bin_name_owned = bin_name.to_string();
     let found = tokio::task::spawn_blocking(move || {
         crate::core::process::std_command(&bin_name_owned)
@@ -239,18 +250,35 @@ pub async fn find_ytdlp() -> Option<PathBuf> {
     .flatten();
 
     if found.is_some() {
+        let abs = resolve_absolute_path(bin_name);
         tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
-        return Some(PathBuf::from(bin_name));
-    }
-
-    let managed = managed_ytdlp_path()?;
-    if managed.exists() {
-        tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
-        return Some(managed);
+        return Some(abs);
     }
 
     tracing::debug!("[perf] find_ytdlp took {:?}", _timer_start.elapsed());
     None
+}
+
+/// Resolve a bare binary name to its absolute path via `where` (Windows)
+/// or `which` (Unix). Returns the original name as fallback.
+fn resolve_absolute_path(bin_name: &str) -> PathBuf {
+    let finder = if cfg!(target_os = "windows") { "where" } else { "which" };
+    if let Ok(output) = std::process::Command::new(finder)
+        .arg(bin_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+    {
+        if output.status.success() {
+            if let Some(line) = String::from_utf8_lossy(&output.stdout).lines().next() {
+                let path = line.trim();
+                if !path.is_empty() {
+                    return PathBuf::from(path);
+                }
+            }
+        }
+    }
+    PathBuf::from(bin_name)
 }
 
 pub async fn find_ytdlp_cached() -> Option<PathBuf> {
@@ -288,6 +316,38 @@ fn managed_ytdlp_path() -> Option<PathBuf> {
 
 pub async fn ensure_ytdlp() -> anyhow::Result<PathBuf> {
     let _timer_start = std::time::Instant::now();
+
+    // Always ensure the managed binary exists — it bundles yt-dlp-ejs and
+    // works reliably with --js-runtimes and --ffmpeg-location.
+    if !crate::core::dependencies::is_flatpak() {
+        let managed = managed_ytdlp_path();
+        if managed.as_ref().map_or(true, |p| !p.exists()) {
+            tracing::info!("[ytdlp] managed binary missing, downloading...");
+            match download_ytdlp_binary().await {
+                Ok(path) => {
+                    reset_ytdlp_cache();
+                    std::thread::Builder::new()
+                        .name("js-runtime-check".into())
+                        .spawn(|| {
+                            let rt = tokio::runtime::Builder::new_current_thread()
+                                .enable_all()
+                                .build()
+                                .expect("js-runtime runtime");
+                            rt.block_on(async {
+                                crate::core::dependencies::ensure_js_runtime().await;
+                            });
+                        })
+                        .ok();
+                    tracing::debug!("[perf] ensure_ytdlp took {:?}", _timer_start.elapsed());
+                    return Ok(path);
+                }
+                Err(e) => {
+                    tracing::warn!("[ytdlp] failed to download managed binary, falling back to system: {}", e);
+                }
+            }
+        }
+    }
+
     if let Some(path) = find_ytdlp_cached().await {
         let path_clone = path.clone();
         std::thread::Builder::new()
@@ -1017,13 +1077,9 @@ pub async fn download_video(
     let mut base_args = vec!["-f".to_string(), format_selector];
     base_args.extend(js_runtime_args());
 
-    if format_id.is_none() {
+    if format_id.is_none() && mode == "audio" {
         base_args.push("-S".to_string());
-        if mode == "audio" {
-            base_args.push("+codec:aac:m4a".to_string());
-        } else {
-            base_args.push("+codec:avc:m4a".to_string());
-        }
+        base_args.push("+codec:aac:m4a".to_string());
     }
 
     if format_id.is_none() && mode != "audio" && ffmpeg_available {


### PR DESCRIPTION
## fix(ytdlp): resolve YouTube 360p quality and system tool detection issues

### Summary

All YouTube downloads were stuck at 640x360 (format 18) regardless of quality setting. Four issues combined to cause this.

### Problems solved

1. **`-S "+codec:avc:m4a"` forced 360p** — Prepended codec preference before resolution in yt-dlp's sort order. Format 18 (the only combined avc+m4a at 360p) scored highest, beating separate 1080p+ streams that need merging. Removed for video mode — `bv*+ba[ext=m4a]` already handles audio preference.

2. **`find_tool()` / `find_ytdlp()` returned bare names** — `PathBuf("ffmpeg.exe")` caused `find_ffmpeg_location().parent()` to return empty string. `--ffmpeg-location` was never passed to yt-dlp, so the standalone binary couldn't find FFmpeg for merging.

3. **`find_ytdlp()` cache invalidation loop** — Cached relative path `"yt-dlp"` always failed `path.exists()`, spamming `[ytdlp] cached path no longer exists` on every call.

4. **`ensure_ytdlp()` / `ensure_ffmpeg()` skipped download** — When system binaries existed (dnf, chocolatey), managed download never triggered. System yt-dlp often lacks `yt-dlp-ejs` (needed for YouTube nsig challenge).

### Changes

**`omniget-core/src/core/ytdlp.rs`**
- Removed `-S "+codec:avc:m4a"` for video mode (audio keeps `-S "+codec:aac:m4a"`)
- `find_ytdlp()` checks managed bin dir **before** system PATH
- System PATH fallback resolves absolute paths via `where`/`which`
- `ensure_ytdlp()` downloads managed binary if missing, even when system exists

**`omniget-core/src/core/dependencies.rs`**
- `find_tool()` checks managed bin dir **before** system PATH
- System PATH fallback resolves absolute paths via `resolve_absolute_path()`
- `ensure_ffmpeg()` downloads managed binary if missing, even when system exists

### Test plan

- [x] `cargo check` passes
- [x] Tests pass
- [x] YouTube download produces 1080p+ with video+audio merge
- [x] Managed yt-dlp + FFmpeg auto-downloaded when bin dir is empty
- [x] `cached path no longer exists` warning no longer appears

Closes #64 
