### PR TITLE
docs: document translation contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,43 @@ cd ..
 pnpm check
 ```
 
+## Adding a translation
+
+Translations live in two places:
+
+**Main app** (`src/lib/i18n/`):
+
+1. Copy `en.json` to `<locale>.json` (e.g. `es.json`) and translate the values.
+2. Register the locale in `src/lib/i18n/index.ts` by adding an entry to the `loaders` array:
+
+   ```ts
+   {
+     locale: "es",
+     key: "",
+     loader: async () => (await import("./es.json")).default,
+   },
+   ```
+
+3. Add a `lang_<locale>` entry (e.g. `"lang_es": "Español"`) under `settings.appearance` in **every** `src/lib/i18n/*.json` file.
+4. Add a matching `<option>` to the language selector in `src/routes/settings/+page.svelte`:
+
+   ```svelte
+   <option value="es">{$t('settings.appearance.lang_es')}</option>
+   ```
+
+5. Regenerate the translation key types:
+
+   ```bash
+   pnpm generate:i18n-keys
+   ```
+
+**Browser extension** (`browser-extension/chrome/_locales/` and `browser-extension/firefox/_locales/`):
+
+1. Create an `<locale>/` folder in both (e.g. `es/`).
+2. Copy `en/messages.json` into it and translate the `message` fields. Leave the keys and `description` fields unchanged.
+
+Run `pnpm check` before opening the PR.
+
 ## Commit style
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`. Keep the subject under 72 characters.


### PR DESCRIPTION
## Summary

Adds an **"Adding a translation"** section to `CONTRIBUTING.md` so contributors know exactly where and how to add a new locale. Motivated by [#72](https://github.com/tonhowtf/omniget/issues/72) where a contributor asked how to add Spanish and the process wasn't documented anywhere.

## What's documented

**Main app (`src/lib/i18n/`):**
1. Copy `en.json` → `<locale>.json` and translate the values.
2. Register the locale in `src/lib/i18n/index.ts` (new entry in the `loaders` array).
3. Add a `lang_<locale>` key under `settings.appearance` in **every** locale JSON.
4. Add a matching `<option>` to the language selector in `src/routes/settings/+page.svelte`.
5. Run `pnpm generate:i18n-keys` to regenerate `keys.ts`.

**Browser extension (`browser-extension/{chrome,firefox}/_locales/`):**
1. Create an `<locale>/` folder in both.
2. Copy `en/messages.json` into each and translate the `message` fields (keys and `description` stay untouched).

## Test plan

- [x] Read through the new section and confirm the steps match the current codebase layout.
- [x] Follow the steps end-to-end for a dummy locale to verify nothing is missing.
- [x] `pnpm check` passes.
