### PR TITLE
fix(magnet): fallback when persistent DHT init fails

### DIFF
--- a/src-tauri/src/platforms/magnet/mod.rs
+++ b/src-tauri/src/platforms/magnet/mod.rs
@@ -117,13 +117,36 @@ impl PlatformDownloader for MagnetDownloader {
                     listen_port,
                     output_dir.display()
                 );
-                let session_opts = SessionOptions {
+                let make_opts = |disable_dht_persistence: bool, disable_dht: bool| SessionOptions {
                     listen_port_range: Some(listen_port..listen_port.saturating_add(10)),
+                    disable_dht,
+                    disable_dht_persistence,
                     ..Default::default()
                 };
                 let cancel_rx = opts.cancel_token.clone();
+                let output_pb: PathBuf = output_dir.into();
                 let s = tokio::select! {
-                    result = Session::new_with_opts(output_dir.into(), session_opts) => {
+                    result = async {
+                        match Session::new_with_opts(output_pb.clone(), make_opts(false, false)).await {
+                            Ok(s) => Ok(s),
+                            Err(e) => {
+                                tracing::warn!(
+                                    "[magnet] persistent DHT init failed ({}); retrying without DHT persistence",
+                                    e
+                                );
+                                match Session::new_with_opts(output_pb.clone(), make_opts(true, false)).await {
+                                    Ok(s) => Ok(s),
+                                    Err(e2) => {
+                                        tracing::warn!(
+                                            "[magnet] DHT init failed ({}); retrying with DHT disabled (trackers/PEX only)",
+                                            e2
+                                        );
+                                        Session::new_with_opts(output_pb, make_opts(true, true)).await
+                                    }
+                                }
+                            }
+                        }
+                    } => {
                         result.map_err(|e| anyhow::anyhow!("Failed to initialize torrent session: {}", e))?
                     }
                     _ = cancel_rx.cancelled() => {


### PR DESCRIPTION
### Summary

Torrent downloads were failing for some users with `Failed to initialize torrent session: error initializing persistent DHT`, with no recovery path other than manually deleting `%LOCALAPPDATA%\rqbit\dht\cache\dht.json`. The error originates in [librqbit-dht/src/persistence.rs](https://github.com/ikatson/rqbit) when the cached routing table is corrupted, the DHT cache directory is unwritable, or the UDP bind is blocked (firewall / VPN / antivirus).

This PR adds a graceful fallback so the session always comes up if at all possible:

1. Try to create the session normally (DHT + persistence).
2. On failure → retry without DHT persistence (handles the corrupted-`dht.json` case, which is what users have actually hit in the wild).
3. On failure again → retry with DHT fully disabled. Trackers and PEX still work, so the download can proceed.

### Changes

**Rust** — [src-tauri/src/platforms/magnet/mod.rs:114-145](src-tauri/src/platforms/magnet/mod.rs#L114-L145)
- Replaced the single `Session::new_with_opts` call with a 3-step cascade using `SessionOptions { disable_dht_persistence, disable_dht, .. }`.
- Each fallback step logs a `tracing::warn!` with the underlying error so the failure mode is visible in logs.
- The cancellation token still races against the whole cascade, so a user-initiated cancel during session creation aborts cleanly.

### Reproduction

Before:

1. Corrupt or make `%LOCALAPPDATA%\rqbit\dht\cache\dht.json` unreadable (or hit the natural case where it gets corrupted on a previous crash).
2. Try to download any magnet link.
3. Error toast: `Failed to initialize torrent session: error initializing persistent DHT`. No download possible until the file is manually deleted.

After:

1. Same starting state.
2. Magnet download starts. Logs show:
   ```
   [magnet] persistent DHT init failed (...); retrying without DHT persistence
   ```
3. Download proceeds normally via fresh in-memory DHT.

### Test plan

- [x] `cargo check` passes
- [x] Reproduce locally by corrupting `dht.json` (e.g., write garbage bytes), confirm download still starts and warning is logged
- [x] Reproduce by making the cache dir read-only, confirm second fallback (no persistence) succeeds
- [x] Confirm a normal run still uses persistent DHT (no fallback log lines on healthy systems)
- [x] Cancellation during session creation still aborts cleanly
