### PR TITLE
Fix:fix proxy handling and multi-stream download progress

### DIFF
--- a/src-tauri/omniget-core/src/core/ytdlp.rs
+++ b/src-tauri/omniget-core/src/core/ytdlp.rs
@@ -504,6 +504,31 @@ fn proxy_args() -> Vec<String> {
     }
 }
 
+fn redacted_proxy_url(url: &str) -> String {
+    if let Some(at) = url.find('@') {
+        if let Some(scheme_end) = url.find("://") {
+            return format!("{}***{}", &url[..scheme_end + 3], &url[at..]);
+        }
+    }
+    url.to_string()
+}
+
+fn proxy_log_label(proxy_url: Option<&str>) -> String {
+    match proxy_url {
+        Some(url) => format!("proxy={}", redacted_proxy_url(url)),
+        None => {
+            let proxy = crate::core::http_client::get_proxy_snapshot();
+            if proxy.enabled && proxy.host.trim().is_empty() {
+                "proxy=disabled (enabled but host is empty)".to_string()
+            } else if proxy.enabled {
+                "proxy=disabled (invalid proxy settings)".to_string()
+            } else {
+                "proxy=disabled".to_string()
+            }
+        }
+    }
+}
+
 fn has_explicit_cookie_header(args: &[String]) -> bool {
     args.windows(2).any(|pair| {
         pair[0] == "--add-headers" && pair[1].to_ascii_lowercase().starts_with("cookie:")
@@ -625,6 +650,9 @@ fn yt_rate_limiter() -> &'static YtRateLimiter {
 }
 
 const CHROME_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+pub const VIDEO_INFO_PROCESS_TIMEOUT_SECS: u64 = 90;
+pub const YOUTUBE_VIDEO_INFO_TOTAL_TIMEOUT_SECS: u64 = 190;
+pub const DEFAULT_VIDEO_INFO_TOTAL_TIMEOUT_SECS: u64 = 110;
 
 pub async fn find_ytdlp() -> Option<PathBuf> {
     let _timer_start = std::time::Instant::now();
@@ -1270,7 +1298,20 @@ pub async fn get_video_info(
 
         append_metadata_cookie_args(&mut args, url, extra_flags, "video info");
 
-        args.extend(proxy_args());
+        let proxy = crate::core::http_client::proxy_url();
+        if attempt == 0 {
+            if let Some(dl_id) = log_hook::current_download_id() {
+                let line = format!(
+                    "[network] yt-dlp metadata {}",
+                    proxy_log_label(proxy.as_deref())
+                );
+                log_hook::emit_log(dl_id, &line);
+            }
+        }
+        if let Some(url) = proxy {
+            args.push("--proxy".to_string());
+            args.push(url);
+        }
         args.extend(extra_flags.iter().cloned());
         args.push(url.to_string());
 
@@ -1287,11 +1328,17 @@ pub async fn get_video_info(
         );
 
         let result =
-            tokio::time::timeout(std::time::Duration::from_secs(60), child.wait_with_output())
+            tokio::time::timeout(
+                std::time::Duration::from_secs(VIDEO_INFO_PROCESS_TIMEOUT_SECS),
+                child.wait_with_output(),
+            )
                 .await
                 .map_err(|_| {
                     tracing::debug!("[perf] get_video_info took {:?}", _timer_start.elapsed());
-                    anyhow!("Timeout fetching video info (60s)")
+                    anyhow!(
+                        "Timeout fetching video info ({}s)",
+                        VIDEO_INFO_PROCESS_TIMEOUT_SECS
+                    )
                 })?
                 .map_err(|e| {
                     tracing::debug!("[perf] get_video_info took {:?}", _timer_start.elapsed());

--- a/src-tauri/omniget-core/src/core/ytdlp.rs
+++ b/src-tauri/omniget-core/src/core/ytdlp.rs
@@ -498,10 +498,10 @@ pub async fn check_ytdlp_update(ytdlp: &Path) -> anyhow::Result<bool> {
 }
 
 fn proxy_args() -> Vec<String> {
-    match crate::core::http_client::proxy_url() {
-        Some(url) => vec!["--proxy".to_string(), url],
-        None => Vec::new(),
-    }
+    vec![
+        "--proxy".to_string(),
+        crate::core::http_client::proxy_url().unwrap_or_default(),
+    ]
 }
 
 fn redacted_proxy_url(url: &str) -> String {
@@ -1308,10 +1308,8 @@ pub async fn get_video_info(
                 log_hook::emit_log(dl_id, &line);
             }
         }
-        if let Some(url) = proxy {
-            args.push("--proxy".to_string());
-            args.push(url);
-        }
+        args.push("--proxy".to_string());
+        args.push(proxy.unwrap_or_default());
         args.extend(extra_flags.iter().cloned());
         args.push(url.to_string());
 
@@ -1319,6 +1317,7 @@ pub async fn get_video_info(
             .args(&args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
             .map_err(|e| anyhow!("Failed to run yt-dlp: {}", e))?;
         tracing::debug!(
@@ -1811,6 +1810,30 @@ fn parse_destination_line(line: &str) -> Option<String> {
     }
 
     None
+}
+
+fn adjusted_multi_stream_progress(
+    phase: &mut u32,
+    last_raw_percent: &mut Option<f64>,
+    max_reported: f64,
+    percent: f64,
+) -> f64 {
+    // Some external downloader output does not include a second Destination line.
+    // Detect the second stream when the raw percentage resets after the first
+    // stream has reached the 50% boundary.
+    if *phase <= 1
+        && max_reported >= 49.0
+        && last_raw_percent.is_some_and(|last| last >= 95.0 && percent < 95.0)
+    {
+        *phase = 2;
+    }
+    *last_raw_percent = Some(percent);
+
+    if *phase <= 1 {
+        percent * 0.5
+    } else {
+        50.0 + percent * 0.5
+    }
 }
 
 pub async fn write_netscape_cookie_file(
@@ -2360,6 +2383,7 @@ pub async fn download_video(
 
         let line_reader = tokio::spawn(async move {
             let mut phase = 0u32;
+            let mut last_raw_percent: Option<f64> = None;
             let mut max_reported = 0.0f64;
             let mut first_line_logged = false;
             let mut first_progress_logged = false;
@@ -2435,11 +2459,12 @@ pub async fn download_video(
                             last_send = std::time::Instant::now();
                         }
                     } else {
-                        let adjusted = if phase <= 1 {
-                            pct * 0.5
-                        } else {
-                            50.0 + pct * 0.5
-                        };
+                        let adjusted = adjusted_multi_stream_progress(
+                            &mut phase,
+                            &mut last_raw_percent,
+                            max_reported,
+                            pct,
+                        );
                         if adjusted > max_reported
                             && (adjusted >= 99.0 || last_send.elapsed() >= throttle)
                         {

--- a/src-tauri/src/commands/downloads.rs
+++ b/src-tauri/src/commands/downloads.rs
@@ -114,6 +114,9 @@ pub async fn prefetch_media_info(
     state: tauri::State<'_, AppState>,
     url: String,
 ) -> Result<(), String> {
+    let settings = config::load_settings(&app);
+    crate::core::http_client::init_proxy(settings.proxy);
+
     let platform = Platform::from_url(&url);
     let platform_name = platform
         .map(|p| p.to_string())

--- a/src-tauri/src/commands/downloads.rs
+++ b/src-tauri/src/commands/downloads.rs
@@ -878,6 +878,10 @@ pub async fn download_from_url(
 
     {
         let settings = config::load_settings(&app);
+        crate::core::http_client::init_proxy(settings.proxy.clone());
+        crate::core::http_fetcher::set_global_max_concurrent_segments(
+            settings.advanced.max_concurrent_segments as usize,
+        );
         let mut q = download_queue.lock().await;
         q.max_concurrent = settings.advanced.max_concurrent_downloads.max(1);
         q.stagger_delay_ms = settings.advanced.stagger_delay_ms;
@@ -1471,26 +1475,11 @@ pub async fn clear_finished_downloads(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
-    let (state_to_emit, finished_ids) = {
+    let state_to_emit = {
         let mut q = state.download_queue.lock().await;
-        let ids = q
-            .items
-            .iter()
-            .filter(|i| {
-                matches!(
-                    i.status,
-                    crate::core::queue::QueueStatus::Complete { .. }
-                        | crate::core::queue::QueueStatus::Error { .. }
-                )
-            })
-            .map(|i| i.id)
-            .collect::<Vec<_>>();
         q.clear_finished();
-        (q.get_state(), ids)
+        q.get_state()
     };
-    for id in finished_ids {
-        crate::core::download_log::clear(id);
-    }
     emit_queue_state_from_state(&app, state_to_emit);
     Ok("Finished downloads cleared".to_string())
 }

--- a/src-tauri/src/core/queue.rs
+++ b/src-tauri/src/core/queue.rs
@@ -1063,6 +1063,11 @@ async fn spawn_download_inner(
         )
     };
 
+    {
+        let settings = crate::storage::config::load_settings(&app);
+        crate::core::http_client::init_proxy(settings.proxy);
+    }
+
     let info_start = std::time::Instant::now();
     let info = match media_info {
         Some(i) if !i.available_qualities.is_empty() => {
@@ -1071,6 +1076,14 @@ async fn spawn_download_inner(
                 item_id,
                 info_start.elapsed()
             );
+            append_download_log(
+                &app,
+                item_id,
+                format!(
+                    "[omniget] using cached video info: platform={} title=\"{}\"",
+                    platform_name, i.title
+                ),
+            );
             i
         }
         _ => {
@@ -1078,6 +1091,21 @@ async fn spawn_download_inner(
                 "[perf] spawn_download_inner {}: media_info is None, fetching info",
                 item_id
             );
+            append_download_log(
+                &app,
+                item_id,
+                format!(
+                    "[omniget] fetching video info: platform={} url={}",
+                    platform_name, url
+                ),
+            );
+            if let Some(slug) = cookie_slug.as_deref() {
+                append_download_log(
+                    &app,
+                    item_id,
+                    format!("[cookies] selected managed cookie account: {}", slug),
+                );
+            }
             let _ = app.emit(
                 "queue-item-progress",
                 &QueueItemProgress {
@@ -1093,15 +1121,53 @@ async fn spawn_download_inner(
                 },
             );
 
+            let info_future = fetch_and_cache_info(
+                &url,
+                &*downloader,
+                &platform_name,
+                ytdlp_path.as_deref(),
+            );
+            let scoped_info_future = omniget_core::core::log_hook::CURRENT_COOKIE_SLUG.scope(
+                cookie_slug.clone(),
+                omniget_core::core::log_hook::CURRENT_DOWNLOAD_ID.scope(item_id, info_future),
+            );
+            let info_timeout_secs = if platform_name == "youtube"
+                || url.to_ascii_lowercase().contains("youtube.com")
+                || url.to_ascii_lowercase().contains("youtu.be")
+            {
+                omniget_core::core::ytdlp::YOUTUBE_VIDEO_INFO_TOTAL_TIMEOUT_SECS
+            } else {
+                omniget_core::core::ytdlp::DEFAULT_VIDEO_INFO_TOTAL_TIMEOUT_SECS
+            };
             let info_result = tokio::time::timeout(
-                std::time::Duration::from_secs(60),
-                fetch_and_cache_info(&url, &*downloader, &platform_name, ytdlp_path.as_deref()),
+                std::time::Duration::from_secs(info_timeout_secs),
+                scoped_info_future,
             )
             .await;
 
             match info_result {
-                Ok(Ok(i)) => i,
+                Ok(Ok(i)) => {
+                    append_download_log(
+                        &app,
+                        item_id,
+                        format!(
+                            "[omniget] video info fetched in {:.1}s: title=\"{}\"",
+                            info_start.elapsed().as_secs_f64(),
+                            i.title
+                        ),
+                    );
+                    i
+                }
                 Ok(Err(e)) => {
+                    append_download_log(
+                        &app,
+                        item_id,
+                        format!(
+                            "[omniget] failed fetching video info after {:.1}s: {}",
+                            info_start.elapsed().as_secs_f64(),
+                            e
+                        ),
+                    );
                     let state = {
                         let mut q = queue.lock().await;
                         q.mark_complete(item_id, false, Some(e.to_string()), None, None);
@@ -1112,7 +1178,19 @@ async fn spawn_download_inner(
                     return;
                 }
                 Err(_) => {
-                    tracing::warn!("[queue] info fetch timed out for {} after 60s", item_id);
+                    tracing::warn!(
+                        "[queue] info fetch timed out for {} after {}s",
+                        item_id,
+                        info_timeout_secs
+                    );
+                    append_download_log(
+                        &app,
+                        item_id,
+                        format!(
+                            "[omniget] video info timed out after {}s",
+                            info_timeout_secs
+                        ),
+                    );
                     let state = {
                         let mut q = queue.lock().await;
                         q.mark_complete(

--- a/src-tauri/src/core/queue.rs
+++ b/src-tauri/src/core/queue.rs
@@ -1065,7 +1065,20 @@ async fn spawn_download_inner(
 
     {
         let settings = crate::storage::config::load_settings(&app);
-        crate::core::http_client::init_proxy(settings.proxy);
+        let proxy = settings.proxy.clone();
+        crate::core::http_client::init_proxy(proxy.clone());
+        let proxy_status = if !proxy.enabled {
+            "disabled; direct connection enforced".to_string()
+        } else if proxy.host.trim().is_empty() {
+            "enabled but host is empty; direct connection enforced".to_string()
+        } else {
+            format!("enabled; {}://{}:{}", proxy.proxy_type, proxy.host, proxy.port)
+        };
+        append_download_log(
+            &app,
+            item_id,
+            format!("[network] proxy setting: {}", proxy_status),
+        );
     }
 
     let info_start = std::time::Instant::now();
@@ -1136,6 +1149,8 @@ async fn spawn_download_inner(
                 || url.to_ascii_lowercase().contains("youtu.be")
             {
                 omniget_core::core::ytdlp::YOUTUBE_VIDEO_INFO_TOTAL_TIMEOUT_SECS
+            } else if platform_name == "douyin" {
+                30
             } else {
                 omniget_core::core::ytdlp::DEFAULT_VIDEO_INFO_TOTAL_TIMEOUT_SECS
             };
@@ -1780,8 +1795,13 @@ pub async fn prefetch_info_with_emit(
 ) {
     let _timer_start = std::time::Instant::now();
     tracing::debug!("[perf] prefetch_info: started");
-    match fetch_and_cache_info(url, downloader, platform, ytdlp_path).await {
-        Ok(info) => {
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        fetch_and_cache_info(url, downloader, platform, ytdlp_path),
+    )
+    .await;
+    match result {
+        Ok(Ok(info)) => {
             tracing::debug!(
                 "[perf] prefetch_info: completed in {:?} — {}",
                 _timer_start.elapsed(),
@@ -1798,10 +1818,14 @@ pub async fn prefetch_info_with_emit(
                 let _ = app.emit("media-info-preview", preview);
             }
         }
-        Err(e) => tracing::warn!(
+        Ok(Err(e)) => tracing::warn!(
             "[perf] prefetch_info: failed in {:?} — {}",
             _timer_start.elapsed(),
             e
+        ),
+        Err(_) => tracing::warn!(
+            "[perf] prefetch_info: timed out after {:?}",
+            _timer_start.elapsed()
         ),
     }
 }

--- a/src/components/settings/SettingsCookies.svelte
+++ b/src/components/settings/SettingsCookies.svelte
@@ -544,7 +544,7 @@
           {$t("common.clear")}
         </button>
         <button type="button" class="danger-btn" onclick={askBulkClear} disabled={selectedCount === 0}>
-          {$t("settings.cookies.action_clear")}
+          delete
         </button>
       </div>
     </div>
@@ -693,7 +693,7 @@
           {$t("settings.cookies.confirm_clear_cancel")}
         </button>
         <button type="button" class="danger-btn" onclick={confirmBulkClear}>
-          {$t("settings.cookies.confirm_clear_action")}
+          delete
         </button>
       </div>
     </div>

--- a/src/lib/components/cookies/CookieBucketCard.svelte
+++ b/src/lib/components/cookies/CookieBucketCard.svelte
@@ -179,9 +179,54 @@
   function keyFor(slug: string): string {
     return `${bucket.domain}__${slug}`;
   }
+
+  function isInteractiveTarget(target: EventTarget | null): boolean {
+    return target instanceof HTMLElement
+      && !!target.closest("button,input,label,a,textarea,select");
+  }
+
+  function toggleAccountSelection(slug: string) {
+    if (!onToggleSelection) return;
+    onToggleSelection(bucket.domain, slug, !selected[keyFor(slug)]);
+  }
+
+  function handleCardClick(event: MouseEvent) {
+    if (!primaryAccount || isInteractiveTarget(event.target)) return;
+    toggleAccountSelection(primaryAccount.slug);
+  }
+
+  function handleCardKeydown(event: KeyboardEvent) {
+    if (!primaryAccount || isInteractiveTarget(event.target)) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    toggleAccountSelection(primaryAccount.slug);
+  }
+
+  function handleExtraAccountClick(event: MouseEvent, slug: string) {
+    event.stopPropagation();
+    if (isInteractiveTarget(event.target)) return;
+    toggleAccountSelection(slug);
+  }
+
+  function handleExtraAccountKeydown(event: KeyboardEvent, slug: string) {
+    if (isInteractiveTarget(event.target)) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    event.stopPropagation();
+    toggleAccountSelection(slug);
+  }
 </script>
 
-<article class="bucket-card" data-status={status}>
+<article
+  class="bucket-card"
+  class:selectable={!!onToggleSelection && !!primaryAccount}
+  class:selected={!!primaryAccount && !!selected[keyFor(primaryAccount.slug)]}
+  data-status={status}
+  role={onToggleSelection && primaryAccount ? "button" : undefined}
+  tabindex={onToggleSelection && primaryAccount ? 0 : undefined}
+  onclick={handleCardClick}
+  onkeydown={handleCardKeydown}
+>
   <PlatformLogo kind={bucket.platform_kind as never} domain={bucket.domain} size={56} />
 
   <div class="meta">
@@ -289,7 +334,15 @@
     {#if extraAccounts.length > 0}
       <ul class="extra-accounts">
         {#each extraAccounts as account (account.slug)}
-          <li class="extra-account" class:selectable={!!onToggleSelection}>
+          <li
+            class="extra-account"
+            class:selectable={!!onToggleSelection}
+            class:selected={!!selected[keyFor(account.slug)]}
+            role={onToggleSelection ? "button" : undefined}
+            tabindex={onToggleSelection ? 0 : undefined}
+            onclick={(e) => handleExtraAccountClick(e, account.slug)}
+            onkeydown={(e) => handleExtraAccountKeydown(e, account.slug)}
+          >
             {#if onToggleSelection}
               <label class="select-extra">
                 <input
@@ -339,8 +392,19 @@
     border-radius: 14px;
     transition: border-color 120ms;
   }
+  .bucket-card.selectable {
+    cursor: pointer;
+  }
   .bucket-card:hover {
     border-color: color-mix(in oklab, var(--content-border) 70%, transparent);
+  }
+  .bucket-card.selected {
+    border-color: color-mix(in oklab, var(--accent) 70%, transparent);
+    background: color-mix(in oklab, var(--accent) 8%, var(--button) 22%);
+  }
+  .bucket-card:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--accent) 70%, transparent);
+    outline-offset: 2px;
   }
   .meta {
     min-width: 0;
@@ -520,9 +584,20 @@
     align-items: center;
     padding: 4px 0;
     font-size: 12px;
+    border-radius: 6px;
   }
   .extra-account.selectable {
     grid-template-columns: auto 1fr auto auto;
+    cursor: pointer;
+    padding: 5px 6px;
+  }
+  .extra-account.selectable:hover,
+  .extra-account.selected {
+    background: color-mix(in oklab, var(--accent) 8%, transparent);
+  }
+  .extra-account:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--accent) 60%, transparent);
+    outline-offset: 1px;
   }
   .extra-alias {
     color: var(--secondary);

--- a/src/lib/stores/omnibox-draft-store.svelte.ts
+++ b/src/lib/stores/omnibox-draft-store.svelte.ts
@@ -1,0 +1,13 @@
+let draftUrl = $state("");
+
+export function getOmniboxDraftUrl(): string {
+  return draftUrl;
+}
+
+export function setOmniboxDraftUrl(url: string) {
+  draftUrl = url;
+}
+
+export function clearOmniboxDraftUrl() {
+  draftUrl = "";
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,6 +24,7 @@
   import { onClipboardUrl } from "$lib/stores/clipboard-monitor";
   import { getMediaPreview, clearMediaPreview } from "$lib/stores/media-preview-store.svelte";
   import { clearPendingExternalPrefill, getPendingExternalPrefill, type ExternalUrlEvent } from "$lib/stores/external-url-store.svelte";
+  import { getOmniboxDraftUrl, setOmniboxDraftUrl } from "$lib/stores/omnibox-draft-store.svelte";
   import { t } from "$lib/i18n";
   import { translateBackendError } from "$lib/error-translate";
   import { platformDisplayName } from "$lib/platform-display-names";
@@ -79,7 +80,7 @@
     | { kind: "search-empty" }
     | { kind: "error"; message: string; originalUrl: string; platform: string };
 
-  let url = $state("");
+  let url = $state(getOmniboxDraftUrl());
   let omniState = $state<OmniState>({ kind: "idle" });
   let debounceTimer = $state<ReturnType<typeof setTimeout> | null>(null);
   let downloadMode = $state<"auto" | "audio" | "mute">("auto");
@@ -141,9 +142,16 @@
       handleInput();
       showToast("info", $t(autoDownload ? "toast.auto_download_started" : "toast.clipboard_url_detected"));
     });
+    if (url.trim()) {
+      queueMicrotask(() => handleInput());
+    }
     return () => {
       onClipboardUrl(null);
     };
+  });
+
+  $effect(() => {
+    setOmniboxDraftUrl(url);
   });
 
   const AUTO_DOWNLOAD_DELAY_MS = 2000;


### PR DESCRIPTION
## Problems
Issue #119,Issue #135 ,Issue #137  

## Changes

### commit [18a83dd](https://github.com/tonhowtf/omniget/pull/138/commits/18a83dd5f13a985b41f037349fde7ada9a331e16)

[src-tauri/omniget-core/src/core/ytdlp.rs:500](https://github.com/SiIverAsh/omniget/blob/18a83dd5f13a985b41f037349fde7ada9a331e16/src-tauri/omniget-core/src/core/ytdlp.rs#L500)
[src-tauri/omniget-core/src/core/ytdlp.rs:1311](https://github.com/SiIverAsh/omniget/blob/18a83dd5f13a985b41f037349fde7ada9a331e16/src-tauri/omniget-core/src/core/ytdlp.rs#L1311)
 - Pass the configured proxy URL when the proxy is enabled and pass `--proxy ""` when the proxy is disabled.

Reason:  
 - This made the application proxy switch unreliable because disabling the proxy in Omniget did not necessarily force yt-dlp to use a direct connection.


[src-tauri/omniget-core/src/core/ytdlp.rs:1320](https://github.com/SiIverAsh/omniget/blob/18a83dd5f13a985b41f037349fde7ada9a331e16/src-tauri/omniget-core/src/core/ytdlp.rs#L1320)
 - The yt-dlp process used for metadata extraction now uses:  .kill_on_drop(true)

Reasons:
  - Ensures metadata requests use the same proxy behavior as downloads.
  - When a metadata request times out or is cancelled, dropping the Rust future now terminates the background yt-
  dlp process instead of leaving it running.



[src-tauri/omniget-core/src/core/ytdlp.rs:1815](https://github.com/SiIverAsh/omniget/blob/18a83dd5f13a985b41f037349fde7ada9a331e16/src-tauri/omniget-core/src/core/ytdlp.rs#L1815)
 - Added `adjusted_multi_stream_progress()`. 
 - Records the previous raw download percentage. 
 - Detects a second media stream when the raw percentage resets from near `100%` to a lower value.
 - Maps the first stream to `0%` through `50%` and the second stream to `50%` through `100%`.

Reason:
 - Some yt-dlp or external downloader output does not include a second `Destination` log line for the audio stream.
  The previous logic could not detect that the video stream had finished and the audio stream had started, causing
  the displayed progress to remain near `50%`.



[src-tauri/src/commands/downloads.rs:117](https://github.com/SiIverAsh/omniget/blob/18a83dd5f13a985b41f037349fde7ada9a331e16/src-tauri/src/commands/downloads.rs#L117)

  - Reloads application settings before prefetching video metadata.
  - Reinitializes the global HTTP proxy using the latest settings.
 
 Reason:
 -   After changing the proxy configuration, the next metadata prefetch could continue using stale settings. Reloading
  the settings ensures that video information previews immediately use the latest proxy configuration.



[src-tauri/src/core/queue.rs:1066](https://github.com/SiIverAsh/omniget/blob/18a83dd5f13a985b41f037349fde7ada9a331e16/src-tauri/src/core/queue.rs#L1066)
  - Reloads proxy settings before each formal download.
  - Reinitializes the global HTTP client using the latest proxy settings.
  - Writes the effective proxy state to the download log.

Example log messages:

  ```text
  [network] proxy setting: enabled; http://127.0.0.1:7897
  [network] proxy setting: disabled; direct connection enforced
  [network] proxy setting: enabled but host is empty; direct connection enforced
```
Reason:
 -   Ensures that every download uses the latest proxy configuration and allows users to confirm whether a task is
  using a proxy or a direct connection.

[src-tauri/src/core/queue.rs:1789](https://github.com/SiIverAsh/omniget/blob/18a83dd5f13a985b41f037349fde7ada9a331e16/src-tauri/src/core/queue.rs#L1789)
  - Added a 15 second timeout to background metadata prefetch.
  - Handles successful, failed, and timed-out prefetch results separately.
  

Reason:
   - Background prefetch and formal downloads may share synchronization for the same URL. If a prefetch request
  remains blocked, the formal download may also wait for it to complete. The timeout prevents prefetch tasks from
  blocking downloads indefinitely.



### commit [e7fd74a](https://github.com/tonhowtf/omniget/pull/138/commits/e7fd74a64464f372fec66936474fd995cec3d247)

[src-tauri/omniget-core/src/core/ytdlp.rs:507](https://github.com/SiIverAsh/omniget/blob/e7fd74a64464f372fec66936474fd995cec3d247/src-tauri/omniget-core/src/core/ytdlp.rs#L507)
[src-tauri/omniget-core/src/core/ytdlp.rs:653](https://github.com/SiIverAsh/omniget/blob/e7fd74a64464f372fec66936474fd995cec3d247/src-tauri/omniget-core/src/core/ytdlp.rs#L653)
 [src-tauri/src/core/queue.rs:1066](https://github.com/SiIverAsh/omniget/blob/e7fd74a64464f372fec66936474fd995cec3d247/src-tauri/src/core/queue.rs#L1066)
  - Preserve download logs when finished tasks are cleared.
  - Reload and apply the latest proxy configuration before downloading and fetching metadata.
  - Pass proxy settings explicitly to yt-dlp and log the active proxy with credentials redacted.
  - Add metadata fetch logs for cache hits, selected cookie accounts, duration, errors, and timeouts.
  - Increase metadata fetch timeouts to allow normal yt-dlp retry attempts to complete.

Reason:
-  Metadata fetching is a common failure point. Preserving detailed logs makes proxy, cookie, and timeout issues
  easier to diagnose. Reloading proxy settings ensures new tasks use the latest configuration, while longer
  timeouts prevent valid retries from being terminated prematurely.

[src/lib/stores/omnibox-draft-store.svelte.ts:1](https://github.com/SiIverAsh/omniget/blob/e7fd74a64464f372fec66936474fd995cec3d247/src/lib/stores/omnibox-draft-store.svelte.ts#L1)
[src/routes/+page.svelte:27](https://github.com/SiIverAsh/omniget/blob/e7fd74a64464f372fec66936474fd995cec3d247/src/routes/%2Bpage.svelte#L27)
  - Add a store for preserving the homepage omnibox draft.
  - Restore the previously entered URL after navigating back to the homepage.
  - Automatically parse the restored URL.

Reason:
 - Users should not lose an unsubmitted URL when navigating between pages or need to manually trigger parsing
again after returning.



[src/lib/components/cookies/CookieBucketCard.svelte:182](https://github.com/SiIverAsh/omniget/blob/e7fd74a64464f372fec66936474fd995cec3d247/src/lib/components/cookies/CookieBucketCard.svelte#L182)
[src/components/settings/SettingsCookies.svelte:547](https://github.com/SiIverAsh/omniget/blob/e7fd74a64464f372fec66936474fd995cec3d247/src/components/settings/SettingsCookies.svelte#L547)
  - Allow selecting cookie accounts by clicking cards or additional account rows.
  - Add Enter and Space keyboard selection support.
  - Prevent nested interactive elements from accidentally toggling selection.
  - Add visual feedback for selected and focused states.
  - Standardize bulk deletion button labels as delete.

Reason:
 - Previously, multi selection required clicking a small checkbox. Expanding the clickable area and adding keyboard
support improves account management efficiency, usability, and accessibility.



  ## New Problems:Douyin WAF limitation

  During testing, Douyin sometimes returned a JavaScript WAF verification page instead of the actual video page.This response contains browser verification scripts such as `WAFJS` and `_wafchallengeid`, which cannot be ompleted by a normal HTTP client or the current yt-dlp environment.This PR does not bypass the Douyin WAF verification. It detects the verification page early and returns a clearer error instead of leaving the download stuck.





