### PR TITLE
feat(i18n): add Russian locale to Firefox extension

### DIFF
--- a/browser-extension/firefox/_locales/ru/messages.json
+++ b/browser-extension/firefox/_locales/ru/messages.json
@@ -1,0 +1,98 @@
+{
+  "action_title_supported": {
+    "message": "Отправить эту медиа-страницу в OmniGet"
+  },
+  "action_title_unsupported": {
+    "message": "На этой странице не обнаружено поддерживаемых медиа"
+  },
+  "error_page_document_title": {
+    "message": "Расширение OmniGet"
+  },
+  "error_page_eyebrow": {
+    "message": "Расширение OmniGet"
+  },
+  "error_page_install_cta": {
+    "message": "Установить OmniGet"
+  },
+  "error_page_open_extensions": {
+    "message": "Открыть расширения Chrome"
+  },
+  "error_host_missing_title": {
+    "message": "Запустите OmniGet один раз, чтобы завершить настройку Chrome"
+  },
+  "error_host_missing_body": {
+    "message": "Chrome пока не может найти мост OmniGet на этом компьютере."
+  },
+  "error_host_missing_detail": {
+    "message": "Установите OmniGet при необходимости, затем запустите приложение один раз и нажмите на расширение снова."
+  },
+  "error_invalid_url_title": {
+    "message": "URL этой страницы нельзя отправить в OmniGet"
+  },
+  "error_invalid_url_body": {
+    "message": "Текущая страница не является поддерживаемой медиа-страницей для расширения OmniGet."
+  },
+  "error_invalid_url_detail": {
+    "message": "Попробуйте снова с прямой страницы видео, рилса, поста, плейлиста или курса."
+  },
+  "error_launch_failed_title": {
+    "message": "Не удалось запустить OmniGet из Chrome"
+  },
+  "error_launch_failed_body": {
+    "message": "Расширение связалось с нативным хостом, но приложение не запустилось корректно."
+  },
+  "error_launch_failed_detail": {
+    "message": "Проверьте, установлен ли OmniGet и не блокируется ли он вашей системой, затем повторите попытку."
+  },
+  "popup_send_default": { "message": "Отправить в OmniGet" },
+  "popup_send_audio": { "message": "Отправить аудио" },
+  "popup_video_found_one": { "message": "Найдено видео" },
+  "popup_videos_found": { "message": "$count$ видео найдено", "placeholders": { "count": { "content": "$1" } } },
+  "popup_listening_title": { "message": "Ожидание медиа…" },
+  "popup_listening_hint": { "message": "Видео и аудио будут появляться здесь по мере загрузки страниц." },
+  "popup_paused_title": { "message": "Обнаружение медиа приостановлено" },
+  "popup_paused_hint": { "message": "Включите переключатель выше, чтобы обнаруживать видео на этой странице." },
+  "popup_send_all": { "message": "Отправить все ($count$ видео)", "placeholders": { "count": { "content": "$1" } } },
+  "popup_detected_one": { "message": "Обнаружено 1 видео" },
+  "popup_detected_many": { "message": "Обнаружено $count$ видео", "placeholders": { "count": { "content": "$1" } } },
+  "popup_video_n": { "message": "Видео $n$", "placeholders": { "n": { "content": "$1" } } },
+  "popup_kind_audio": { "message": "Аудио" },
+  "popup_kind_video": { "message": "Видео" },
+  "popup_download_aria": { "message": "Скачать $name$", "placeholders": { "name": { "content": "$1" } } },
+  "popup_sending": { "message": "Отправка…" },
+  "popup_sent": { "message": "Отправлено!" },
+  "popup_sending_n": { "message": "Отправка $count$ видео…", "placeholders": { "count": { "content": "$1" } } },
+  "popup_sent_n": { "message": "$count$ видео отправлено!", "placeholders": { "count": { "content": "$1" } } },
+  "popup_sent_failed": { "message": "Отправлено $sent$, не удалось $failed$", "placeholders": { "sent": { "content": "$1" }, "failed": { "content": "$2" } } },
+  "popup_not_running": { "message": "OmniGet не запущен" },
+  "popup_try_again": { "message": "Повторить" },
+  "popup_get_app": { "message": "Скачать OmniGet" },
+  "popup_lbl_course": { "message": "Отправить курс в OmniGet" },
+  "popup_lbl_playlist": { "message": "Отправить плейлист в OmniGet" },
+  "popup_lbl_video": { "message": "Отправить видео в OmniGet" },
+  "popup_lbl_reel": { "message": "Отправить рилс в OmniGet" },
+  "popup_lbl_post": { "message": "Отправить пост в OmniGet" },
+  "popup_lbl_short": { "message": "Отправить короткое видео в OmniGet" },
+  "popup_lbl_clip": { "message": "Отправить клип в OmniGet" },
+  "popup_lbl_image": { "message": "Отправить изображение в OmniGet" },
+  "popup_lbl_audio": { "message": "Отправить аудио в OmniGet" },
+  "popup_lbl_profile": { "message": "Отправить профиль в OmniGet" },
+  "popup_lbl_page": { "message": "Отправить страницу в OmniGet" },
+  "popup_ck_saving": { "message": "Сохранение cookies…" },
+  "popup_ck_saved": { "message": "Сохранено cookies: $count$", "placeholders": { "count": { "content": "$1" } } },
+  "popup_ck_btn": { "message": "Сохранить cookies сайта" },
+  "popup_ck_meta": { "message": "$domain$ • $kind$", "placeholders": { "domain": { "content": "$1" }, "kind": { "content": "$2" } } },
+  "popup_ck_hint": { "message": "Отправляет cookies этого сайта в менеджер cookies OmniGet." },
+  "popup_ckerr_no_url": { "message": "Нет активной вкладки" },
+  "popup_ckerr_invalid_url": { "message": "Страница недоступна для проверки" },
+  "popup_ckerr_unsupported": { "message": "Только страницы http/https" },
+  "popup_ckerr_no_api": { "message": "API cookies заблокирован" },
+  "popup_ckerr_no_cookies": { "message": "Нет cookies для этого сайта" },
+  "popup_ckerr_missing_token": { "message": "Сначала свяжите OmniGet" },
+  "popup_ckerr_missing_endpoint": { "message": "OmniGet не обнаружен" },
+  "popup_ckerr_fetch_failed": { "message": "OmniGet не запущен" },
+  "popup_ckerr_unauthorized": { "message": "Неверный токен связывания" },
+  "popup_ckerr_default": { "message": "Не удалось сохранить cookies" },
+  "popup_open_app_label": { "message": "Открывать приложение при загрузке" },
+  "popup_sniffer_label": { "message": "Обнаружение медиа" }
+}

--- a/browser-extension/firefox/_locales/ru/messages.json
+++ b/browser-extension/firefox/_locales/ru/messages.json
@@ -15,13 +15,13 @@
     "message": "Установить OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "Открыть расширения Chrome"
+    "message": "Открыть настройки расширения"
   },
   "error_host_missing_title": {
-    "message": "Запустите OmniGet один раз, чтобы завершить настройку Chrome"
+    "message": "Запустите OmniGet один раз, чтобы завершить настройку Firefox"
   },
   "error_host_missing_body": {
-    "message": "Chrome пока не может найти мост OmniGet на этом компьютере."
+    "message": "Firefox пока не может найти мост OmniGet на этом компьютере."
   },
   "error_host_missing_detail": {
     "message": "Установите OmniGet при необходимости, затем запустите приложение один раз и нажмите на расширение снова."
@@ -36,7 +36,7 @@
     "message": "Попробуйте снова с прямой страницы видео, рилса, поста, плейлиста или курса."
   },
   "error_launch_failed_title": {
-    "message": "Не удалось запустить OmniGet из Chrome"
+    "message": "Не удалось запустить OmniGet из Firefox"
   },
   "error_launch_failed_body": {
     "message": "Расширение связалось с нативным хостом, но приложение не запустилось корректно."


### PR DESCRIPTION
## Summary

Fifth PR in the Russian-locale review series (after #171, #172, #173, #174; the app-side series concludes with #176).

The Chrome extension ships a complete Russian locale (66/66 keys), but the Firefox extension had **no `ru` locale at all** — Russian users of the Firefox extension get the English UI:

- `browser-extension/chrome/_locales/` → el, en, es, fr, it, ja, pt, **ru**, zh_CN, zh_TW
- `browser-extension/firefox/_locales/` → el, en, es, fr, it, ja, pt, zh_CN, zh_TW (no ru)

All other locales are byte-identical between the two extensions (verified with `git diff --no-index`), so this PR follows the same convention and copies the existing `chrome/_locales/ru/messages.json` into `firefox/_locales/ru/`, with one adjustment: the 4 strings that mention Chrome by name use Firefox wording, consistent with **#177**, which fixes the same Chrome-specific text in all other locales of the Firefox extension (a leftover from the fork).

- Key set matches `en` exactly (66/66), all `$placeholders$` intact, JSON validated.
- No manifest changes needed (`default_locale` stays `en`; WebExtensions pick up new locales from the folder automatically).

## Test plan

- [x] JSON valid, key set identical to `en` (66/66), placeholders intact
- [ ] Load the Firefox extension with a Russian browser profile and check the popup/error pages
