### PR TITLE
fix(extension): replace Chrome-specific wording in the Firefox extension

### DIFF
--- a/browser-extension/firefox/_locales/el/messages.json
+++ b/browser-extension/firefox/_locales/el/messages.json
@@ -15,13 +15,13 @@
     "message": "Εγκατάσταση του OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "Άνοιγμα επεκτάσεων Chrome"
+    "message": "Άνοιγμα ρυθμίσεων επέκτασης"
   },
   "error_host_missing_title": {
-    "message": "Ανοίξτε το OmniGet μία φορά για να ολοκληρώσετε τη ρύθμιση του Chrome"
+    "message": "Ανοίξτε το OmniGet μία φορά για να ολοκληρώσετε τη ρύθμιση του Firefox"
   },
   "error_host_missing_body": {
-    "message": "Το Chrome δεν μπόρεσε ακόμη να βρει τη γέφυρα OmniGet σε αυτόν τον υπολογιστή."
+    "message": "Το Firefox δεν μπόρεσε ακόμη να βρει τη γέφυρα OmniGet σε αυτόν τον υπολογιστή."
   },
   "error_host_missing_detail": {
     "message": "Εγκαταστήστε το OmniGet αν χρειάζεται, έπειτα ανοίξτε μία φορά την εφαρμογή υπολογιστή και πατήστε ξανά την επέκταση."
@@ -36,7 +36,7 @@
     "message": "Δοκιμάστε ξανά από μια άμεση σελίδα βίντεο, reel, ανάρτησης, λίστας αναπαραγωγής ή μαθήματος."
   },
   "error_launch_failed_title": {
-    "message": "Το OmniGet δεν μπόρεσε να εκκινηθεί από το Chrome"
+    "message": "Το OmniGet δεν μπόρεσε να εκκινηθεί από το Firefox"
   },
   "error_launch_failed_body": {
     "message": "Η επέκταση επικοινώνησε με το native host, αλλά η εφαρμογή υπολογιστή δεν ξεκίνησε σωστά."

--- a/browser-extension/firefox/_locales/en/messages.json
+++ b/browser-extension/firefox/_locales/en/messages.json
@@ -15,13 +15,13 @@
     "message": "Install OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "Open Chrome Extensions"
+    "message": "Open extension settings"
   },
   "error_host_missing_title": {
-    "message": "Open OmniGet once to finish Chrome setup"
+    "message": "Open OmniGet once to finish Firefox setup"
   },
   "error_host_missing_body": {
-    "message": "Chrome could not find the OmniGet bridge on this computer yet."
+    "message": "Firefox could not find the OmniGet bridge on this computer yet."
   },
   "error_host_missing_detail": {
     "message": "Install OmniGet if needed, then launch the desktop app once and click the extension again."
@@ -36,7 +36,7 @@
     "message": "Try again from a direct video, reel, post, playlist, or course page."
   },
   "error_launch_failed_title": {
-    "message": "OmniGet could not be launched from Chrome"
+    "message": "OmniGet could not be launched from Firefox"
   },
   "error_launch_failed_body": {
     "message": "The extension talked to the native host, but the desktop app did not start correctly."

--- a/browser-extension/firefox/_locales/es/messages.json
+++ b/browser-extension/firefox/_locales/es/messages.json
@@ -15,13 +15,13 @@
     "message": "Instalar OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "Abrir extensiones de Chrome"
+    "message": "Abrir la configuración de la extensión"
   },
   "error_host_missing_title": {
-    "message": "Abre OmniGet una vez para terminar la configuración de Chrome"
+    "message": "Abre OmniGet una vez para terminar la configuración de Firefox"
   },
   "error_host_missing_body": {
-    "message": "Chrome aún no pudo encontrar el puente de OmniGet en este equipo."
+    "message": "Firefox aún no pudo encontrar el puente de OmniGet en este equipo."
   },
   "error_host_missing_detail": {
     "message": "Instala OmniGet si es necesario, luego abre la app de escritorio una vez y vuelve a hacer clic en la extensión."
@@ -36,7 +36,7 @@
     "message": "Inténtalo de nuevo desde una página de vídeo directo, reel, publicación, lista o curso."
   },
   "error_launch_failed_title": {
-    "message": "No se pudo iniciar OmniGet desde Chrome"
+    "message": "No se pudo iniciar OmniGet desde Firefox"
   },
   "error_launch_failed_body": {
     "message": "La extensión se comunicó con el host nativo, pero la app de escritorio no se inició correctamente."

--- a/browser-extension/firefox/_locales/fr/messages.json
+++ b/browser-extension/firefox/_locales/fr/messages.json
@@ -15,13 +15,13 @@
     "message": "Installer OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "Ouvrir les extensions Chrome"
+    "message": "Ouvrir les paramètres de l'extension"
   },
   "error_host_missing_title": {
-    "message": "Ouvrez OmniGet une fois pour terminer la configuration de Chrome"
+    "message": "Ouvrez OmniGet une fois pour terminer la configuration de Firefox"
   },
   "error_host_missing_body": {
-    "message": "Chrome n'a pas encore trouvé le pont OmniGet sur cet ordinateur."
+    "message": "Firefox n'a pas encore trouvé le pont OmniGet sur cet ordinateur."
   },
   "error_host_missing_detail": {
     "message": "Installez OmniGet si nécessaire, puis lancez l'application de bureau une fois et cliquez à nouveau sur l'extension."
@@ -36,7 +36,7 @@
     "message": "Réessayez depuis une page directe de vidéo, reel, publication, playlist ou cours."
   },
   "error_launch_failed_title": {
-    "message": "OmniGet n'a pas pu être lancé depuis Chrome"
+    "message": "OmniGet n'a pas pu être lancé depuis Firefox"
   },
   "error_launch_failed_body": {
     "message": "L'extension a bien contacté l'hôte natif, mais l'application de bureau ne s'est pas lancée correctement."

--- a/browser-extension/firefox/_locales/it/messages.json
+++ b/browser-extension/firefox/_locales/it/messages.json
@@ -15,13 +15,13 @@
     "message": "Installa OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "Apri estensioni di Chrome"
+    "message": "Apri le impostazioni dell'estensione"
   },
   "error_host_missing_title": {
-    "message": "Apri OmniGet una volta per completare la configurazione di Chrome"
+    "message": "Apri OmniGet una volta per completare la configurazione di Firefox"
   },
   "error_host_missing_body": {
-    "message": "Chrome non riesce ancora a trovare il bridge di OmniGet su questo computer."
+    "message": "Firefox non riesce ancora a trovare il bridge di OmniGet su questo computer."
   },
   "error_host_missing_detail": {
     "message": "Installa OmniGet se necessario, poi avvia una volta l'app desktop e fai di nuovo clic sull'estensione."
@@ -36,7 +36,7 @@
     "message": "Riprova da una pagina diretta di video, reel, post, playlist o corso."
   },
   "error_launch_failed_title": {
-    "message": "OmniGet non è stato avviato da Chrome"
+    "message": "OmniGet non è stato avviato da Firefox"
   },
   "error_launch_failed_body": {
     "message": "L'estensione ha comunicato con l'host nativo, ma l'app desktop non si è avviata correttamente."

--- a/browser-extension/firefox/_locales/ja/messages.json
+++ b/browser-extension/firefox/_locales/ja/messages.json
@@ -15,13 +15,13 @@
     "message": "OmniGet をインストール"
   },
   "error_page_open_extensions": {
-    "message": "Chrome 拡張機能を開く"
+    "message": "拡張機能の設定を開く"
   },
   "error_host_missing_title": {
-    "message": "Chrome のセットアップを完了するには OmniGet を一度開いてください"
+    "message": "Firefox のセットアップを完了するには OmniGet を一度開いてください"
   },
   "error_host_missing_body": {
-    "message": "Chrome はこのコンピューター上の OmniGet ブリッジをまだ見つけられませんでした。"
+    "message": "Firefox はこのコンピューター上の OmniGet ブリッジをまだ見つけられませんでした。"
   },
   "error_host_missing_detail": {
     "message": "必要なら OmniGet をインストールし、デスクトップアプリを一度起動してからもう一度拡張機能をクリックしてください。"
@@ -36,7 +36,7 @@
     "message": "動画、リール、投稿、再生リスト、またはコースの直接ページからもう一度お試しください。"
   },
   "error_launch_failed_title": {
-    "message": "Chrome から OmniGet を起動できませんでした"
+    "message": "Firefox から OmniGet を起動できませんでした"
   },
   "error_launch_failed_body": {
     "message": "拡張機能はネイティブホストと通信しましたが、デスクトップアプリは正しく起動しませんでした。"

--- a/browser-extension/firefox/_locales/pt/messages.json
+++ b/browser-extension/firefox/_locales/pt/messages.json
@@ -15,13 +15,13 @@
     "message": "Instalar OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "Abrir extensões do Chrome"
+    "message": "Abrir as configurações da extensão"
   },
   "error_host_missing_title": {
-    "message": "Abra o OmniGet uma vez para concluir a configuração do Chrome"
+    "message": "Abra o OmniGet uma vez para concluir a configuração do Firefox"
   },
   "error_host_missing_body": {
-    "message": "O Chrome ainda não conseguiu encontrar a ponte do OmniGet neste computador."
+    "message": "O Firefox ainda não conseguiu encontrar a ponte do OmniGet neste computador."
   },
   "error_host_missing_detail": {
     "message": "Instale o OmniGet se necessário, depois abra o aplicativo de desktop uma vez e clique novamente na extensão."
@@ -36,7 +36,7 @@
     "message": "Tente novamente a partir de uma página direta de vídeo, reel, publicação, playlist ou curso."
   },
   "error_launch_failed_title": {
-    "message": "O OmniGet não pôde ser iniciado pelo Chrome"
+    "message": "O OmniGet não pôde ser iniciado pelo Firefox"
   },
   "error_launch_failed_body": {
     "message": "A extensão falou com o host nativo, mas o aplicativo de desktop não iniciou corretamente."

--- a/browser-extension/firefox/_locales/zh_CN/messages.json
+++ b/browser-extension/firefox/_locales/zh_CN/messages.json
@@ -15,13 +15,13 @@
     "message": "安装 OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "打开 Chrome 扩展程序"
+    "message": "打开扩展设置"
   },
   "error_host_missing_title": {
-    "message": "先打开一次 OmniGet 以完成 Chrome 设置"
+    "message": "先打开一次 OmniGet 以完成 Firefox 设置"
   },
   "error_host_missing_body": {
-    "message": "Chrome 目前还找不到这台电脑上的 OmniGet 桥接程序。"
+    "message": "Firefox 目前还找不到这台电脑上的 OmniGet 桥接程序。"
   },
   "error_host_missing_detail": {
     "message": "如有需要请安装 OmniGet，然后先启动一次桌面应用，再次点击扩展程序。"
@@ -36,7 +36,7 @@
     "message": "请从视频、Reel、帖子、播放列表或课程的直接页面重试。"
   },
   "error_launch_failed_title": {
-    "message": "Chrome 无法启动 OmniGet"
+    "message": "Firefox 无法启动 OmniGet"
   },
   "error_launch_failed_body": {
     "message": "扩展程序已与原生主机通信，但桌面应用未能正确启动。"

--- a/browser-extension/firefox/_locales/zh_TW/messages.json
+++ b/browser-extension/firefox/_locales/zh_TW/messages.json
@@ -15,13 +15,13 @@
     "message": "安裝 OmniGet"
   },
   "error_page_open_extensions": {
-    "message": "開啟 Chrome 擴充功能"
+    "message": "開啟擴充功能設定"
   },
   "error_host_missing_title": {
-    "message": "請先開啟一次 OmniGet 以完成 Chrome 設定"
+    "message": "請先開啟一次 OmniGet 以完成 Firefox 設定"
   },
   "error_host_missing_body": {
-    "message": "Chrome 目前還找不到這台電腦上的 OmniGet 橋接程式。"
+    "message": "Firefox 目前還找不到這台電腦上的 OmniGet 橋接程式。"
   },
   "error_host_missing_detail": {
     "message": "如有需要請安裝 OmniGet，然後先啟動一次桌面應用程式，再次點擊擴充功能。"
@@ -36,7 +36,7 @@
     "message": "請從影片、Reel、貼文、播放清單或課程的直接頁面再試一次。"
   },
   "error_launch_failed_title": {
-    "message": "Chrome 無法啟動 OmniGet"
+    "message": "Firefox 無法啟動 OmniGet"
   },
   "error_launch_failed_body": {
     "message": "擴充功能已與原生主機通訊，但桌面應用程式未能正確啟動。"

--- a/browser-extension/firefox/pages/error-content.js
+++ b/browser-extension/firefox/pages/error-content.js
@@ -2,9 +2,9 @@ const ERROR_PAGE_MESSAGES = Object.freeze({
   error_page_document_title: "OmniGet Extension",
   error_page_eyebrow: "OmniGet Extension",
   error_page_install_cta: "Install OmniGet",
-  error_page_open_extensions: "Open Chrome Extensions",
-  error_host_missing_title: "Open OmniGet once to finish Chrome setup",
-  error_host_missing_body: "Chrome could not find the OmniGet bridge on this computer yet.",
+  error_page_open_extensions: "Open extension settings",
+  error_host_missing_title: "Open OmniGet once to finish Firefox setup",
+  error_host_missing_body: "Firefox could not find the OmniGet bridge on this computer yet.",
   error_host_missing_detail:
     "Install OmniGet if needed, then launch the desktop app once and click the extension again.",
   error_invalid_url_title: "This page URL cannot be sent to OmniGet",
@@ -12,7 +12,7 @@ const ERROR_PAGE_MESSAGES = Object.freeze({
     "The current page is not a supported media page for the OmniGet extension.",
   error_invalid_url_detail:
     "Try again from a direct video, reel, post, playlist, or course page.",
-  error_launch_failed_title: "OmniGet could not be launched from Chrome",
+  error_launch_failed_title: "OmniGet could not be launched from Firefox",
   error_launch_failed_body:
     "The extension talked to the native host, but the desktop app did not start correctly.",
   error_launch_failed_detail:

--- a/browser-extension/firefox/pages/error.html
+++ b/browser-extension/firefox/pages/error.html
@@ -16,7 +16,7 @@
         <pre id="url" class="url"></pre>
         <div class="actions">
           <a id="install-link" class="button primary" href="#" target="_blank" rel="noreferrer">Install OmniGet</a>
-          <button id="open-extensions" class="button" type="button">Open Chrome Extensions</button>
+          <button id="open-extensions" class="button" type="button">Open extension settings</button>
         </div>
       </div>
     </main>

--- a/browser-extension/firefox/pages/error.js
+++ b/browser-extension/firefox/pages/error.js
@@ -29,5 +29,7 @@ installLink.textContent = content.installLabel;
 openExtensionsBtn.textContent = content.openExtensionsLabel;
 
 openExtensionsBtn.addEventListener("click", () => {
-  chrome.tabs.create({ url: "chrome://extensions" });
+  // about:addons is a privileged URL that extensions cannot open in Firefox,
+  // so open the extension's own settings page instead.
+  chrome.runtime.openOptionsPage();
 });


### PR DESCRIPTION
## Summary

Companion to #175. The Firefox extension was forked from the Chrome one with its locale files and error page copied verbatim, so Firefox users see Chrome-specific text — in every language:

- "Open Chrome Extensions" (button on the error page)
- "Open OmniGet once to finish Chrome setup"
- "Chrome could not find the OmniGet bridge on this computer yet."
- "OmniGet could not be launched from Chrome"

### Changes

**Locale files** — the 4 affected strings updated in all 9 locales of the Firefox extension (`en`, `es`, `fr`, `it`, `pt`, `el`, `ja`, `zh_CN`, `zh_TW`): Chrome → Firefox, and the button label changed to "Open extension settings" (see below for why). Message keys unchanged; the Chrome extension is untouched. The `ru` locale added in #175 has been updated on its branch with the same wording, so the two PRs are consistent.

**Error page behavior fix** (`pages/error.js`) — the button opened `chrome://extensions` via `tabs.create()`. In Firefox that is a privileged URL, so the call is rejected with `Illegal URL` and the button silently did nothing. `about:addons` is equally privileged and [cannot be opened by extensions either](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update), so the button now calls `runtime.openOptionsPage()` — the extension's own settings page (`options_ui` is already declared in the manifest), which is where the bridge/token setup lives. Fallback strings in `error-content.js` and the static label in `error.html` updated to match.

## Test plan

- [x] All 9 locale files parse, message keys unchanged
- [x] No "Chrome" mentions left in `firefox/_locales` or page text (only `chrome.*` API calls, which are correct — Firefox supports the `chrome` namespace)
- [ ] Trigger the error page in Firefox (e.g. with the desktop app not running) and check that the button opens the extension settings
