### PR TITLE
feat(omnibox): allow choosing download mode for batch downloads

### DIFF
--- a/src/components/omnibox/DownloadModeSelector.svelte
+++ b/src/components/omnibox/DownloadModeSelector.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { t } from "$lib/i18n";
 
-  let { downloadMode = $bindable("auto" as "auto" | "audio" | "mute"), onChange } = $props();
+  let { downloadMode = $bindable("auto" as "auto" | "audio" | "mute"), onChange = undefined } = $props();
 </script>
 
 <div class="mode-group">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -954,7 +954,10 @@
     {/if}
 
     {#if omniState.kind === "batch"}
-      <BatchDownload count={omniState.urls.length} onDownload={handleBatchDownload} />
+      <div class="batch-options">
+        <DownloadModeSelector bind:downloadMode />
+        <BatchDownload count={omniState.urls.length} onDownload={handleBatchDownload} />
+      </div>
 
     {:else if omniState.kind === "searching"}
       <div class="feedback feedback-enter">
@@ -1305,6 +1308,12 @@
       opacity: 0.7;
       transform: scale(0.95);
     }
+  }
+
+  .batch-options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
   }
 
   .feedback {


### PR DESCRIPTION
## Problem
When pasting multiple URLs, the batch download UI only shows "Download all" — there's no way to choose the download mode. So batch downloads always use whatever `downloadMode` happens to be set, and you can't force "Audio only". This is especially noticeable with YouTube Music links (`music.youtube.com`), which are detected as regular YouTube videos: in single-download you can pick "Audio Only (MP3)", but in batch you can't.

## Fix
The batch flow already forwards `downloadMode` to the backend (`handleBatchDownload`) — only the UI to choose it was missing. This renders the existing `DownloadModeSelector` (Auto / Audio Only / No Sound) above the "Download all" button in the batch state, bound to the same `downloadMode` state. `DownloadModeSelector`'s `onChange` prop is made optional, since the batch usage has no format selection to reset.

# Demonstration
<img width="900" height="494" alt="batch-mode" src="https://github.com/user-attachments/assets/4bba447e-01eb-4b89-8fa0-bca8dd25ba57" />

## Notes
- No backend changes.
- `pnpm check` passes (0 errors). No Rust files touched.
- Selected mode applies to every URL in the batch.
