### PR TITLE
docs: SEO pass on all three READMEs, and fix the broken Linux install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 <!--
 SEO / discovery: OmniGet is a free open source downloader for Windows, macOS and Linux.
-Suggested GitHub topics (set these in repo Settings > Topics):
-video-downloader, youtube-downloader, media-downloader, course-downloader, udemy-downloader,
-music-downloader, ebook-reader, yt-dlp, yt-dlp-gui, tauri, svelte, rust, desktop-app,
-cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, torrent, p2p
+GitHub caps topics at 20, so this list is exactly 20 — adding one means removing one.
+Chosen for rankability: OmniGet is #1 by stars in course-downloader, udemy-downloader,
+hotmart-downloader, bilibili-downloader, tiktok-downloader, twitter-downloader,
+reddit-downloader and media-downloader. Broad topics (rust, svelte, tauri, desktop-app,
+open-source) were dropped on purpose: the field there is 10k-110k repos deep and this repo
+cannot rank, so the slots are worth more elsewhere.
+downloader, download-manager, media-downloader, video-downloader, youtube-downloader,
+yt-dlp, yt-dlp-gui, course-downloader, udemy-downloader, hotmart-downloader,
+bilibili-downloader, tiktok-downloader, instagram-downloader, twitter-downloader,
+reddit-downloader, telegram-downloader, twitch-downloader, subtitle-downloader,
+epub-reader, spaced-repetition
 -->
 
 <p align="center">
@@ -29,7 +36,7 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
 </p>
 
 <p align="center">
-  <b>OmniGet</b> is a free, open source desktop app for Windows, macOS, and Linux. It downloads online courses (Udemy, Hotmart, Kiwify, Skool, Teachable, and more), video and audio from YouTube, TikTok, Instagram, Twitter/X, Reddit, and 1,800+ other sites, plus music and books. Everything plays inside the app. No command line, no Python, no setup, and your files stay on your computer.
+  <b>OmniGet is a free, open source desktop application for Windows, macOS, and Linux.</b> It downloads online courses (Udemy, Hotmart, Kiwify, Skool, Teachable, and more), video and audio from YouTube, TikTok, Instagram, Twitter/X, Reddit, and 1,800+ other sites, plus music and books. Everything plays inside the app. No command line, no Python, no setup, and your files stay on your computer. Released under the GPL-3.0 license.
 </p>
 
 <p align="center">
@@ -58,7 +65,7 @@ Pick your system, download the latest release, and open it. There is no installe
     <td>
       <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="Download OmniGet for Windows" src="https://img.shields.io/badge/Windows-Portable_EXE-0078D6?style=for-the-badge&logo=windows&logoColor=white" height="38"></a>
       <br/>
-      <sub>Download the <code>.exe</code> from Releases and double click it. It is portable, so it runs from anywhere.</sub>
+      <sub>Download the <code>.exe</code> from Releases and double click it. It is portable, so it runs from anywhere. There is also an <code>.msi</code> installer, and <code>winget install -e --id tonhowtf.OmniGet</code> if you prefer the command line.</sub>
     </td>
   </tr>
   <tr>
@@ -72,12 +79,14 @@ Pick your system, download the latest release, and open it. There is no installe
   <tr>
     <td><strong>Linux</strong></td>
     <td>
-      <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="Download OmniGet for Linux" src="https://img.shields.io/badge/Linux-Flatpak-FFAA33?style=for-the-badge&logo=linux&logoColor=white" height="38"></a>
+      <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="Download OmniGet for Linux as deb, rpm or AppImage" src="https://img.shields.io/badge/Linux-deb_·_rpm_·_AppImage-FFAA33?style=for-the-badge&logo=linux&logoColor=white" height="38"></a>
       <br/>
-      <sub>Run <code>flatpak install wtf.tonho.omniget</code>, or grab the bundle from Releases.</sub>
+      <sub>Debian and Ubuntu: download the <code>.deb</code>. Fedora and openSUSE: the <code>.rpm</code>. Everything else: the <code>.AppImage</code>. x86_64 and ARM64 builds are both published.</sub>
     </td>
   </tr>
 </table>
+
+<sub><strong>AppImage on Debian 12+ or Ubuntu 24.04+:</strong> those releases ship without FUSE 2, which AppImage needs. If <code>./omniget.AppImage</code> fails with a libfuse error, run <code>sudo apt install libfuse2</code>, or start it with <code>./omniget.AppImage --appimage-extract-and-run</code>. The <code>.deb</code> avoids this entirely.</sub>
 
 ### ⚠️ Please read this before the first launch
 
@@ -93,6 +102,10 @@ codesign --force --deep --sign - /Applications/omniget.app
 Then open OmniGet normally. You only do this once.
 
 **Windows.** SmartScreen may show a blue warning on the first run. Click **More info**, then **Run anyway**. This is standard for open source apps without a paid code signing certificate.
+
+### Portable mode, for a USB stick or a locked-down PC
+
+Create an empty file named `portable.txt` (or `.portable`) next to the `.exe` and relaunch. OmniGet then keeps settings, the database, cookies, plugins, caches, and the bundled yt-dlp and FFmpeg in a `data` folder beside the executable. Nothing is written to `AppData\Roaming` or any other user folder, so the whole install travels on the stick. Without that file, OmniGet uses the standard per-user data directory.
 
 Free and open source under GPL-3.0. Updates run quietly in the background. The bundled tools (yt-dlp and FFmpeg) install themselves, and yt-dlp is verified by SHA256 before it runs. Plugins install on first launch and update themselves too, with nothing for you to configure.
 
@@ -120,6 +133,26 @@ It is the only open source app that downloads a full Udemy or Hotmart course, vi
 
 ---
 
+## How OmniGet compares to yt-dlp and other downloaders
+
+Different tools do different jobs. This is where OmniGet fits, not a scoreboard.
+
+### OmniGet vs yt-dlp
+
+[yt-dlp](https://github.com/yt-dlp/yt-dlp) is the extraction engine, and OmniGet uses it. yt-dlp is a command-line tool: you install Python, you learn the flags, you write the format selector, and you get an unmatched amount of control over 1,800+ sites. It is excellent at that, and OmniGet would not exist without it.
+
+OmniGet is the app around it. You install one file, paste a link, and see a preview with quality options. yt-dlp and FFmpeg install and update themselves, and yt-dlp is verified by SHA256 before it runs. On top of that sit a queue that retries and resumes, a download history, a course player, a reader, and a music library. If you are comfortable in a terminal and only want files, use yt-dlp directly. If you want a library you can actually watch and read, use OmniGet.
+
+### OmniGet vs single-purpose downloaders
+
+Most downloaders do one site well. OmniGet covers courses, video, audio, images, torrents, and Telegram in one queue, and then plays the result. The trade-off is honest: a dedicated tool for one platform will sometimes support an edge case first.
+
+### OmniGet vs paid course downloaders
+
+Paid course downloaders typically charge a subscription for something you already own access to. OmniGet is GPL-3.0, has no account, no ads, and no paid tier, and it downloads only what your own logged-in session can already reach.
+
+---
+
 ## What OmniGet downloads
 
 Paste a link. OmniGet detects the site, shows a preview with quality options, and downloads. If [yt-dlp](https://github.com/yt-dlp/yt-dlp) supports a site, OmniGet downloads from it, which is roughly a thousand more than the table below.
@@ -131,6 +164,7 @@ Paste a link. OmniGet detects the site, shows a preview with quality options, an
 | Bilibili (deep) | Sign in for 4K, HDR, Dolby Vision, Hi-Res lossless, Dolby Atmos. Danmaku (XML/ASS/JSON), NFO for Kodi and Jellyfin, 11 URL types (UGC, 番剧, 课程, 收藏夹, UP主, 每周必看, 稍后再看, 历史记录, b23.tv) |
 | Asian platforms | Douyin (抖音), Xiaohongshu (小红书), Kuaishou (快手), Youku (优酷), iQiyi (爱奇艺), Tencent Video, Mango TV |
 | Image galleries | DeviantArt, Pixiv, ArtStation, Flickr, Tumblr, Imgur albums, Kemono, Newgrounds, image boards |
+| Bulk profiles | Whole subreddits and their sort pages, Reddit user profiles, and X/Twitter profiles |
 | Files and transfer | `.torrent` and magnet links, plus direct P2P transfer between two computers with a short code |
 
 Things people search for, and OmniGet does:
@@ -138,7 +172,7 @@ Things people search for, and OmniGet does:
 - **Download a full online course**, every lesson and attached PDF, then watch it inside the app and resume where you stopped.
 - **Download a YouTube video or whole playlist**, pick the quality, or grab audio only as MP3, M4A, Opus, FLAC, or WAV.
 - **Download TikTok, Instagram, Twitter/X, Reddit** posts, reels, stories, carousels, and galleries.
-- **Batch download** a list of links from a text file, or an entire creator profile.
+- **Batch download** a list of links from a text file, an entire subreddit, a Reddit user profile, or an X/Twitter profile, all in one go.
 - **Download only part of a video** by setting a start and end time.
 - **Download subtitles** in any language, embed them, or generate them with Whisper when none exist.
 - **Skip sponsors** with SponsorBlock, and auto embed metadata and thumbnails.
@@ -260,36 +294,54 @@ Quietly there when you need them.
 ## Frequently asked questions
 
 **Is OmniGet free?**
-Yes. Free and open source under GPL-3.0, with no account, no ads, and no paid tier.
+Yes. OmniGet is free and open source under GPL-3.0, with no account, no ads, and no paid tier.
 
-**Do I need the terminal or Python?**
+**Do I need an account to use OmniGet?**
+No. OmniGet needs no account and no sign-up of its own. You only log in to a platform when the content itself requires it, such as a paid course you bought or a Bilibili premium stream, and that session stays on your computer.
+
+**Can OmniGet download a YouTube playlist or an entire channel?**
+Yes. Paste a playlist URL and OmniGet queues every video in it. You can also follow a channel, and OmniGet downloads new uploads automatically and shows a tray notification.
+
+**Does OmniGet resume an interrupted download?**
+Yes. The queue keeps partially downloaded files and continues from where it stopped instead of starting over, and it retries with backoff when a site rate-limits you. Closing the app or losing your connection does not throw away progress.
+
+**What file formats can OmniGet save?**
+Video as MP4, MKV, or WebM, and audio as MP3, M4A, Opus, FLAC, or WAV. Subtitles save as SRT, VTT, or ASS, and can be embedded into the video file. Books open as PDF, EPUB, CBZ, TXT, and HTML.
+
+**Can OmniGet download paid content I already bought?**
+OmniGet downloads what your own logged-in session can already open, such as a Udemy or Hotmart course you paid for. It does not bypass DRM, break paywalls, or share credentials. Content you have no access to stays inaccessible.
+
+**Do I need the terminal or Python to use OmniGet?**
 No. OmniGet is a normal desktop app. Download it, open it, paste a link. yt-dlp and FFmpeg are bundled and update themselves. The only time you may touch Terminal is the one time macOS first launch step above.
 
-**The app will not open on macOS, what do I do?**
+**OmniGet will not open on macOS, what do I do?**
 Run the two Terminal commands in the [first launch note](#️-please-read-this-before-the-first-launch). Gatekeeper blocks unsigned open source apps, and those lines clear the flag. You do it once.
 
-**Is this just a yt-dlp GUI?**
-It uses yt-dlp under the hood for the 1,800+ generic sites, with native extractors for the big platforms, plus a real interface, a queue, a library, and built-in players on top. So yes, and a lot more than a GUI.
+**Is OmniGet just a yt-dlp GUI?**
+OmniGet uses yt-dlp under the hood for the 1,800+ generic sites, with native extractors for the big platforms, plus a real interface, a queue, a library, and built-in players on top. So yes, and a lot more than a GUI.
 
-**Can it download a full Udemy or Hotmart course?**
+**Can OmniGet download a full Udemy or Hotmart course?**
 Yes. You log in once on the platform, pick the course, and OmniGet downloads every lesson and attachment, then plays them back with timestamped notes.
 
-**Which sites are supported?**
+**Which sites does OmniGet support?**
 Online courses, YouTube, TikTok, Instagram, Twitter/X, Reddit, Twitch, Vimeo, Bilibili, Pinterest, Bluesky, major Asian platforms, image galleries, torrents and magnets, plus around 1,800 more through yt-dlp.
 
-**Does it work on Windows, macOS, and Linux?**
-Yes, all three. Windows is a portable `.exe`, macOS is a `.dmg`, Linux is a Flatpak or bundle.
+**Does OmniGet work on Windows, macOS, and Linux?**
+Yes, all three, on both x86_64 and ARM64. Windows ships as a portable `.exe`, an `.msi` installer, and a winget package. macOS ships as a `.dmg` for Apple Silicon and Intel. Linux ships as `.deb`, `.rpm`, and `.AppImage`.
 
-**Can I keep everything in one folder (true portable mode, e.g. on a USB stick)?**
+**Which Linux distributions are supported?**
+OmniGet runs on any modern desktop Linux. Debian and Ubuntu users should take the `.deb`, Fedora and openSUSE the `.rpm`, and anything else the `.AppImage`. On Debian 12+ and Ubuntu 24.04+ the AppImage needs `sudo apt install libfuse2`, because those releases dropped FUSE 2; the `.deb` has no such requirement.
+
+**Can OmniGet run fully portable from a USB stick?**
 Yes. Create an empty file named `portable.txt` (or `.portable`) next to the `.exe` and relaunch. OmniGet then stores settings, the database, cookies, plugins, caches, and the bundled yt-dlp/FFmpeg in a `data` folder beside the executable — nothing is written to `AppData\Roaming` or other user folders. Without that file, the app uses the standard per-user data directory.
 
-**Can it download audio only, or just a clip?**
-Yes. Extract audio as MP3, M4A, Opus, FLAC, or WAV, or set a start and end time to download only the part you need.
+**Can OmniGet download audio only, or just a clip?**
+Yes. OmniGet extracts audio as MP3, M4A, Opus, FLAC, or WAV, or set a start and end time to download only the part you need.
 
-**Are my downloads private?**
-Yes. Everything runs locally and your files never leave your computer. There is no telemetry on what you download.
+**Are my OmniGet downloads private?**
+Yes. Everything in OmniGet runs locally and your files never leave your computer. There is no telemetry on what you download.
 
-**Can it download Bilibili in 4K, HDR, or Hi-Res lossless?**
+**Can OmniGet download Bilibili in 4K, HDR, or Hi-Res lossless?**
 Yes, with a Bilibili account signed in. OmniGet talks to the official Bilibili API and respects exactly what your 大会员 (premium) subscription unlocks. Without signing in, downloads still work through yt-dlp at standard quality.
 
 ---
@@ -317,6 +369,24 @@ sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file lib
 </details>
 
 Production build: `pnpm tauri build`.
+
+### Command line interface (build it yourself)
+
+The repository also contains `omniget-cli`, a small Rust binary that makes OmniGet scriptable. **It is not included in the release downloads yet** — you build it from this repository:
+
+```bash
+cargo build --release -p omniget-cli
+```
+
+```bash
+omniget info <url>                     # preview title, formats and size, download nothing
+omniget download <url> -q 1080 -o ~/Videos
+omniget download <url> --audio-only --subs en,pt
+omniget batch links.txt -m 3           # one URL per line, 3 at a time
+omniget import-cookies cookies.txt     # Netscape format
+```
+
+The desktop app never needs this. It exists for cron jobs, dotfiles, and scripts.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,9 +1,11 @@
 <!--
 SEO / discovery: OmniGet - бесплатный загрузчик с открытым исходным кодом для Windows, macOS и Linux.
 Рекомендуемые GitHub topics (задайте их в репозитории: Settings > Topics):
-video-downloader, youtube-downloader, media-downloader, course-downloader, udemy-downloader,
-music-downloader, ebook-reader, yt-dlp, yt-dlp-gui, tauri, svelte, rust, desktop-app,
-cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, torrent, p2p
+downloader, download-manager, media-downloader, video-downloader, youtube-downloader,
+yt-dlp, yt-dlp-gui, course-downloader, udemy-downloader, hotmart-downloader,
+bilibili-downloader, tiktok-downloader, instagram-downloader, twitter-downloader,
+reddit-downloader, telegram-downloader, twitch-downloader, subtitle-downloader,
+epub-reader, spaced-repetition
 -->
 
 <p align="center">
@@ -29,7 +31,7 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
 </p>
 
 <p align="center">
-  <b>OmniGet</b> - это бесплатное настольное приложение с открытым исходным кодом для Windows, macOS и Linux. Оно скачивает онлайн-курсы (Udemy, Hotmart, Kiwify, Skool, Teachable и другие), видео и аудио с YouTube, TikTok, Instagram, Twitter/X, Reddit и 1800+ других сайтов, а также вашу музыку и книги. Всё воспроизводится прямо в приложении. Без командной строки, без Python, без настройки, и ваши файлы остаются на вашем компьютере.
+  <b>OmniGet — это бесплатное настольное приложение с открытым исходным кодом для Windows, macOS и Linux.</b> Оно скачивает онлайн-курсы (Udemy, Hotmart, Kiwify, Skool, Teachable и другие), видео и аудио с YouTube, TikTok, Instagram, Twitter/X, Reddit и 1800+ других сайтов, а также вашу музыку и книги. Всё воспроизводится прямо в приложении. Без командной строки, без Python, без настройки, и ваши файлы остаются на вашем компьютере. Распространяется по лицензии GPL-3.0.
 </p>
 
 <p align="center">
@@ -58,7 +60,7 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
     <td>
       <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="Скачать OmniGet для Windows" src="https://img.shields.io/badge/Windows-Portable_EXE-0078D6?style=for-the-badge&logo=windows&logoColor=white" height="38"></a>
       <br/>
-      <sub>Скачайте <code>.exe</code> из Releases и дважды кликните. Это портативная версия, она запускается откуда угодно.</sub>
+      <sub>Скачайте <code>.exe</code> из Releases и дважды кликните. Это портативная версия, она запускается откуда угодно. Есть также установщик <code>.msi</code>, а если привычнее командная строка — <code>winget install -e --id tonhowtf.OmniGet</code>.</sub>
     </td>
   </tr>
   <tr>
@@ -72,12 +74,14 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
   <tr>
     <td><strong>Linux</strong></td>
     <td>
-      <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="Скачать OmniGet для Linux" src="https://img.shields.io/badge/Linux-Flatpak-FFAA33?style=for-the-badge&logo=linux&logoColor=white" height="38"></a>
+      <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="Скачать OmniGet для Linux в формате deb, rpm или AppImage" src="https://img.shields.io/badge/Linux-deb_·_rpm_·_AppImage-FFAA33?style=for-the-badge&logo=linux&logoColor=white" height="38"></a>
       <br/>
-      <sub>Выполните <code>flatpak install wtf.tonho.omniget</code> или возьмите сборку из Releases.</sub>
+      <sub>Debian и Ubuntu — <code>.deb</code>, Fedora и openSUSE — <code>.rpm</code>, остальные дистрибутивы — <code>.AppImage</code>. Собираются сборки для x86_64 и ARM64.</sub>
     </td>
   </tr>
 </table>
+
+<sub><strong>AppImage на Debian 12+ и Ubuntu 24.04+:</strong> в этих выпусках больше нет FUSE 2, который нужен AppImage. Если <code>./omniget.AppImage</code> завершается с ошибкой libfuse, выполните <code>sudo apt install libfuse2</code> или запустите с ключом <code>./omniget.AppImage --appimage-extract-and-run</code>. С <code>.deb</code> этой проблемы нет вовсе.</sub>
 
 ### ⚠️ Обязательно прочитайте перед первым запуском
 
@@ -93,6 +97,10 @@ codesign --force --deep --sign - /Applications/omniget.app
 Затем откройте OmniGet как обычно. Это делается один раз.
 
 **Windows.** При первом запуске SmartScreen может показать синее предупреждение. Нажмите **More info (Подробнее)**, затем **Run anyway (Выполнить в любом случае)**. Это стандартно для приложений с открытым исходным кодом без платного сертификата подписи кода.
+
+### Портативный режим: флешка или рабочий компьютер с ограничениями
+
+Создайте рядом с `.exe` пустой файл с именем `portable.txt` (или `.portable`) и перезапустите приложение. После этого OmniGet держит настройки, базу данных, cookie, плагины, кеш и встроенные yt-dlp и FFmpeg в папке `data` рядом с исполняемым файлом. Ничего не пишется в `AppData\Roaming` или другие пользовательские каталоги, поэтому вся установка переносится вместе с флешкой. Без этого файла OmniGet использует стандартный пользовательский каталог данных.
 
 Бесплатно и с открытым исходным кодом под лицензией GPL-3.0. Обновления идут тихо в фоне. Встроенные инструменты (yt-dlp и FFmpeg) устанавливаются сами, а yt-dlp проверяется по SHA256 перед запуском. Плагины устанавливаются при первом запуске и обновляются сами, настраивать ничего не нужно.
 
@@ -120,6 +128,26 @@ OmniGet делает всё это в одном окне. Вставьте сс
 
 ---
 
+## Чем OmniGet отличается от yt-dlp и других загрузчиков
+
+У разных инструментов разные задачи. Здесь о том, где место OmniGet, а не о том, кто лучше.
+
+### OmniGet и yt-dlp
+
+[yt-dlp](https://github.com/yt-dlp/yt-dlp) — это движок извлечения, и OmniGet работает на нём. yt-dlp — инструмент командной строки: нужно поставить Python, разобраться с ключами, написать выражение выбора формата, и взамен вы получаете непревзойдённый контроль над 1800+ сайтами. Он отлично с этим справляется, и без него OmniGet бы не было.
+
+OmniGet — это приложение вокруг него. Вы скачиваете один файл, вставляете ссылку и видите превью с вариантами качества. yt-dlp и FFmpeg ставятся и обновляются сами, а yt-dlp перед запуском проверяется по SHA256. Сверху — очередь загрузок с повторными попытками и докачкой, история, плеер курсов, читалка и музыкальная библиотека. Если вам привычен терминал и нужны только файлы, берите yt-dlp напрямую. Если нужна библиотека, которую можно смотреть и читать, берите OmniGet.
+
+### OmniGet и загрузчики под одну платформу
+
+Большинство загрузчиков хорошо делают один сайт. OmniGet собирает курсы, видео, аудио, изображения, торренты и Telegram в одну очередь, а потом воспроизводит результат. Компромисс честный: узкоспециализированный инструмент иногда раньше поддержит редкий случай.
+
+### OmniGet и платные загрузчики курсов
+
+Платные загрузчики курсов обычно берут подписку за то, к чему у вас уже есть доступ. OmniGet распространяется по GPL-3.0, без аккаунта, без рекламы и без платных тарифов, и скачивает только то, что уже открывается в вашей собственной авторизованной сессии.
+
+---
+
 ## Что скачивает OmniGet
 
 Вставьте ссылку. OmniGet определит сайт, покажет предпросмотр с вариантами качества и скачает. Если сайт поддерживается [yt-dlp](https://github.com/yt-dlp/yt-dlp), OmniGet качает с него, а это примерно на тысячу сайтов больше, чем в таблице ниже.
@@ -131,6 +159,7 @@ OmniGet делает всё это в одном окне. Вставьте сс
 | Bilibili (глубоко) | Войдите для 4K, HDR, Dolby Vision, Hi-Res lossless, Dolby Atmos. Данмаку (XML/ASS/JSON), NFO для Kodi и Jellyfin, 11 типов ссылок (UGC, 番剧, 课程, 收藏夹, UP主, 每周必看, 稍后再看, 历史记录, b23.tv) |
 | Азиатские платформы | Douyin (抖音), Xiaohongshu (小红书), Kuaishou (快手), Youku (优酷), iQiyi (爱奇艺), Tencent Video, Mango TV |
 | Галереи изображений | DeviantArt, Pixiv, ArtStation, Flickr, Tumblr, альбомы Imgur, Kemono, Newgrounds, имиджборды |
+| Массовые профили | Целые сабреддиты и их страницы сортировки, профили пользователей Reddit, профили X/Twitter |
 | Файлы и передача | `.torrent` и магнет-ссылки, а также прямая P2P-передача между двумя компьютерами по короткому коду |
 
 То, что люди ищут, и что OmniGet умеет:
@@ -138,7 +167,7 @@ OmniGet делает всё это в одном окне. Вставьте сс
 - **Скачать полный онлайн-курс**, каждый урок и приложенный PDF, затем смотреть его внутри приложения и продолжать с места остановки.
 - **Скачать видео с YouTube или целый плейлист**, выбрать качество или взять только аудио в MP3, M4A, Opus, FLAC или WAV.
 - **Скачать TikTok, Instagram, Twitter/X, Reddit**: посты, reels, истории, карусели и галереи.
-- **Пакетная загрузка** списка ссылок из текстового файла или целого профиля автора.
+- **Пакетная загрузка** списка ссылок из текстового файла, целого сабреддита, профиля пользователя Reddit или профиля X/Twitter.
 - **Скачать только часть видео**, задав начало и конец.
 - **Скачать субтитры** на любом языке, встроить их или сгенерировать через Whisper, если их нет.
 - **Пропускать спонсорские вставки** через SponsorBlock, автоматически встраивать метаданные и обложки.
@@ -259,6 +288,21 @@ OmniGet поставляется с полным набором плагинов
 
 ## Частые вопросы
 
+**Нужен ли аккаунт, чтобы пользоваться OmniGet?**
+Нет. Собственный аккаунт или регистрация OmniGet не нужны. Входить на платформу приходится только тогда, когда этого требует сам контент — например, купленный вами курс или премиум-поток Bilibili, — и эта сессия остаётся на вашем компьютере.
+
+**Может ли OmniGet скачать плейлист или целый канал YouTube?**
+Да. Вставьте ссылку на плейлист, и OmniGet поставит в очередь каждое видео из него. Можно также подписаться на канал, и OmniGet будет автоматически скачивать новые загрузки и показывать уведомление в трее.
+
+**Продолжит ли OmniGet прерванную загрузку?**
+Да. Очередь сохраняет частично скачанные файлы и продолжает с того места, где остановилась, а при ограничении скорости со стороны сайта повторяет попытки с нарастающей паузой. Закрытие приложения или обрыв связи не обнуляют прогресс.
+
+**Какие форматы файлов сохраняет OmniGet?**
+Видео — MP4, MKV или WebM, аудио — MP3, M4A, Opus, FLAC или WAV. Субтитры сохраняются как SRT, VTT или ASS и могут встраиваться в видеофайл. Книги открываются в форматах PDF, EPUB, CBZ, TXT и HTML.
+
+**Может ли OmniGet скачать платный контент, который я уже купил?**
+OmniGet скачивает то, что уже открывается в вашей собственной авторизованной сессии, например купленный курс Udemy или Hotmart. Он не обходит DRM, не взламывает платный доступ и не передаёт чужие учётные данные. То, к чему у вас нет доступа, останется недоступным.
+
 **OmniGet бесплатный?**
 Да. Бесплатно и с открытым исходным кодом под GPL-3.0, без аккаунта, без рекламы и без платных тарифов.
 
@@ -278,7 +322,10 @@ OmniGet поставляется с полным набором плагинов
 Онлайн-курсы, YouTube, TikTok, Instagram, Twitter/X, Reddit, Twitch, Vimeo, Bilibili, Pinterest, Bluesky, крупные азиатские платформы, галереи изображений, торренты и магнеты, плюс около 1800 других через yt-dlp.
 
 **Работает ли на Windows, macOS и Linux?**
-Да, на всех трёх. Windows это портативный `.exe`, macOS это `.dmg`, Linux это Flatpak или сборка.
+Да, на всех трёх, в сборках для x86_64 и ARM64. Для Windows есть портативный `.exe`, установщик `.msi` и пакет winget. Для macOS — `.dmg` для Apple Silicon и Intel. Для Linux — `.deb`, `.rpm` и `.AppImage`.
+
+**Какие дистрибутивы Linux поддерживаются?**
+OmniGet работает на любом современном настольном Linux. Для Debian и Ubuntu лучше взять `.deb`, для Fedora и openSUSE — `.rpm`, для остальных — `.AppImage`. На Debian 12+ и Ubuntu 24.04+ для AppImage сначала нужно выполнить `sudo apt install libfuse2`, потому что в этих выпусках убрали FUSE 2; для `.deb` это не требуется.
 
 **Можно скачать только аудио или только фрагмент?**
 Да. Извлеките аудио в MP3, M4A, Opus, FLAC или WAV, или задайте начало и конец, чтобы скачать только нужную часть.
@@ -314,6 +361,24 @@ sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file lib
 </details>
 
 Продакшен-сборка: `pnpm tauri build`.
+
+### Интерфейс командной строки (собирается вручную)
+
+В репозитории также есть `omniget-cli` — небольшая программа на Rust, которая делает OmniGet пригодным для скриптов. **В готовые сборки она пока не входит**, её нужно собрать из этого репозитория:
+
+```bash
+cargo build --release -p omniget-cli
+```
+
+```bash
+omniget info <url>                     # только превью: название, форматы, размер
+omniget download <url> -q 1080 -o ~/Videos
+omniget download <url> --audio-only --subs ru,en
+omniget batch links.txt -m 3           # по одной ссылке в строке, по 3 одновременно
+omniget import-cookies cookies.txt     # формат Netscape
+```
+
+Настольному приложению это не нужно совсем. Оно существует для cron, dotfiles и скриптов.
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -1,9 +1,11 @@
 <!--
 SEO / discovery: OmniGet 是适用于 Windows、macOS 和 Linux 的免费开源下载器。
 建议的 GitHub topics（在仓库 Settings > Topics 中设置）:
-video-downloader, youtube-downloader, media-downloader, course-downloader, udemy-downloader,
-music-downloader, ebook-reader, yt-dlp, yt-dlp-gui, tauri, svelte, rust, desktop-app,
-cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, torrent, p2p
+downloader, download-manager, media-downloader, video-downloader, youtube-downloader,
+yt-dlp, yt-dlp-gui, course-downloader, udemy-downloader, hotmart-downloader,
+bilibili-downloader, tiktok-downloader, instagram-downloader, twitter-downloader,
+reddit-downloader, telegram-downloader, twitch-downloader, subtitle-downloader,
+epub-reader, spaced-repetition
 -->
 
 <p align="center">
@@ -12,7 +14,7 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
 
 <h1 align="center">OmniGet</h1>
 
-<h3 align="center">一个应用，下载 Udemy 课程、YouTube、音乐、电子书，以及 1,800+ 网站。无需终端。</h3>
+<h3 align="center">一个应用搞定 B 站、抖音、YouTube、网课、音乐与电子书下载，支持 1800+ 网站。无需终端。</h3>
 
 <p align="center">
   <a href="README.md">English</a>
@@ -29,7 +31,7 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
 </p>
 
 <p align="center">
-  <b>OmniGet</b> 是一款适用于 Windows、macOS 和 Linux 的免费开源桌面应用。它可以下载在线课程（Udemy、Hotmart、Kiwify、Skool、Teachable 等），下载来自 YouTube、TikTok、Instagram、Twitter/X、Reddit 以及 1,800+ 其他网站的视频和音频，还能管理你的音乐和电子书。所有内容都能在应用内播放。无需命令行，无需 Python，无需配置，你的文件始终留在本地电脑上。
+  <b>OmniGet 是一款适用于 Windows、macOS 和 Linux 的免费开源桌面应用。</b>它可以下载在线课程（Udemy、Hotmart、Kiwify、Skool、Teachable 等），下载来自 YouTube、TikTok、Instagram、Twitter/X、Reddit 以及 1800+ 其他网站的视频和音频，还能管理你的音乐和电子书。所有内容都能在应用内播放。无需命令行，无需 Python，无需配置，你的文件始终留在本地电脑上。基于 GPL-3.0 许可证发布。
 </p>
 
 <p align="center">
@@ -58,7 +60,7 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
     <td>
       <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="下载 Windows 版 OmniGet" src="https://img.shields.io/badge/Windows-Portable_EXE-0078D6?style=for-the-badge&logo=windows&logoColor=white" height="38"></a>
       <br/>
-      <sub>从 Releases 下载 <code>.exe</code> 并双击运行。它是便携版，放在哪里都能运行。</sub>
+      <sub>从 Releases 下载 <code>.exe</code> 并双击运行。它是便携版，放在哪里都能运行。也提供 <code>.msi</code> 安装包；习惯命令行的话可以用 <code>winget install -e --id tonhowtf.OmniGet</code>。</sub>
     </td>
   </tr>
   <tr>
@@ -72,12 +74,14 @@ cross-platform, open-source, instagram-downloader, tiktok-downloader, bilibili, 
   <tr>
     <td><strong>Linux</strong></td>
     <td>
-      <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="下载 Linux 版 OmniGet" src="https://img.shields.io/badge/Linux-Flatpak-FFAA33?style=for-the-badge&logo=linux&logoColor=white" height="38"></a>
+      <a href="https://github.com/tonhowtf/omniget/releases/latest"><img alt="下载 Linux 版 OmniGet，提供 deb、rpm 与 AppImage" src="https://img.shields.io/badge/Linux-deb_·_rpm_·_AppImage-FFAA33?style=for-the-badge&logo=linux&logoColor=white" height="38"></a>
       <br/>
-      <sub>运行 <code>flatpak install wtf.tonho.omniget</code>，或从 Releases 下载安装包。</sub>
+      <sub>Debian 与 Ubuntu 用 <code>.deb</code>，Fedora 与 openSUSE 用 <code>.rpm</code>，其他发行版用 <code>.AppImage</code>。x86_64 与 ARM64 均已提供。</sub>
     </td>
   </tr>
 </table>
+
+<sub><strong>Debian 12+ / Ubuntu 24.04+ 使用 AppImage：</strong>这些版本默认不再自带 FUSE 2，而 AppImage 需要它。若 <code>./omniget.AppImage</code> 报 libfuse 错误，请运行 <code>sudo apt install libfuse2</code>，或改用 <code>./omniget.AppImage --appimage-extract-and-run</code> 启动。直接下载 <code>.deb</code> 则完全没有这个问题。</sub>
 
 ### ⚠️ 首次启动前请务必阅读
 
@@ -93,6 +97,10 @@ codesign --force --deep --sign - /Applications/omniget.app
 然后正常打开 OmniGet 即可。只需操作一次。
 
 **Windows。** 首次运行时 SmartScreen 可能会显示蓝色警告。点击 **More info（更多信息）**，然后点击 **Run anyway（仍要运行）**。对于没有付费代码签名证书的开源应用，这是很常见的。
+
+### 便携模式：U 盘或受限电脑
+
+在 `.exe` 同级目录新建一个名为 `portable.txt`（或 `.portable`）的空文件，然后重新启动。OmniGet 会把设置、数据库、Cookie、插件、缓存以及自带的 yt-dlp 和 FFmpeg 全部放在可执行文件旁边的 `data` 文件夹里，不会写入 `AppData\Roaming` 或任何其他用户目录，整套程序可以随 U 盘带走。没有这个文件时，OmniGet 使用系统标准的用户数据目录。
 
 本软件基于 GPL-3.0 免费开源。更新会在后台静默进行。内置工具（yt-dlp 和 FFmpeg）会自行安装，yt-dlp 在运行前会通过 SHA256 校验。插件会在首次启动时安装并自动更新，无需你做任何配置。
 
@@ -116,7 +124,27 @@ codesign --force --deep --sign - /Applications/omniget.app
 
 OmniGet 在一个窗口里搞定这一切。粘贴课程链接、YouTube 链接、TikTok、磁力链接、播客，它会自动判断该怎么做。文件落到你的文件夹，并且就在应用里播放。
 
-它是唯一一款能在同一处、无需命令行就完整下载 Udemy 或 Hotmart 课程、下载来自 1,800+ 网站的视频和音频、还能管理音乐库的开源应用。它在上线头几个月就收获了数千个 GitHub star，正是因为这种组合此前别处没有。
+它是唯一一款能在同一处、无需命令行就完整下载 Udemy 或 Hotmart 课程、下载来自 1800+ 网站的视频和音频、还能管理音乐库的开源应用。它在上线头几个月就收获了数千个 GitHub star，正是因为这种组合此前别处没有。
+
+---
+
+## OmniGet 与 yt-dlp 及其他下载器的区别
+
+工具各有分工，这里说的是 OmniGet 的位置，不是谁高谁低。
+
+### OmniGet 与 yt-dlp
+
+[yt-dlp](https://github.com/yt-dlp/yt-dlp) 是解析引擎，OmniGet 正是基于它。yt-dlp 是命令行工具：装 Python、记参数、写格式选择表达式，换来的是对 1800+ 网站无与伦比的控制力。它在这件事上做得极好，没有它就没有 OmniGet。
+
+OmniGet 是围绕它做的应用。下载一个文件、粘贴链接、看到带画质选项的预览就行。yt-dlp 和 FFmpeg 会自我安装并更新，yt-dlp 每次运行前都会经过 SHA256 校验。在这之上还有会重试和续传的队列、下载历史、课程播放器、阅读器和音乐库。如果你熟悉终端且只要文件，直接用 yt-dlp；如果你想要一个能真正观看和阅读的媒体库，用 OmniGet。
+
+### OmniGet 与单平台下载器
+
+大多数下载器把一个站点做透。OmniGet 把网课、视频、音频、图集、种子和 Telegram 放进同一个队列，下完还能直接播放。代价也说清楚：专攻单一平台的工具，有时会更早支持某些边缘情况。
+
+### OmniGet 与付费课程下载器
+
+付费课程下载器通常对你本来就有权限的内容按月收费。OmniGet 采用 GPL-3.0，无账号、无广告、无付费档，且只下载你自己已登录的会话本来就能打开的内容。
 
 ---
 
@@ -131,6 +159,7 @@ OmniGet 在一个窗口里搞定这一切。粘贴课程链接、YouTube 链接�
 | 哔哩哔哩（深度支持） | 登录后可下 4K、HDR、杜比视界、Hi-Res 无损、杜比全景声。弹幕（XML/ASS/JSON）、用于 Kodi 和 Jellyfin 的 NFO、11 种链接类型（UGC、番剧、课程、收藏夹、UP主、每周必看、稍后再看、历史记录、b23.tv） |
 | 亚洲平台 | 抖音、小红书、快手、优酷、爱奇艺、腾讯视频、芒果 TV |
 | 图集 | DeviantArt、Pixiv、ArtStation、Flickr、Tumblr、Imgur 相册、Kemono、Newgrounds、各类图床 |
+| 主页批量 | 整个 subreddit 及其排序页、Reddit 用户主页、X/Twitter 主页 |
 | 文件与传输 | `.torrent` 和磁力链接，以及两台电脑之间用短代码直接 P2P 传输 |
 
 大家常搜、OmniGet 都能做到的：
@@ -138,7 +167,7 @@ OmniGet 在一个窗口里搞定这一切。粘贴课程链接、YouTube 链接�
 - **下载完整的在线课程**，包括每节课和附带的 PDF，然后在应用内观看，并从上次停下的地方继续。
 - **下载 YouTube 视频或整个播放列表**，自选画质，或只提取音频，格式可选 MP3、M4A、Opus、FLAC 或 WAV。
 - **下载 TikTok、Instagram、Twitter/X、Reddit** 的帖子、短视频、快拍、轮播图和图集。
-- **批量下载** 文本文件里的链接列表，或某个创作者的整个主页。
+- **批量下载** 文本文件里的链接列表、整个 subreddit、Reddit 用户主页，或 X/Twitter 主页。
 - **只下载视频的一部分**，设置开始和结束时间即可。
 - **下载任意语言的字幕**，可嵌入，也可在没有字幕时用 Whisper 自动生成。
 - **跳过赞助片段**（SponsorBlock），并自动嵌入元数据和缩略图。
@@ -259,6 +288,21 @@ OmniGet 自带完整的插件（课程、学习、Telegram、转换等等），�
 
 ## 常见问题
 
+**使用 OmniGet 需要注册账号吗？**
+不需要。OmniGet 本身不需要任何账号或注册。只有当内容本身要求登录时才需要登录对应平台，比如你已购买的付费课程或哔哩哔哩大会员视频，而这些登录状态只保存在你自己的电脑上。
+
+**OmniGet 能下载 YouTube 播放列表或整个频道吗？**
+可以。粘贴播放列表链接，OmniGet 会把其中每个视频加入队列。你也可以关注某个频道，OmniGet 会自动下载新发布的内容并弹出托盘通知。
+
+**下载中断后 OmniGet 会续传吗？**
+会。队列会保留已下载的部分文件并从中断处继续，而不是从头再来；遇到网站限速时会按退避策略重试。关闭应用或断网都不会让已下载的进度白费。
+
+**OmniGet 支持哪些文件格式？**
+视频支持 MP4、MKV、WebM；音频支持 MP3、M4A、Opus、FLAC、WAV。字幕可保存为 SRT、VTT、ASS，也可以直接嵌入视频。电子书支持 PDF、EPUB、CBZ、TXT 和 HTML。
+
+**OmniGet 能下载我已经购买的付费内容吗？**
+OmniGet 只下载你自己已登录的会话本来就能打开的内容，例如你已购买的 Udemy 或 Hotmart 课程。它不会绕过 DRM、不会破解付费墙、也不会共享账号凭据。你本来无权访问的内容仍然无法访问。
+
 **OmniGet 免费吗？**
 免费。基于 GPL-3.0 开源，无需账号，没有广告，也没有付费档位。
 
@@ -269,16 +313,19 @@ OmniGet 自带完整的插件（课程、学习、Telegram、转换等等），�
 运行[首次启动说明](#️-首次启动前请务必阅读)里的两条终端命令。Gatekeeper 会拦截未签名的开源应用，那两行命令会清除这个标记。只需操作一次。
 
 **这只是 yt-dlp 的图形界面吗？**
-对于那 1,800+ 个通用网站，它底层使用 yt-dlp，同时为大平台配有原生解析器，并在其上提供真正的界面、下载队列、媒体库和内置播放器。所以可以说是，但远不止一个图形界面。
+对于那 1800+ 个通用网站，它底层使用 yt-dlp，同时为大平台配有原生解析器，并在其上提供真正的界面、下载队列、媒体库和内置播放器。所以可以说是，但远不止一个图形界面。
 
 **它能下载完整的 Udemy 或 Hotmart 课程吗？**
 可以。你在平台上登录一次，选择课程，OmniGet 就会下载每节课和每个附件，然后用带时间戳笔记的播放器回放。
 
 **支持哪些网站？**
-在线课程、YouTube、TikTok、Instagram、Twitter/X、Reddit、Twitch、Vimeo、哔哩哔哩、Pinterest、Bluesky、各大亚洲平台、图集、种子和磁力，以及通过 yt-dlp 支持的约 1,800 个网站。
+在线课程、YouTube、TikTok、Instagram、Twitter/X、Reddit、Twitch、Vimeo、哔哩哔哩、Pinterest、Bluesky、各大亚洲平台、图集、种子和磁力，以及通过 yt-dlp 支持的约 1800 个网站。
 
 **它能在 Windows、macOS 和 Linux 上运行吗？**
-都可以。Windows 是便携版 `.exe`，macOS 是 `.dmg`，Linux 是 Flatpak 或安装包。
+都可以，且同时提供 x86_64 与 ARM64 版本。Windows 提供便携版 `.exe`、`.msi` 安装包和 winget 包；macOS 提供 Apple Silicon 与 Intel 的 `.dmg`；Linux 提供 `.deb`、`.rpm` 与 `.AppImage`。
+
+**支持哪些 Linux 发行版？**
+OmniGet 可在任何主流桌面 Linux 上运行。Debian 与 Ubuntu 建议用 `.deb`，Fedora 与 openSUSE 用 `.rpm`，其他发行版用 `.AppImage`。在 Debian 12+ 与 Ubuntu 24.04+ 上使用 AppImage 需要先 `sudo apt install libfuse2`，因为这些版本移除了 FUSE 2；用 `.deb` 则无此要求。
 
 **能只下载音频，或者只下一个片段吗？**
 可以。提取音频为 MP3、M4A、Opus、FLAC 或 WAV，或者设置开始和结束时间，只下载你需要的那一段。
@@ -314,6 +361,24 @@ sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file lib
 </details>
 
 生产构建：`pnpm tauri build`。
+
+### 命令行工具（需自行构建）
+
+仓库中还包含 `omniget-cli`，一个让 OmniGet 可被脚本调用的小型 Rust 程序。**它目前尚未随 Release 一起发布**，需要你从本仓库自行构建：
+
+```bash
+cargo build --release -p omniget-cli
+```
+
+```bash
+omniget info <url>                     # 只预览标题、格式和体积，不下载
+omniget download <url> -q 1080 -o ~/Videos
+omniget download <url> --audio-only --subs zh-Hans,en
+omniget batch links.txt -m 3           # 每行一个链接，同时 3 个
+omniget import-cookies cookies.txt     # Netscape 格式
+```
+
+桌面应用完全不需要它。它是给定时任务、dotfiles 和脚本用的。
 
 ---
 


### PR DESCRIPTION
## What this is

SEO and discoverability pass over the three READMEs. Three commits, one per language, so the diff is reviewable per file.

**The most important change is not SEO — it is a broken install instruction.**

## 🔴 The Linux install command did not work

All three READMEs told Linux users to run `flatpak install wtf.tonho.omniget`. Verified:

- `https://flathub.org/api/v2/appstream/wtf.tonho.omniget` returns `{"detail":"App not found"}`
- `.github/workflows/release.yml` contains zero references to flatpak or flathub
- Releases actually ship `.deb`, `.rpm` and `.AppImage`, for x86_64 and ARM64

The Linux badge also read "Flatpak". Every Linux visitor following the README hit a dead end. The table now lists the formats that exist, and the libfuse2 note for Debian 12+ / Ubuntu 24.04+ is lifted from the release notes, where it was already correct.

## What else changed, per language

Applied to all three:

- **winget** — `winget install -e --id tonhowtf.OmniGet`. The package already exists in `microsoft/winget-pkgs`.
- **Comparison section** — "How OmniGet compares to yt-dlp and other downloaders", with subsections for yt-dlp, single-purpose downloaders and paid course downloaders. `X vs Y` and `X alternative` are heavy query shapes and the READMEs had neither. Framed as different jobs, not better/worse — yt-dlp is a dependency and a friend of this project.
- **`omniget-cli`** — documented under Build from source, explicitly marked as build-it-yourself because it is **not in any release asset**. See the note below.
- **Portable mode** — promoted from a FAQ line to its own section.
- **Bulk downloads** — subreddits, Reddit user profiles and X/Twitter profiles are now named the way people search for them. Verified against `is_bulk_media_url` in `gallerydl/mod.rs` and its tests.
- **FAQ** — 5–6 new entries each (accounts, playlists and channels, resuming, file formats, paid content you own, Linux distros). Existing questions reworded to name OmniGet instead of a pronoun so each answer stands alone when quoted out of context.
- **License as text**, not only as a badge image.

Language-specific:

- **Chinese** — `1,800+` → `1800+` throughout. Comma digit grouping is not used in Chinese tech copy at this magnitude. The subtitle now leads with B 站, 抖音 and 网课, which is where the Chinese audience and this project's real advantage overlap.
- **Russian** — `1800+` deliberately left alone. Ководство §62 / Мильчин: digit groups take a space only from five digits up, so `1 800+` would be wrong. Avoided `видеозагрузчик`, which is not idiomatic.

## Not done here, on purpose

- **The repo description and topics are not in the repo**, so they cannot be changed by a PR. Both are in the review comment below for pasting into the About dialog.
- **`llms.txt` not added** — proposed for a follow-up rather than slipped in here.
- **The Website field still points at a Discord invite.** A Discord link earns no SEO and passes no authority. Worth pointing at a GitHub Pages site if one ever exists; flagged, not changed.

## Two things worth separate issues

1. **Ship the `omniget-cli` binary in releases.** It exists in the workspace with `download` / `info` / `batch` / `import-cookies`, but `release.yml` never builds it, so nobody who downloads a release has it. A shipped CLI makes the project scriptable, and scriptable projects show up in blog posts, dotfiles and forum threads. That is mention generation, and it is worth more than any wording change in this PR.
2. **The winget manifest is stale.** Latest published there is `0.7.0`; the app is at `0.7.6`.

## Verification

No claim in these files was written without checking it against the code or a live endpoint. Flathub, the winget manifest, the release assets, the CLI subcommands and the gallery-dl bulk URL matcher were each verified directly.

Russian prose is built from researched native patterns but has not been reviewed by a native speaker — @D0n-A, a second pass would be welcome.
