### PR TITLE
B47 + B48 + B41: add CI, sanitise plugin_id, fall back on SABR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'weblate' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri'
+
+      - name: Format
+        if: matrix.platform == 'ubuntu-latest'
+        working-directory: src-tauri
+        run: cargo fmt --all -- --check
+
+      # Informativo por enquanto: o workspace tem warnings pre-existentes, entao
+      # `-D warnings` reprovaria toda PR no primeiro dia. Fica visivel no log; ver
+      # docs/backlog.md B47 para o baseline que torna isso um portao de verdade.
+      - name: Clippy
+        working-directory: src-tauri
+        run: cargo clippy --workspace --all-targets
+
+      - name: Test
+        working-directory: src-tauri
+        run: cargo test --workspace
+
+  rust-debian:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'weblate' }}
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    steps:
+      - name: Install base tools
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl wget git build-essential pkg-config \
+            libssl-dev file unzip xz-utils
+
+      - uses: actions/checkout@v4
+
+      - name: Install Debian system dependencies
+        run: |
+          apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev \
+            patchelf xdg-utils
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri'
+          key: debian
+
+      - name: Cargo check (Debian compat)
+        working-directory: src-tauri
+        run: cargo check --workspace --all-targets
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Este e o portao que faltava: `pnpm check` sai com 1 em erro de tipo, que
+      # foi exatamente o que passou despercebido na PR #197.
+      - name: svelte-check
+        run: pnpm check
+
+      - name: Unit tests (vitest)
+        run: pnpm test
+
+      # `--strict` reprova quando algum locale esta fora de sincronia com en.json.
+      - name: Locales in sync with en.json
+        run: pnpm check:i18n
+
+      - name: Generated i18n keys are committed
+        run: |
+          pnpm generate:i18n-keys
+          git diff --exit-code -- src/lib/i18n/keys.ts
+
+  metainfo:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'weblate' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install appstreamcli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y appstream
+
+      - name: Validate flatpak metainfo
+        run: appstreamcli validate flatpak/wtf.tonho.omniget.metainfo.xml

--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,12 @@ src-tauri/gen/schemas
 .DS_Store
 Thumbs.db
 Desktop.ini
-/docs
+# /docs e /.github contem arquivos do projeto (docs/backlog.md,
+# docs/plugin-development.md, .github/workflows/). Ignora-los inteiros fazia
+# qualquer arquivo novo falhar em silencio no `git add` — os que existem hoje
+# so entraram com `git add -f`. Ignorar apenas o que e de fato local.
 settings.local.json
 /.claude
-/.github
 claude.md
 
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -5,10 +5,15 @@ Itens abertos por ordem de retorno. Numeração contínua; concluídos não são
 **Legenda.** Custo P/M/G · Impacto 1–5 · Status: `aberto` · `bloqueado` · `em análise`
 
 **Concluído em v0.7.7:** B21–B31 (11 itens).
+**Concluído e aguardando release:** B47, B48, B41.
 
 ---
 
-## Onda proposta — v0.7.8
+## Onda v0.7.8 — concluída, aguardando release
+
+B47, B48 e B41 entregues na branch `feat/ci-and-hardening`. Portões: clippy no baseline (34/42/8/1), 460 testes (era 456), `pnpm check` 0 erros / 107 warnings.
+
+### Escopo original
 
 Duas correções baratas com impacto real, mais a rede de proteção que impede a próxima PR de entrar quebrada. Ordem de entrada: B47 → B48 → B41.
 
@@ -16,7 +21,7 @@ Duas correções baratas com impacto real, mais a rede de proteção que impede 
 
 ### B47 — Ter CI
 
-**Status:** aberto · **Custo:** P · **Impacto:** 5 · **Pré-requisito de tudo**
+**Status:** concluído · **Custo:** P · **Impacto:** 5 · **Pré-requisito de tudo**
 
 **Problema.** Não existe CI neste repositório. Nenhum `pnpm check`, nenhum `cargo test`, nenhum `cargo clippy` roda em PR. Só `release.yml` está versionado.
 
@@ -38,7 +43,7 @@ Duas correções baratas com impacto real, mais a rede de proteção que impede 
 
 ### B48 — Sanitizar `plugin_id` antes do `remove_dir_all`
 
-**Status:** aberto · **Custo:** P · **Impacto:** 5 · **Segurança — prevenção**
+**Status:** concluído · **Custo:** P · **Impacto:** 5 · **Segurança — prevenção**
 
 **Problema.** `plugin_loader.rs:193` faz `join(plugin_id)` cru e apaga o resultado com `remove_dir_all`. Um id contendo `..` escapa do diretório de plugins e deleta caminho arbitrário.
 
@@ -56,7 +61,7 @@ Ainda assim **não é release de segurança isolada**: explorar exige compromete
 
 ### B41 — Cascata de client do YouTube (SABR)
 
-**Status:** aberto · **Custo:** P · **Impacto:** 5 · **Melhor razão custo/impacto da lista**
+**Status:** concluído · **Custo:** P · **Impacto:** 5 · **Melhor razão custo/impacto da lista**
 
 **Problema.** O extractor `web` passou a devolver formatos SABR-only que quebram o caminho normal de download. O usuário vê falha sem causa legível.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tauri": "tauri",
     "version:set": "node scripts/bump-version.js",
     "generate:i18n-keys": "node scripts/generate-i18n-keys.js",
-    "sync:locales": "node scripts/sync-locales.mjs",
+    "check:i18n": "node scripts/generate-i18n-keys.js --strict",
     "plugins:deploy": "node scripts/deploy-plugins-local.mjs",
     "extension:sync": "node browser-extension/sync.mjs",
     "test": "vitest run",

--- a/src-tauri/omniget-cli/src/commands/batch.rs
+++ b/src-tauri/omniget-cli/src/commands/batch.rs
@@ -4,7 +4,12 @@ use tokio::sync::Semaphore;
 
 use crate::output;
 
-pub async fn execute(file: String, max_concurrent: usize, output_dir: Option<String>, proxy: Option<String>) -> Result<()> {
+pub async fn execute(
+    file: String,
+    max_concurrent: usize,
+    output_dir: Option<String>,
+    proxy: Option<String>,
+) -> Result<()> {
     let content = tokio::fs::read_to_string(&file)
         .await
         .with_context(|| format!("Failed to read {}", file))?;
@@ -22,7 +27,10 @@ pub async fn execute(file: String, max_concurrent: usize, output_dir: Option<Str
 
     let total = urls.len();
     if !output::is_json_mode() {
-        println!("Batch downloading {} URLs (max concurrent: {})", total, max_concurrent);
+        println!(
+            "Batch downloading {} URLs (max concurrent: {})",
+            total, max_concurrent
+        );
     }
 
     let semaphore = Arc::new(Semaphore::new(max_concurrent));
@@ -58,7 +66,10 @@ pub async fn execute(file: String, max_concurrent: usize, output_dir: Option<Str
     }
 
     if output::is_json_mode() {
-        println!(r#"{{"total":{},"success":{},"failed":{}}}"#, total, success, failed);
+        println!(
+            r#"{{"total":{},"success":{},"failed":{}}}"#,
+            total, success, failed
+        );
     } else {
         println!("Done: {} ok, {} failed", success, failed);
     }

--- a/src-tauri/omniget-cli/src/commands/common.rs
+++ b/src-tauri/omniget-cli/src/commands/common.rs
@@ -10,8 +10,8 @@ use omniget_core::models::settings::ProxySettings;
 use omniget_core::platforms::{
     BilibiliDownloader, BlueskyDownloader, DirectFileDownloader, DouyinDownloader,
     GenericYtdlpDownloader, InstagramDownloader, P2pDownloader, PinterestDownloader,
-    PlatformDownloader, RedditDownloader,
-    TikTokDownloader, TwitchClipsDownloader, TwitterDownloader, VimeoDownloader, YouTubeDownloader,
+    PlatformDownloader, RedditDownloader, TikTokDownloader, TwitchClipsDownloader,
+    TwitterDownloader, VimeoDownloader, YouTubeDownloader,
 };
 use tokio_util::sync::CancellationToken;
 

--- a/src-tauri/omniget-cli/src/commands/import_cookies.rs
+++ b/src-tauri/omniget-cli/src/commands/import_cookies.rs
@@ -12,9 +12,7 @@ pub async fn execute(file: String, name: Option<String>, dry_run: bool) -> Resul
         if output::is_json_mode() {
             let items: Vec<serde_json::Value> = preview
                 .iter()
-                .map(|(domain, count)| {
-                    serde_json::json!({ "domain": domain, "cookies": count })
-                })
+                .map(|(domain, count)| serde_json::json!({ "domain": domain, "cookies": count }))
                 .collect();
             output::print_json(&serde_json::json!({ "domains": items }));
         } else {
@@ -37,7 +35,9 @@ pub async fn execute(file: String, name: Option<String>, dry_run: bool) -> Resul
         println!(
             r#"{{"success":true,"total":{},"destination":"{}"}}"#,
             total,
-            dest.as_deref().map(|p| p.display().to_string()).unwrap_or_default()
+            dest.as_deref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default()
         );
     } else {
         if let Some(d) = &dest {

--- a/src-tauri/omniget-cli/src/cookies.rs
+++ b/src-tauri/omniget-cli/src/cookies.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use omniget_core::core::paths::app_data_dir;
 use omniget_core::core::cookie_parser::parse_cookie_input;
+use omniget_core::core::paths::app_data_dir;
 
 const COOKIES_DIR: &str = "cookies";
 const DEFAULT_COOKIE_FILE: &str = "cookies.txt";

--- a/src-tauri/omniget-cli/src/main.rs
+++ b/src-tauri/omniget-cli/src/main.rs
@@ -40,9 +40,7 @@ enum Commands {
         format: Option<String>,
     },
     /// Preview media info without downloading
-    Info {
-        url: String,
-    },
+    Info { url: String },
     /// Batch download from a file (one URL per line)
     Batch {
         file: String,
@@ -89,7 +87,8 @@ async fn main() -> anyhow::Result<()> {
             subs,
             format,
         } => {
-            commands::download::execute(url, quality, output, audio_only, subs, format, cli.proxy).await?;
+            commands::download::execute(url, quality, output, audio_only, subs, format, cli.proxy)
+                .await?;
         }
         Commands::Info { url } => {
             commands::info::execute(url, cli.proxy).await?;
@@ -101,7 +100,11 @@ async fn main() -> anyhow::Result<()> {
         } => {
             commands::batch::execute(file, max_concurrent, output, cli.proxy).await?;
         }
-        Commands::ImportCookies { file, name, dry_run } => {
+        Commands::ImportCookies {
+            file,
+            name,
+            dry_run,
+        } => {
             commands::import_cookies::execute(file, name, dry_run).await?;
         }
     }

--- a/src-tauri/omniget-cli/src/reporter.rs
+++ b/src-tauri/omniget-cli/src/reporter.rs
@@ -17,13 +17,20 @@ pub struct CliReporter {
 impl CliReporter {
     pub fn new(json_mode: bool) -> Self {
         let pb = ProgressBar::new(100);
-        pb.set_style(ProgressStyle::default_bar().template(SPINNER_STYLE).unwrap());
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template(SPINNER_STYLE)
+                .unwrap(),
+        );
         Self { pb, json_mode }
     }
 
     pub fn message(&self, msg: &str) {
         if self.json_mode {
-            println!(r#"{{"type":"message","content":"{}"}}"#, msg.replace('"', "\\\""));
+            println!(
+                r#"{{"type":"message","content":"{}"}}"#,
+                msg.replace('"', "\\\"")
+            );
         } else {
             self.pb.set_message(msg.to_string());
         }
@@ -42,7 +49,8 @@ impl CliReporter {
             println!("{}", json);
         } else {
             if update.percent >= 0.0 {
-                self.pb.set_position(update.percent.clamp(0.0, 100.0).round() as u64);
+                self.pb
+                    .set_position(update.percent.clamp(0.0, 100.0).round() as u64);
                 self.pb.set_style(
                     ProgressStyle::default_bar()
                         .template(PROGRESS_STYLE)

--- a/src-tauri/omniget-core/src/core/dependencies.rs
+++ b/src-tauri/omniget-core/src/core/dependencies.rs
@@ -925,9 +925,19 @@ mod integrity_tests {
         // Regressao: a versao anterior usava `?` dentro do laco, entao a
         // primeira linha vazia ou de um token so abortava a funcao inteira e o
         // asset seguinte nunca era encontrado -> instalacao sem verificacao.
-        let sums = format!("\n\ncomentario\n{}  yt-dlp.exe\n\n{}  yt-dlp_macos\n", VAZIO, "1".repeat(64));
-        assert_eq!(parse_sha256sums(&sums, "yt-dlp.exe").as_deref(), Some(VAZIO));
-        assert_eq!(parse_sha256sums(&sums, "yt-dlp_macos").as_deref(), Some("1".repeat(64).as_str()));
+        let sums = format!(
+            "\n\ncomentario\n{}  yt-dlp.exe\n\n{}  yt-dlp_macos\n",
+            VAZIO,
+            "1".repeat(64)
+        );
+        assert_eq!(
+            parse_sha256sums(&sums, "yt-dlp.exe").as_deref(),
+            Some(VAZIO)
+        );
+        assert_eq!(
+            parse_sha256sums(&sums, "yt-dlp_macos").as_deref(),
+            Some("1".repeat(64).as_str())
+        );
         assert_eq!(parse_sha256sums(&sums, "ausente"), None);
     }
 
@@ -936,12 +946,18 @@ mod integrity_tests {
         let bin = format!("{} *ffmpeg.zip\n", VAZIO);
         assert_eq!(parse_sha256sums(&bin, "ffmpeg.zip").as_deref(), Some(VAZIO));
         assert_eq!(parse_sha256sums("abc  yt-dlp.exe\n", "yt-dlp.exe"), None);
-        assert_eq!(parse_sha256sums(&format!("{}  yt-dlp.exe\n", "z".repeat(64)), "yt-dlp.exe"), None);
+        assert_eq!(
+            parse_sha256sums(&format!("{}  yt-dlp.exe\n", "z".repeat(64)), "yt-dlp.exe"),
+            None
+        );
     }
 
     #[test]
     fn digest_da_api_do_github() {
-        assert_eq!(parse_github_digest(&format!("sha256:{}", VAZIO)).as_deref(), Some(VAZIO));
+        assert_eq!(
+            parse_github_digest(&format!("sha256:{}", VAZIO)).as_deref(),
+            Some(VAZIO)
+        );
         assert_eq!(parse_github_digest(VAZIO), None);
         assert_eq!(parse_github_digest("sha512:abc"), None);
     }

--- a/src-tauri/omniget-core/src/core/hls_downloader.rs
+++ b/src-tauri/omniget-core/src/core/hls_downloader.rs
@@ -442,10 +442,7 @@ struct EncryptionInfo {
 /// Attach `Referer` (and a matching `Origin`) headers to a request.
 /// An empty referer means "send no Referer/Origin at all" — some CDNs
 /// reject requests with a wrong Referer but accept ones without any.
-fn apply_referer_headers(
-    req: reqwest::RequestBuilder,
-    referer: &str,
-) -> reqwest::RequestBuilder {
+fn apply_referer_headers(req: reqwest::RequestBuilder, referer: &str) -> reqwest::RequestBuilder {
     if referer.is_empty() {
         return req;
     }

--- a/src-tauri/omniget-core/src/core/http_fetcher.rs
+++ b/src-tauri/omniget-core/src/core/http_fetcher.rs
@@ -466,13 +466,7 @@ impl HttpFetcher {
                             (s > 0.0 && total > dl).then(|| ((total - dl) as f64 / s) as u64)
                         });
                         let _ = progress_tx
-                            .send(ProgressUpdate::rich(
-                                pct,
-                                Some(dl),
-                                Some(total),
-                                speed,
-                                eta,
-                            ))
+                            .send(ProgressUpdate::rich(pct, Some(dl), Some(total), speed, eta))
                             .await;
                         last_emit = std::time::Instant::now();
                     }

--- a/src-tauri/omniget-core/src/core/ytdlp.rs
+++ b/src-tauri/omniget-core/src/core/ytdlp.rs
@@ -1011,7 +1011,6 @@ fn ytdlp_release_base(channel: YtdlpChannel) -> &'static str {
 
 use crate::core::dependencies::integrity;
 
-
 async fn download_ytdlp_binary() -> anyhow::Result<PathBuf> {
     let target =
         managed_ytdlp_path().ok_or_else(|| anyhow!("Could not determine data directory"))?;
@@ -1412,23 +1411,22 @@ pub async fn get_video_info(
             attempt + 1
         );
 
-        let result =
-            tokio::time::timeout(
-                std::time::Duration::from_secs(VIDEO_INFO_PROCESS_TIMEOUT_SECS),
-                child.wait_with_output(),
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(VIDEO_INFO_PROCESS_TIMEOUT_SECS),
+            child.wait_with_output(),
+        )
+        .await
+        .map_err(|_| {
+            tracing::debug!("[perf] get_video_info took {:?}", _timer_start.elapsed());
+            anyhow!(
+                "Timeout fetching video info ({}s)",
+                VIDEO_INFO_PROCESS_TIMEOUT_SECS
             )
-                .await
-                .map_err(|_| {
-                    tracing::debug!("[perf] get_video_info took {:?}", _timer_start.elapsed());
-                    anyhow!(
-                        "Timeout fetching video info ({}s)",
-                        VIDEO_INFO_PROCESS_TIMEOUT_SECS
-                    )
-                })?
-                .map_err(|e| {
-                    tracing::debug!("[perf] get_video_info took {:?}", _timer_start.elapsed());
-                    anyhow!("Failed to run yt-dlp: {}", e)
-                })?;
+        })?
+        .map_err(|e| {
+            tracing::debug!("[perf] get_video_info took {:?}", _timer_start.elapsed());
+            anyhow!("Failed to run yt-dlp: {}", e)
+        })?;
 
         tracing::debug!(
             "[perf] get_video_info: yt-dlp process exited at {:?} (attempt {})",
@@ -2811,10 +2809,8 @@ pub async fn download_video(
 
             if is_youtube_url(url) {
                 if let Some(client) = sabr_fallback_client(&stderr_lower, attempt) {
-                    base_args
-                        .retain(|a| a != "--extractor-args" && !a.contains("player_client"));
-                    extra_args
-                        .retain(|a| a != "--extractor-args" && !a.contains("player_client"));
+                    base_args.retain(|a| a != "--extractor-args" && !a.contains("player_client"));
+                    extra_args.retain(|a| a != "--extractor-args" && !a.contains("player_client"));
                     extra_args.push("--extractor-args".to_string());
                     extra_args.push(client.clone());
                     tracing::warn!(
@@ -2964,10 +2960,16 @@ async fn convert_vtt_sidecars_to_srt(video_path: &Path) {
             .await;
         match result {
             Ok(out) if out.status.success() => {
-                tracing::info!("[yt-dlp] converted subtitle sidecar {} to srt (vtt kept)", name);
+                tracing::info!(
+                    "[yt-dlp] converted subtitle sidecar {} to srt (vtt kept)",
+                    name
+                );
             }
             _ => {
-                tracing::warn!("[yt-dlp] failed to convert subtitle sidecar {} to srt", name);
+                tracing::warn!(
+                    "[yt-dlp] failed to convert subtitle sidecar {} to srt",
+                    name
+                );
                 let _ = std::fs::remove_file(&srt_path);
             }
         }
@@ -3582,10 +3584,12 @@ mod tests {
         // Bilibili cheese season entries are full info dicts with webpage_url
         // but no top-level "url" (issue #157).
         let dump = r#"{"id":"12345","title":"Lesson 1","webpage_url":"https://www.bilibili.com/cheese/play/ep12345","extractor_key":"BiliBiliCheese"}"#;
-        let (_, entries) =
-            parse_playlist_dump(dump, "https://www.bilibili.com/cheese/play/ss999");
+        let (_, entries) = parse_playlist_dump(dump, "https://www.bilibili.com/cheese/play/ss999");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].url, "https://www.bilibili.com/cheese/play/ep12345");
+        assert_eq!(
+            entries[0].url,
+            "https://www.bilibili.com/cheese/play/ep12345"
+        );
     }
 
     #[test]
@@ -3593,25 +3597,27 @@ mod tests {
         let dump = r#"{"id":"dQw4w9WgXcQ","title":"YT Video","ie_key":"Youtube"}"#;
         let (_, entries) = parse_playlist_dump(dump, "https://example.com/playlist");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].url, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+        assert_eq!(
+            entries[0].url,
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        );
     }
 
     #[test]
     fn playlist_dump_fabricates_youtube_url_for_youtube_source() {
         let dump = r#"{"id":"dQw4w9WgXcQ","title":"YT Video"}"#;
-        let (_, entries) = parse_playlist_dump(
-            dump,
-            "https://www.youtube.com/playlist?list=PL123",
-        );
+        let (_, entries) = parse_playlist_dump(dump, "https://www.youtube.com/playlist?list=PL123");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].url, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+        assert_eq!(
+            entries[0].url,
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        );
     }
 
     #[test]
     fn playlist_dump_skips_non_youtube_entry_without_url() {
         let dump = r#"{"id":"12345","title":"Lesson 1","extractor_key":"BiliBiliCheese"}"#;
-        let (_, entries) =
-            parse_playlist_dump(dump, "https://www.bilibili.com/cheese/play/ss999");
+        let (_, entries) = parse_playlist_dump(dump, "https://www.bilibili.com/cheese/play/ss999");
         assert!(entries.is_empty());
     }
 
@@ -4020,7 +4026,10 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  yt-dlp.exe\n\
         let downloader = &args[1];
         assert!(downloader.starts_with("http,ftp:"), "{downloader}");
         for proto in ["m3u8", "m3u8_native", "m3u8_frag_urls", "dash_frag_urls"] {
-            assert!(!downloader.contains(proto), "protocolo {proto} nao pode ir ao aria2c");
+            assert!(
+                !downloader.contains(proto),
+                "protocolo {proto} nao pode ir ao aria2c"
+            );
         }
         assert_eq!(downloader, "http,ftp:/opt/bin/aria2c");
         // A chave de --downloader-args e o NOME do downloader, nao o protocolo.
@@ -4030,7 +4039,11 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  yt-dlp.exe\n\
     #[test]
     fn aria2c_downloader_args_rejeita_proxy_com_espaco() {
         let limpo = aria2c_downloader_args("/bin/aria2c", 2, Some("http://127.0.0.1:8080"));
-        assert!(limpo[3].ends_with("--all-proxy=http://127.0.0.1:8080"), "{}", limpo[3]);
+        assert!(
+            limpo[3].ends_with("--all-proxy=http://127.0.0.1:8080"),
+            "{}",
+            limpo[3]
+        );
         let sujo = aria2c_downloader_args("/bin/aria2c", 2, Some("http://h:1 --seed-ratio=0"));
         assert!(!sujo[3].contains("--all-proxy"), "{}", sujo[3]);
         assert!(!sujo[3].contains("--seed-ratio"));
@@ -4039,7 +4052,11 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  yt-dlp.exe\n\
     #[test]
     fn aria2c_nunca_zera_conexoes() {
         let args = aria2c_downloader_args("/bin/aria2c", 0, None);
-        assert!(args[3].contains("-x 1") && args[3].contains("-j 1"), "{}", args[3]);
+        assert!(
+            args[3].contains("-x 1") && args[3].contains("-j 1"),
+            "{}",
+            args[3]
+        );
     }
 
     // --- Piso de versao do yt-dlp ---
@@ -4047,8 +4064,14 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  yt-dlp.exe\n\
     #[test]
     fn parse_ytdlp_version_le_os_formatos_reais() {
         assert_eq!(parse_ytdlp_version("2026.06.09"), Some((2026, 6, 9)));
-        assert_eq!(parse_ytdlp_version("2025.12.31.232815"), Some((2025, 12, 31)));
-        assert_eq!(parse_ytdlp_version("2026.06.10.232815-nightly"), Some((2026, 6, 10)));
+        assert_eq!(
+            parse_ytdlp_version("2025.12.31.232815"),
+            Some((2025, 12, 31))
+        );
+        assert_eq!(
+            parse_ytdlp_version("2026.06.10.232815-nightly"),
+            Some((2026, 6, 10))
+        );
         for lixo in ["", "unknown", "1.2", "2026.13.01", "2026.06.99"] {
             assert_eq!(parse_ytdlp_version(lixo), None, "aceitou {lixo:?}");
         }

--- a/src-tauri/omniget-core/src/core/ytdlp.rs
+++ b/src-tauri/omniget-core/src/core/ytdlp.rs
@@ -64,6 +64,28 @@ static SPONSORBLOCK_CATEGORIES_FN: OnceLock<SponsorBlockCategoriesFn> = OnceLock
 /// yt-dlp removeu esse suporte na 2026.06.09 e recomenda `-N` no lugar.
 pub(crate) const ARIA2C_ALLOWED_PROTOCOLS: &str = "http,ftp";
 
+/// Ordem de fallback de `player_client` quando o YouTube devolve formato
+/// SABR-only.
+///
+/// O extractor `web` passou a entregar formatos que o caminho normal de
+/// download nao consegue puxar. Estes quatro clients ainda servem URL
+/// progressiva; a ordem vai do mais confiavel ao mais restrito.
+pub(crate) const SABR_CLIENT_CASCADE: [&str; 4] = ["android", "ios", "tv", "web_safari"];
+
+/// `Some(arg)` quando o stderr indica formato SABR-only e ainda resta client na
+/// cascata; `None` quando nao e SABR ou a cascata se esgotou.
+///
+/// Separado do laco de retry de proposito: e o unico jeito de testar a decisao
+/// com stderr real capturado como fixture, sem subir um download.
+pub(crate) fn sabr_fallback_client(stderr_lower: &str, attempt: usize) -> Option<String> {
+    if !stderr_lower.contains("sabr") {
+        return None;
+    }
+    SABR_CLIENT_CASCADE
+        .get(attempt)
+        .map(|client| format!("youtube:player_client={client}"))
+}
+
 /// Piso de versão do yt-dlp. 2026.06.09 é a release que corrigiu
 /// CVE-2026-50019 (vazamento de cookie no downloader curl), CVE-2026-50023
 /// (escrita de `.desktop`/`.url`/`.webloc`) e CVE-2026-50574 (execução
@@ -2787,6 +2809,21 @@ pub async fn download_video(
                 tracing::warn!("[yt-dlp] nsig error, switching to {}", client);
             }
 
+            if is_youtube_url(url) {
+                if let Some(client) = sabr_fallback_client(&stderr_lower, attempt) {
+                    base_args
+                        .retain(|a| a != "--extractor-args" && !a.contains("player_client"));
+                    extra_args
+                        .retain(|a| a != "--extractor-args" && !a.contains("player_client"));
+                    extra_args.push("--extractor-args".to_string());
+                    extra_args.push(client.clone());
+                    tracing::warn!(
+                        "[yt-dlp] SABR-only formats detected, switching player_client to {}",
+                        client
+                    );
+                }
+            }
+
             if (stderr_lower.contains("http error 403") || stderr_lower.contains("forbidden"))
                 && !extra_args.contains(&"--force-ipv4".to_string())
             {
@@ -4024,5 +4061,68 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  yt-dlp.exe\n\
         assert_eq!(ytdlp_version_is_supported("2026.06.08"), Some(false));
         // Versao ilegivel nao pode ser reportada como desatualizada.
         assert_eq!(ytdlp_version_is_supported("sei la"), None);
+    }
+
+    // --- B41: cascata de client acionada por SABR ---
+
+    /// stderr real do yt-dlp quando o cliente `web` devolve formato SABR-only.
+    const SABR_STDERR: &str = "WARNING: [youtube] abc123: Some web client https formats have been \
+skipped as they are missing a url. YouTube is forcing SABR streaming for this client. \
+See  https://github.com/yt-dlp/yt-dlp/issues/12482  for more details\n\
+ERROR: [youtube] abc123: Requested format is not available";
+
+    #[test]
+    fn sabr_no_stderr_dispara_a_cascata_na_ordem() {
+        let lower = SABR_STDERR.to_lowercase();
+        assert_eq!(
+            sabr_fallback_client(&lower, 0).as_deref(),
+            Some("youtube:player_client=android")
+        );
+        assert_eq!(
+            sabr_fallback_client(&lower, 1).as_deref(),
+            Some("youtube:player_client=ios")
+        );
+        assert_eq!(
+            sabr_fallback_client(&lower, 2).as_deref(),
+            Some("youtube:player_client=tv")
+        );
+        assert_eq!(
+            sabr_fallback_client(&lower, 3).as_deref(),
+            Some("youtube:player_client=web_safari")
+        );
+    }
+
+    #[test]
+    fn cascata_esgotada_devolve_none_em_vez_de_repetir() {
+        let lower = SABR_STDERR.to_lowercase();
+        assert_eq!(sabr_fallback_client(&lower, 4), None);
+        assert_eq!(sabr_fallback_client(&lower, 99), None);
+    }
+
+    #[test]
+    fn erro_que_nao_e_sabr_nao_troca_de_client() {
+        // Regressao: trocar de client em qualquer falha mascararia a causa real
+        // e gastaria as tentativas de retry a toa.
+        for stderr in [
+            "error: [youtube] abc: video unavailable",
+            "error: http error 429: too many requests",
+            "error: [youtube] abc: nsig extraction failed",
+            "error: unable to download webpage: timed out",
+            "",
+        ] {
+            assert_eq!(
+                sabr_fallback_client(stderr, 0),
+                None,
+                "trocou de client sem SABR: {stderr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cascata_nao_contem_o_client_que_causa_o_problema() {
+        // `web` e `default` sao justamente os que devolvem SABR-only.
+        assert!(!SABR_CLIENT_CASCADE.contains(&"web"));
+        assert!(!SABR_CLIENT_CASCADE.contains(&"default"));
+        assert_eq!(SABR_CLIENT_CASCADE.len(), 4);
     }
 }

--- a/src-tauri/omniget-core/src/platforms/bluesky.rs
+++ b/src-tauri/omniget-core/src/platforms/bluesky.rs
@@ -1,6 +1,6 @@
+use crate::models::progress::ProgressUpdate;
 use anyhow::anyhow;
 use async_trait::async_trait;
-use crate::models::progress::ProgressUpdate;
 use tokio::sync::mpsc;
 
 use crate::core::direct_downloader;

--- a/src-tauri/omniget-core/src/platforms/direct_file.rs
+++ b/src-tauri/omniget-core/src/platforms/direct_file.rs
@@ -6,9 +6,7 @@ use tokio::sync::mpsc;
 
 use crate::core::direct_downloader;
 use crate::core::http_client;
-use crate::models::media::{
-    DownloadOptions, DownloadResult, MediaInfo, MediaType, VideoQuality,
-};
+use crate::models::media::{DownloadOptions, DownloadResult, MediaInfo, MediaType, VideoQuality};
 
 pub struct DirectFileDownloader;
 
@@ -117,11 +115,12 @@ impl PlatformDownloader for DirectFileDownloader {
             builder = builder.user_agent(ua);
         }
 
-        let jar = crate::core::cookie_parser::load_extension_cookies_for_url(file_url).or_else(|| {
-            opts.referer
-                .as_deref()
-                .and_then(crate::core::cookie_parser::load_extension_cookies_for_url)
-        });
+        let jar =
+            crate::core::cookie_parser::load_extension_cookies_for_url(file_url).or_else(|| {
+                opts.referer
+                    .as_deref()
+                    .and_then(crate::core::cookie_parser::load_extension_cookies_for_url)
+            });
         if let Some(jar) = jar {
             builder = builder.cookie_provider(jar);
         }

--- a/src-tauri/omniget-core/src/platforms/instagram.rs
+++ b/src-tauri/omniget-core/src/platforms/instagram.rs
@@ -1,6 +1,6 @@
+use crate::models::progress::ProgressUpdate;
 use anyhow::anyhow;
 use async_trait::async_trait;
-use crate::models::progress::ProgressUpdate;
 use rand::RngExt;
 use regex::Regex;
 use tokio::sync::mpsc;

--- a/src-tauri/omniget-core/src/platforms/p2p.rs
+++ b/src-tauri/omniget-core/src/platforms/p2p.rs
@@ -1,5 +1,3 @@
-
-
 use crate::models::progress::ProgressUpdate;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src-tauri/omniget-core/src/platforms/reddit.rs
+++ b/src-tauri/omniget-core/src/platforms/reddit.rs
@@ -1,6 +1,6 @@
+use crate::models::progress::ProgressUpdate;
 use anyhow::anyhow;
 use async_trait::async_trait;
-use crate::models::progress::ProgressUpdate;
 use tokio::sync::mpsc;
 
 use crate::core::direct_downloader;

--- a/src-tauri/omniget-core/src/platforms/twitch.rs
+++ b/src-tauri/omniget-core/src/platforms/twitch.rs
@@ -1,6 +1,6 @@
+use crate::models::progress::ProgressUpdate;
 use anyhow::anyhow;
 use async_trait::async_trait;
-use crate::models::progress::ProgressUpdate;
 use tokio::sync::mpsc;
 
 use crate::core::direct_downloader;

--- a/src-tauri/omniget-core/src/platforms/vimeo.rs
+++ b/src-tauri/omniget-core/src/platforms/vimeo.rs
@@ -126,9 +126,9 @@ impl PlatformDownloader for VimeoDownloader {
     }
 
     async fn get_media_info(&self, url: &str) -> anyhow::Result<MediaInfo> {
-        let ytdlp_path = ytdlp::ensure_ytdlp().await.map_err(|e| {
-            anyhow!("Vimeo requires yt-dlp. Failed to get yt-dlp: {}", e)
-        })?;
+        let ytdlp_path = ytdlp::ensure_ytdlp()
+            .await
+            .map_err(|e| anyhow!("Vimeo requires yt-dlp. Failed to get yt-dlp: {}", e))?;
 
         let json = ytdlp::get_video_info(&ytdlp_path, url, &[]).await?;
         Self::parse_video_info(&json)

--- a/src-tauri/src/commands/auth_webview.rs
+++ b/src-tauri/src/commands/auth_webview.rs
@@ -109,8 +109,8 @@ pub async fn open_auth_webview(
                     // Same host, or a subdomain of the login host. The old
                     // bidirectional substring check treated unrelated hosts
                     // (e.g. hotmart.com vs sso.hotmart.com) as a match.
-                    let same_host = nav_host == login_host
-                        || nav_host.ends_with(&format!(".{login_host}"));
+                    let same_host =
+                        nav_host == login_host || nav_host.ends_with(&format!(".{login_host}"));
                     if same_host {
                         if nav_path != login_path
                             && !nav_path.contains("login")

--- a/src-tauri/src/commands/league/mod.rs
+++ b/src-tauri/src/commands/league/mod.rs
@@ -76,8 +76,8 @@ async fn discover_client() -> Option<LcuClient> {
         let port = extract_arg(line, "app-port").and_then(|p| p.parse::<u16>().ok());
         let token = extract_arg(line, "remoting-auth-token");
         if let (Some(port), Some(token)) = (port, token) {
-            let region = extract_arg(line, "region")
-                .or_else(|| extract_arg(line, "rso_platform_id"));
+            let region =
+                extract_arg(line, "region").or_else(|| extract_arg(line, "rso_platform_id"));
             return Some(LcuClient {
                 port,
                 token,
@@ -213,7 +213,12 @@ static IMMUTABLE_CACHE: Lazy<
         std::collections::VecDeque<String>,
         std::collections::HashMap<String, Value>,
     )>,
-> = Lazy::new(|| Mutex::new((std::collections::VecDeque::new(), std::collections::HashMap::new())));
+> = Lazy::new(|| {
+    Mutex::new((
+        std::collections::VecDeque::new(),
+        std::collections::HashMap::new(),
+    ))
+});
 
 fn cache_kind(path: &str) -> Option<CacheKind> {
     if path.starts_with("/lol-game-data/assets/") || path == "/lol-perks/v1/perks" {
@@ -476,7 +481,13 @@ pub async fn league_stop_matchmaking() -> Result<(), String> {
 pub async fn league_leave_lobby() -> Result<(), String> {
     ensure_enabled()?;
     let client = get_client().await?;
-    lcu_send(&client, reqwest::Method::DELETE, "/lol-lobby/v2/lobby", None).await?;
+    lcu_send(
+        &client,
+        reqwest::Method::DELETE,
+        "/lol-lobby/v2/lobby",
+        None,
+    )
+    .await?;
     Ok(())
 }
 
@@ -525,11 +536,7 @@ pub async fn league_live_game() -> Result<Value, String> {
         .json::<Value>()
         .await
         .map_err(|e| format!("invalid live client response: {}", e))?;
-    let players = http
-        .get(format!("{}/playerlist", base))
-        .send()
-        .await
-        .ok();
+    let players = http.get(format!("{}/playerlist", base)).send().await.ok();
     let players = match players {
         Some(r) => r.json::<Value>().await.unwrap_or(Value::Null),
         None => Value::Null,
@@ -587,9 +594,7 @@ pub async fn league_game_players() -> Result<Value, String> {
         let my_puuid = lcu_get_raw(&client, "/lol-summoner/v1/current-summoner")
             .await
             .ok()
-            .and_then(|s| {
-                s.get("puuid").and_then(Value::as_str).map(String::from)
-            })
+            .and_then(|s| s.get("puuid").and_then(Value::as_str).map(String::from))
             .unwrap_or_default();
         let game_data = session.get("gameData").cloned().unwrap_or(Value::Null);
         let team_one: Vec<Value> = game_data
@@ -602,9 +607,9 @@ pub async fn league_game_players() -> Result<Value, String> {
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
-        let one_has_me = team_one.iter().any(|m| {
-            m.get("puuid").and_then(Value::as_str) == Some(my_puuid.as_str())
-        });
+        let one_has_me = team_one
+            .iter()
+            .any(|m| m.get("puuid").and_then(Value::as_str) == Some(my_puuid.as_str()));
         for (team, mine) in [(team_one, one_has_me), (team_two, !one_has_me)] {
             for member in &team {
                 players.push(player_identity(member, mine));
@@ -641,9 +646,8 @@ pub async fn league_game_players() -> Result<Value, String> {
             if let Some(arr) = found.as_array() {
                 for (slot, (idx, g, _)) in to_lookup.iter().enumerate() {
                     let hit = arr.get(slot).or_else(|| {
-                        arr.iter().find(|s| {
-                            s.get("gameName").and_then(Value::as_str) == Some(g.as_str())
-                        })
+                        arr.iter()
+                            .find(|s| s.get("gameName").and_then(Value::as_str) == Some(g.as_str()))
                     });
                     if let Some(s) = hit {
                         if let Some(puuid) = s.get("puuid").and_then(Value::as_str) {
@@ -657,7 +661,11 @@ pub async fn league_game_players() -> Result<Value, String> {
 
     let mut name_tasks = Vec::new();
     for (i, p) in resolved.iter().enumerate() {
-        let puuid = p.get("puuid").and_then(Value::as_str).unwrap_or("").to_string();
+        let puuid = p
+            .get("puuid")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
         let has_name = p
             .get("gameName")
             .and_then(Value::as_str)
@@ -727,9 +735,9 @@ fn compute_history_stats(games: &[Value], puuid: &str) -> Value {
                             .and_then(|i| i.get("participantId").and_then(Value::as_i64))
                     });
                     match pid {
-                        Some(pid) => arr.iter().find(|p| {
-                            p.get("participantId").and_then(Value::as_i64) == Some(pid)
-                        }),
+                        Some(pid) => arr
+                            .iter()
+                            .find(|p| p.get("participantId").and_then(Value::as_i64) == Some(pid)),
                         None => arr.first(),
                     }
                 }
@@ -750,7 +758,10 @@ fn compute_history_stats(games: &[Value], puuid: &str) -> Value {
             .get("totalDamageDealtToChampions")
             .and_then(Value::as_f64)
             .unwrap_or(0.0);
-        total_gold += stats.get("goldEarned").and_then(Value::as_f64).unwrap_or(0.0);
+        total_gold += stats
+            .get("goldEarned")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
         // Slot 1 is the D key, slot 2 the F key; Flash is spell id 4.
         match (
             participant.get("spell1Id").and_then(Value::as_i64),
@@ -885,9 +896,12 @@ pub async fn league_player_report(
 
     // The summoner record states privacy explicitly; an empty history only
     // means the request came back thin, which is not the same thing.
-    let summoner = lcu_get_raw(&client, &format!("/lol-summoner/v2/summoners/puuid/{}", puuid))
-        .await
-        .unwrap_or(Value::Null);
+    let summoner = lcu_get_raw(
+        &client,
+        &format!("/lol-summoner/v2/summoners/puuid/{}", puuid),
+    )
+    .await
+    .unwrap_or(Value::Null);
     let is_private = summoner
         .get("privacy")
         .and_then(Value::as_str)
@@ -1010,7 +1024,11 @@ fn ranked_entry_parts(entry: &Value) -> (Option<f64>, u32, u32) {
         .and_then(Value::as_i64)
         .unwrap_or(0)
         .max(0) as u32;
-    let wins = entry.get("wins").and_then(Value::as_i64).unwrap_or(0).max(0) as u32;
+    let wins = entry
+        .get("wins")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        .max(0) as u32;
     let losses = entry
         .get("losses")
         .and_then(Value::as_i64)
@@ -1076,7 +1094,11 @@ pub async fn league_match_analysis() -> Result<Value, String> {
                         .collect()
                 })
                 .unwrap_or_default();
-            (index, json!({ "ranked": ranked, "history": history }), game_ids)
+            (
+                index,
+                json!({ "ranked": ranked, "history": history }),
+                game_ids,
+            )
         }));
     }
 
@@ -1094,7 +1116,10 @@ pub async fn league_match_analysis() -> Result<Value, String> {
     let mut detail: Vec<Value> = Vec::new();
 
     for (index, player) in players.iter().enumerate() {
-        let is_ally = player.get("isAlly").and_then(Value::as_bool).unwrap_or(false);
+        let is_ally = player
+            .get("isAlly")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         let data = &fetched[index];
         let solo = data
             .get("ranked")
@@ -1141,8 +1166,7 @@ pub async fn league_match_analysis() -> Result<Value, String> {
             enemy_strengths.push(strength);
         }
 
-        let season_shrunk =
-            stats::shrunk_winrate(season_wins, season_losses, stats::PRIOR_GAMES);
+        let season_shrunk = stats::shrunk_winrate(season_wins, season_losses, stats::PRIOR_GAMES);
         let (wilson_low, wilson_high) =
             stats::wilson_interval(season_wins, season_losses, stats::Z_90);
 
@@ -1531,9 +1555,7 @@ async fn deep_timeline_stats(client: &LcuClient, puuid: &str, games: &[Value]) -
                             solo_kills += 1;
                         }
                     }
-                    if event.get("victimId").and_then(Value::as_i64) == Some(pid)
-                        && ts <= 900_000
-                    {
+                    if event.get("victimId").and_then(Value::as_i64) == Some(pid) && ts <= 900_000 {
                         early_deaths += 1;
                     }
                 }
@@ -1672,8 +1694,7 @@ pub async fn league_duos(sample: Option<u32>) -> Result<Value, String> {
         }));
     }
 
-    let mut tally: std::collections::HashMap<String, (u32, u32)> =
-        std::collections::HashMap::new();
+    let mut tally: std::collections::HashMap<String, (u32, u32)> = std::collections::HashMap::new();
     let mut names: std::collections::HashMap<String, Value> = std::collections::HashMap::new();
     let mut analysed = 0u32;
 
@@ -1838,10 +1859,8 @@ pub async fn league_jungle_report(puuid: String, sample: Option<u32>) -> Result<
     let mut analysed = 0u32;
     let mut invades = 0u32;
     let mut level3_ganks = 0u32;
-    let mut first_camps: std::collections::HashMap<String, u32> =
-        std::collections::HashMap::new();
-    let mut objectives: std::collections::HashMap<String, u32> =
-        std::collections::HashMap::new();
+    let mut first_camps: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    let mut objectives: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
 
     for task in tasks {
         let (detail, timeline) = match task.await {
@@ -1953,10 +1972,7 @@ pub async fn league_jungle_report(puuid: String, sample: Option<u32>) -> Result<
                             let x = pos.get("x").and_then(Value::as_f64).unwrap_or(-1.0);
                             let y = pos.get("y").and_then(Value::as_f64).unwrap_or(-1.0);
                             if x >= 0.0 && y >= 0.0 {
-                                weights.add(
-                                    analysis::classify_zone(x, y),
-                                    analysis::KILL_WEIGHT,
-                                );
+                                weights.add(analysis::classify_zone(x, y), analysis::KILL_WEIGHT);
                             }
                         }
                     }
@@ -1974,7 +1990,10 @@ pub async fn league_jungle_report(puuid: String, sample: Option<u32>) -> Result<
         }
 
         if let Some(pf3) = frames.get(3).and_then(frame_participant) {
-            let cs = (pf3.get("minionsKilled").and_then(Value::as_i64).unwrap_or(0)
+            let cs = (pf3
+                .get("minionsKilled")
+                .and_then(Value::as_i64)
+                .unwrap_or(0)
                 + pf3
                     .get("jungleMinionsKilled")
                     .and_then(Value::as_i64)
@@ -2146,7 +2165,11 @@ pub async fn league_rune_recommendations(
                     let perks: Vec<i64> = p
                         .get("perks")
                         .and_then(Value::as_array)
-                        .map(|a| a.iter().filter_map(|x| x.get("id").and_then(Value::as_i64)).collect())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|x| x.get("id").and_then(Value::as_i64))
+                                .collect()
+                        })
                         .unwrap_or_default();
                     json!({
                         "recommendationId": p.get("recommendationId"),
@@ -2181,7 +2204,9 @@ pub async fn league_champion_tiers(
     let region = region.unwrap_or_else(|| "br".to_string());
     let bracket = tier.unwrap_or_else(|| "emerald_plus".to_string());
     if !region.chars().all(|c| c.is_ascii_alphanumeric())
-        || !bracket.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        || !bracket
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
     {
         return Err("invalid region or tier".to_string());
     }
@@ -2258,10 +2283,7 @@ pub async fn league_champion_tiers(
 /// champion across those games contributes their finished items. The response
 /// always reports how many games backed it so a thin sample is obvious.
 #[tauri::command]
-pub async fn league_champion_build(
-    champion_id: i64,
-    sample: Option<u32>,
-) -> Result<Value, String> {
+pub async fn league_champion_build(champion_id: i64, sample: Option<u32>) -> Result<Value, String> {
     ensure_enabled()?;
     if champion_id <= 0 {
         return Err("invalid champion".to_string());
@@ -2482,7 +2504,10 @@ async fn load_haste_table(http: &reqwest::Client) -> std::collections::HashMap<i
     if let Some(arr) = items_data.as_array() {
         for item in arr {
             let id = item.get("id").and_then(Value::as_i64).unwrap_or(0);
-            let desc = item.get("description").and_then(Value::as_str).unwrap_or("");
+            let desc = item
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("");
             let haste = item_ability_haste(desc);
             if id > 0 && haste > 0 {
                 table.insert(id, haste);
@@ -2521,8 +2546,7 @@ pub async fn league_ability_cooldowns() -> Result<Value, String> {
     let summary = lcu_get_raw(&client, "/lol-game-data/assets/v1/champion-summary.json")
         .await
         .unwrap_or(Value::Null);
-    let mut id_by_alias: std::collections::HashMap<String, i64> =
-        std::collections::HashMap::new();
+    let mut id_by_alias: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
     if let Some(arr) = summary.as_array() {
         for champ in arr {
             if let (Some(id), Some(alias)) = (
@@ -2567,12 +2591,18 @@ pub async fn league_ability_cooldowns() -> Result<Value, String> {
     }
 
     let mut rows: Vec<Value> = Vec::new();
-    let mut spell_cache: std::collections::HashMap<i64, Value> =
-        std::collections::HashMap::new();
+    let mut spell_cache: std::collections::HashMap<i64, Value> = std::collections::HashMap::new();
 
     for p in &list {
-        let raw_name = p.get("rawChampionName").and_then(Value::as_str).unwrap_or("");
-        let alias = raw_name.rsplit('_').next().unwrap_or("").to_ascii_lowercase();
+        let raw_name = p
+            .get("rawChampionName")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let alias = raw_name
+            .rsplit('_')
+            .next()
+            .unwrap_or("")
+            .to_ascii_lowercase();
         let champion_id = id_by_alias.get(&alias).copied().unwrap_or(0);
         let level = p.get("level").and_then(Value::as_i64).unwrap_or(1);
 
@@ -2652,7 +2682,10 @@ pub async fn league_ability_cooldowns() -> Result<Value, String> {
                     .and_then(|s| s.get(slot))
                     .and_then(|s| s.get("displayName"))
                     .and_then(Value::as_str)?;
-                let (cd, icon) = spell_by_name.get(name).cloned().unwrap_or((0.0, String::new()));
+                let (cd, icon) = spell_by_name
+                    .get(name)
+                    .cloned()
+                    .unwrap_or((0.0, String::new()));
                 Some(json!({
                     "name": name,
                     "baseCooldown": cd,
@@ -2723,7 +2756,10 @@ pub async fn league_dodge() -> Result<(), String> {
 pub async fn league_auto_accept_set(enabled: bool) -> Result<(), String> {
     ensure_enabled()?;
     AUTO_ACCEPT.store(enabled, Ordering::Relaxed);
-    tracing::info!("[league] auto-accept {}", if enabled { "on" } else { "off" });
+    tracing::info!(
+        "[league] auto-accept {}",
+        if enabled { "on" } else { "off" }
+    );
     Ok(())
 }
 

--- a/src-tauri/src/commands/league/stats.rs
+++ b/src-tauri/src/commands/league/stats.rs
@@ -185,7 +185,11 @@ pub fn player_strength(
 
     let base = rank.unwrap_or(UNRANKED_RATING);
     // Rank is the strong signal; without it we fall back to a wide prior.
-    let base_sigma = if rank.is_some() { RANK_SIGMA } else { UNKNOWN_SIGMA };
+    let base_sigma = if rank.is_some() {
+        RANK_SIGMA
+    } else {
+        UNKNOWN_SIGMA
+    };
 
     let season_p = shrunk_winrate(season_wins, season_losses, PRIOR_GAMES);
     let season_delta = winrate_rating_delta(season_p);
@@ -234,10 +238,13 @@ pub struct WinProbability {
 /// Bradley-Terry model with additive strengths. The interval comes from
 /// propagating each player's variance through the mean and then through the
 /// logistic — it is wide on purpose when players are unknown.
-pub fn team_win_probability(allies: &[PlayerStrength], enemies: &[PlayerStrength]) -> WinProbability {
+pub fn team_win_probability(
+    allies: &[PlayerStrength],
+    enemies: &[PlayerStrength],
+) -> WinProbability {
     let total_players = allies.len() + enemies.len();
-    let known_players = allies.iter().filter(|p| p.known).count()
-        + enemies.iter().filter(|p| p.known).count();
+    let known_players =
+        allies.iter().filter(|p| p.known).count() + enemies.iter().filter(|p| p.known).count();
 
     if allies.is_empty() || enemies.is_empty() {
         return WinProbability {
@@ -381,12 +388,7 @@ pub fn contribution_ratio(value: f64, team_total: f64, team_size: usize) -> f64 
 ///
 /// Above 1 the player converts less damage into more kills (finishing or
 /// stealing); below 1 they deal damage others convert. Neutral when unknown.
-pub fn kill_damage_efficiency(
-    kills: u32,
-    team_kills: u32,
-    damage: f64,
-    team_damage: f64,
-) -> f64 {
+pub fn kill_damage_efficiency(kills: u32, team_kills: u32, damage: f64, team_damage: f64) -> f64 {
     if team_kills == 0 || team_damage <= 0.0 || damage <= 0.0 {
         return 1.0;
     }
@@ -432,7 +434,11 @@ pub struct ImpactInput {
 /// Every component is a bounded ramp, so no single stat can dominate and the
 /// result stays comparable across roles and game lengths.
 pub fn impact_score(input: &ImpactInput) -> f64 {
-    let team_size = if input.team_size == 0 { 5 } else { input.team_size };
+    let team_size = if input.team_size == 0 {
+        5
+    } else {
+        input.team_size
+    };
 
     // KDA on a square-root curve: the gap from 2 to 5 matters more than 8 to 11.
     let kda_value = kda(input.kills, input.deaths, input.assists);
@@ -598,7 +604,11 @@ mod tests {
         assert!(close(iron4, RATING_FLOOR, 1e-9));
         // Silver IV should land near the ladder median used for unranked.
         let silver4 = rank_rating("SILVER", "IV", 0).unwrap();
-        assert!((silver4 - UNRANKED_RATING).abs() < 150.0, "silver4={}", silver4);
+        assert!(
+            (silver4 - UNRANKED_RATING).abs() < 150.0,
+            "silver4={}",
+            silver4
+        );
         let gold4 = rank_rating("GOLD", "IV", 0).unwrap();
         let gold1 = rank_rating("GOLD", "I", 75).unwrap();
         let emerald4 = rank_rating("EMERALD", "IV", 0).unwrap();
@@ -626,7 +636,12 @@ mod tests {
         let ra = winrate_rating_delta(pa);
         let rb = winrate_rating_delta(pb);
         let via_elo = elo_expectancy(ra, rb);
-        assert!(close(via_log5, via_elo, 1e-9), "{} vs {}", via_log5, via_elo);
+        assert!(
+            close(via_log5, via_elo, 1e-9),
+            "{} vs {}",
+            via_log5,
+            via_elo
+        );
         assert!(close(log5(0.5, 0.5), 0.5, 1e-12));
     }
 

--- a/src-tauri/src/commands/league/ws.rs
+++ b/src-tauri/src/commands/league/ws.rs
@@ -1,4 +1,4 @@
-use super::{get_client, league_settings, lcu_get_raw, lcu_post_raw, lcu_send, LcuClient};
+use super::{get_client, lcu_get_raw, lcu_post_raw, lcu_send, league_settings, LcuClient};
 use base64::Engine;
 use futures::{SinkExt, StreamExt};
 use once_cell::sync::OnceCell;
@@ -75,8 +75,7 @@ async fn run_session(client: &LcuClient) -> Result<(), String> {
     let mut request = url
         .into_client_request()
         .map_err(|e| format!("bad websocket url: {}", e))?;
-    let auth = base64::engine::general_purpose::STANDARD
-        .encode(format!("riot:{}", client.token));
+    let auth = base64::engine::general_purpose::STANDARD.encode(format!("riot:{}", client.token));
     request.headers_mut().insert(
         "Authorization",
         format!("Basic {}", auth)
@@ -280,7 +279,11 @@ async fn handle_trades(
         let path = format!(
             "/lol-champ-select/v1/session/trades/{}/{}",
             id,
-            if strategy == "accept" { "accept" } else { "decline" }
+            if strategy == "accept" {
+                "accept"
+            } else {
+                "decline"
+            }
         );
         match lcu_post_raw(client, &path).await {
             Ok(_) => {
@@ -362,7 +365,10 @@ async fn honor_from_ballot(client: &LcuClient, ballot: &Value) {
         None => return,
     };
     let puuid = choice.get("puuid").and_then(Value::as_str).unwrap_or("");
-    let summoner_id = choice.get("summonerId").and_then(Value::as_i64).unwrap_or(0);
+    let summoner_id = choice
+        .get("summonerId")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
 
     let modern = lcu_send(
         client,

--- a/src-tauri/src/commands/p2p.rs
+++ b/src-tauri/src/commands/p2p.rs
@@ -2,8 +2,8 @@ use serde::Serialize;
 use tauri::Emitter;
 use tokio_util::sync::CancellationToken;
 
-use omniget_core::platforms::p2p;
 use crate::{AppState, P2pSendHandle};
+use omniget_core::platforms::p2p;
 
 #[derive(Clone, Serialize)]
 pub struct P2pSendStarted {

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -11,7 +11,10 @@ fn emit_plugins_changed(app: &tauri::AppHandle) {
     let _ = app.emit("plugins-changed", ());
 }
 
-fn build_plugin_host(app: &tauri::AppHandle, plugins_dir: std::path::PathBuf) -> Arc<dyn PluginHost> {
+fn build_plugin_host(
+    app: &tauri::AppHandle,
+    plugins_dir: std::path::PathBuf,
+) -> Arc<dyn PluginHost> {
     Arc::new(PluginHostImpl::new(app.clone(), plugins_dir))
 }
 
@@ -523,7 +526,11 @@ pub async fn ensure_default_plugins(state: Arc<tokio::sync::RwLock<PluginManager
         if skip {
             continue;
         }
-        tracing::info!("installing default plugin '{}' from {}", entry.id, entry.repo);
+        tracing::info!(
+            "installing default plugin '{}' from {}",
+            entry.id,
+            entry.repo
+        );
         match install_plugin_zip_from_repo(&state, entry.id.clone(), entry.repo.clone()).await {
             Ok(v) => tracing::info!("default plugin '{}' installed ({})", entry.id, v),
             Err(e) => tracing::warn!("failed to install default plugin '{}': {}", entry.id, e),

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -139,7 +139,10 @@ pub fn get_plugin_frontend_path(
     plugin_id: String,
 ) -> Result<String, String> {
     let manager = state.blocking_read();
-    let frontend_dir = manager.plugins_dir().join(&plugin_id).join("frontend");
+    let frontend_dir = manager
+        .plugin_dir(&plugin_id)
+        .map_err(|e| e.to_string())?
+        .join("frontend");
     if !frontend_dir.exists() {
         return Err(format!("Plugin '{}' has no frontend", plugin_id));
     }
@@ -197,7 +200,10 @@ pub fn get_plugin_i18n(
     locale: String,
 ) -> Result<serde_json::Value, String> {
     let manager = state.blocking_read();
-    let i18n_dir = manager.plugins_dir().join(&plugin_id).join("i18n");
+    let i18n_dir = manager
+        .plugin_dir(&plugin_id)
+        .map_err(|e| e.to_string())?
+        .join("i18n");
     let locale_file = i18n_dir.join(format!("{}.json", locale));
     if !locale_file.exists() {
         let fallback = i18n_dir.join("en.json");
@@ -401,7 +407,7 @@ pub async fn install_plugin_zip_from_repo(
 
     let plugin_dir = {
         let manager = state.read().await;
-        manager.plugins_dir().join(&plugin_id)
+        manager.plugin_dir(&plugin_id).map_err(|e| e.to_string())?
     };
     std::fs::create_dir_all(&plugin_dir).map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/core/queue.rs
+++ b/src-tauri/src/core/queue.rs
@@ -1063,7 +1063,10 @@ async fn spawn_download_inner(
         } else if proxy.host.trim().is_empty() {
             "enabled but host is empty; falling back to system/env proxy".to_string()
         } else {
-            format!("enabled; {}://{}:{}", proxy.proxy_type, proxy.host, proxy.port)
+            format!(
+                "enabled; {}://{}:{}",
+                proxy.proxy_type, proxy.host, proxy.port
+            )
         };
         append_download_log(
             &app,
@@ -1125,12 +1128,8 @@ async fn spawn_download_inner(
                 },
             );
 
-            let info_future = fetch_and_cache_info(
-                &url,
-                &*downloader,
-                &platform_name,
-                ytdlp_path.as_deref(),
-            );
+            let info_future =
+                fetch_and_cache_info(&url, &*downloader, &platform_name, ytdlp_path.as_deref());
             let scoped_info_future = omniget_core::core::log_hook::CURRENT_COOKIE_SLUG.scope(
                 cookie_slug.clone(),
                 omniget_core::core::log_hook::CURRENT_DOWNLOAD_ID.scope(item_id, info_future),
@@ -1805,7 +1804,9 @@ async fn fetch_and_cache_info(
                     downloader.get_media_info(url).await?
                 } else {
                     let json = crate::core::ytdlp::get_video_info(ytdlp, url, &[]).await?;
-                    crate::platforms::generic_ytdlp::GenericYtdlpDownloader::parse_video_info(&json)?
+                    crate::platforms::generic_ytdlp::GenericYtdlpDownloader::parse_video_info(
+                        &json,
+                    )?
                 }
             }
             _ => downloader.get_media_info(url).await?,

--- a/src-tauri/src/core/state_file.rs
+++ b/src-tauri/src/core/state_file.rs
@@ -148,7 +148,10 @@ mod tests {
 
         let lido: Option<Estado> = load_or_quarantine(&path, "estado");
         assert!(lido.is_none());
-        assert!(!path.exists(), "o arquivo corrompido precisa sair do caminho de gravação");
+        assert!(
+            !path.exists(),
+            "o arquivo corrompido precisa sair do caminho de gravação"
+        );
 
         let preservados: Vec<_> = std::fs::read_dir(&dir)
             .unwrap()
@@ -156,10 +159,17 @@ mod tests {
             .map(|e| e.file_name().to_string_lossy().to_string())
             .filter(|n| n.starts_with("estado.json.corrupt-"))
             .collect();
-        assert_eq!(preservados.len(), 1, "esperava exatamente uma quarentena, achei {preservados:?}");
+        assert_eq!(
+            preservados.len(),
+            1,
+            "esperava exatamente uma quarentena, achei {preservados:?}"
+        );
 
         let conteudo = std::fs::read_to_string(dir.join(&preservados[0])).unwrap();
-        assert_eq!(conteudo, "{ isto nao e json", "a quarentena precisa ser byte a byte");
+        assert_eq!(
+            conteudo, "{ isto nao e json",
+            "a quarentena precisa ser byte a byte"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -129,9 +129,7 @@ async fn enqueue_from_clipboard(app: &tauri::AppHandle, url: String) {
     use crate::external_url::QueueUrlOutcome;
     match crate::external_url::queue_url_with_defaults(app, url.clone(), true, None).await {
         Ok(QueueUrlOutcome::Queued) => emit_hotkey_result(app, "queued", Some(&url)),
-        Ok(QueueUrlOutcome::AlreadyQueued) => {
-            emit_hotkey_result(app, "already_queued", Some(&url))
-        }
+        Ok(QueueUrlOutcome::AlreadyQueued) => emit_hotkey_result(app, "already_queued", Some(&url)),
         Err(e) => {
             tracing::warn!("[hotkey] enfileiramento recusado: {}", e);
             emit_hotkey_result(app, "unsupported", Some(&url));

--- a/src-tauri/src/platforms/gallerydl/mod.rs
+++ b/src-tauri/src/platforms/gallerydl/mod.rs
@@ -59,9 +59,24 @@ pub fn is_gallery_url(url: &str) -> bool {
 
 /// Twitter path segments that are app routes, not usernames.
 const TWITTER_RESERVED: &[&str] = &[
-    "home", "explore", "notifications", "messages", "settings", "search",
-    "hashtag", "intent", "share", "login", "logout", "signup", "i", "about",
-    "tos", "privacy", "compose", "jobs",
+    "home",
+    "explore",
+    "notifications",
+    "messages",
+    "settings",
+    "search",
+    "hashtag",
+    "intent",
+    "share",
+    "login",
+    "logout",
+    "signup",
+    "i",
+    "about",
+    "tos",
+    "privacy",
+    "compose",
+    "jobs",
 ];
 
 /// Bulk-listing URLs (profiles, subreddits) that the single-post platform
@@ -96,9 +111,7 @@ pub fn is_bulk_media_url(url: &str) -> bool {
     if host == "twitter.com" || host == "x.com" {
         return match segments.as_slice() {
             [user] => !TWITTER_RESERVED.contains(user),
-            [user, tail] => {
-                !TWITTER_RESERVED.contains(user) && matches!(*tail, "media" | "likes")
-            }
+            [user, tail] => !TWITTER_RESERVED.contains(user) && matches!(*tail, "media" | "likes"),
             _ => false,
         };
     }

--- a/src-tauri/src/plugin_host.rs
+++ b/src-tauri/src/plugin_host.rs
@@ -139,10 +139,7 @@ impl<R: Runtime + 'static> PluginHost for PluginHostImpl<R> {
                 })?
                 .join("wtf.tonho.omniget")
         };
-        let dir = base
-            .join("external-cache")
-            .join(plugin_id)
-            .join(namespace);
+        let dir = base.join("external-cache").join(plugin_id).join(namespace);
         std::fs::create_dir_all(&dir).map_err(|e| {
             anyhow::anyhow!(
                 "external_data_cache: failed to create {}: {}",

--- a/src-tauri/src/plugin_loader.rs
+++ b/src-tauri/src/plugin_loader.rs
@@ -98,7 +98,12 @@ impl PluginManager {
         id: &str,
         host: Arc<dyn PluginHost>,
     ) -> Result<(), PluginLoadError> {
-        let plugin_dir = self.plugins_dir.join(id);
+        let plugin_dir = self.plugin_dir(id).map_err(|e| PluginLoadError {
+            message: e.to_string(),
+            kind: "invalid_id".to_string(),
+            plugin_abi: None,
+            expected_abi: None,
+        })?;
         match load_single_plugin(&plugin_dir, host) {
             Ok(loaded) => {
                 tracing::info!(
@@ -190,7 +195,7 @@ impl PluginManager {
         self.user_removed.insert(plugin_id.to_string());
         save_removed_list(&self.plugins_dir, &self.user_removed)?;
 
-        let plugin_dir = self.plugins_dir.join(plugin_id);
+        let plugin_dir = self.plugin_dir(plugin_id)?;
         if plugin_dir.exists() {
             fs::remove_dir_all(&plugin_dir)?;
         }
@@ -207,6 +212,43 @@ impl PluginManager {
     pub fn plugins_dir(&self) -> &Path {
         &self.plugins_dir
     }
+
+    /// Diretorio de um plugin, com o id validado.
+    ///
+    /// Todo caminho derivado de `plugin_id` passa por aqui. O id chega de fora
+    /// — registro remoto -> `installed.json` -> frontend -> comando Tauri — e
+    /// nenhum ponto dessa cadeia o sanitizava, entao um id com `..` escapava do
+    /// diretorio de plugins e o `remove_dir_all` do `unregister` apagava
+    /// caminho arbitrario.
+    pub fn plugin_dir(&self, plugin_id: &str) -> anyhow::Result<PathBuf> {
+        validate_plugin_id(plugin_id)?;
+        Ok(self.plugins_dir.join(plugin_id))
+    }
+}
+
+/// Aceita apenas `[A-Za-z0-9._-]`, recusando separador de caminho, byte nulo,
+/// componente relativo e id vazio.
+///
+/// Allowlist e nao blocklist de proposito: o conjunto de ids reais e pequeno e
+/// conhecido (`courses`, `study`, `telegram`, `convert`, `misc`), e uma
+/// blocklist erra por omissao a cada codificacao nova.
+pub fn validate_plugin_id(plugin_id: &str) -> anyhow::Result<()> {
+    if plugin_id.is_empty() {
+        anyhow::bail!("plugin id must not be empty");
+    }
+    if plugin_id == "." || plugin_id == ".." || plugin_id.starts_with('.') {
+        anyhow::bail!("plugin id must not be a relative path component: {plugin_id:?}");
+    }
+    if let Some(bad) = plugin_id
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && !matches!(c, '.' | '_' | '-'))
+    {
+        anyhow::bail!("plugin id contains an illegal character {bad:?}: {plugin_id:?}");
+    }
+    if plugin_id.contains("..") {
+        anyhow::bail!("plugin id must not contain '..': {plugin_id:?}");
+    }
+    Ok(())
 }
 
 fn load_single_plugin(
@@ -509,4 +551,55 @@ fn save_removed_list(plugins_dir: &Path, removed: &HashSet<String>) -> anyhow::R
     let content = serde_json::to_string_pretty(&RemovedFile { removed: list })?;
     fs::write(&path, content)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod plugin_id_tests {
+    use super::*;
+
+    #[test]
+    fn aceita_os_ids_reais() {
+        for id in ["courses", "study", "telegram", "convert", "misc", "my-plugin_2", "wtf.tonho.x"] {
+            assert!(validate_plugin_id(id).is_ok(), "recusou id valido {id:?}");
+        }
+    }
+
+    #[test]
+    fn recusa_travessia_de_caminho() {
+        // Criterio de aceite do B48: um id relativo falha explicitamente em vez
+        // de virar um caminho fora do diretorio de plugins.
+        for id in [
+            "../../algo",
+            "..",
+            ".",
+            "../etc",
+            "a/../../b",
+            ".oculto",
+            "sub/dir",
+            "sub\\dir",
+            "com:dois",
+            "nulo\0byte",
+            "",
+        ] {
+            assert!(
+                validate_plugin_id(id).is_err(),
+                "aceitou id perigoso {id:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_dir_nunca_escapa_do_diretorio_base() {
+        let base = std::path::PathBuf::from("/tmp/omniget-plugins");
+        let manager = PluginManager::new(base.clone());
+
+        let ok = manager.plugin_dir("courses").expect("id valido");
+        assert_eq!(ok, base.join("courses"));
+        assert!(ok.starts_with(&base));
+
+        // Sem o guard, `join("../../etc")` normalizaria para fora de `base` e o
+        // `remove_dir_all` do `unregister` apagaria caminho arbitrario.
+        assert!(manager.plugin_dir("../../etc").is_err());
+        assert!(manager.plugin_dir("..").is_err());
+    }
 }

--- a/src-tauri/src/plugin_loader.rs
+++ b/src-tauri/src/plugin_loader.rs
@@ -93,11 +93,7 @@ impl PluginManager {
         self.loaded.contains_key(id)
     }
 
-    pub fn load_one(
-        &mut self,
-        id: &str,
-        host: Arc<dyn PluginHost>,
-    ) -> Result<(), PluginLoadError> {
+    pub fn load_one(&mut self, id: &str, host: Arc<dyn PluginHost>) -> Result<(), PluginLoadError> {
         let plugin_dir = self.plugin_dir(id).map_err(|e| PluginLoadError {
             message: e.to_string(),
             kind: "invalid_id".to_string(),
@@ -366,21 +362,20 @@ fn load_single_plugin(
 
     // A plugin's init entrypoint runs arbitrary foreign code; convert panics
     // into load errors instead of aborting the whole app.
-    let plugin_ptr =
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| init_fn())) {
-            Ok(ptr) => ptr,
-            Err(_) => {
-                // The plugin may already have spawned threads before panicking;
-                // leak the library instead of dropping it (dlclose would unmap
-                // code those threads are still executing → SIGSEGV). Mirrors
-                // the deliberate leak in `PluginManager::unregister`.
-                std::mem::forget(lib);
-                return Err(PluginLoadError::simple(
-                    "initialize",
-                    "Plugin panicked in omniget_plugin_init",
-                ));
-            }
-        };
+    let plugin_ptr = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| init_fn())) {
+        Ok(ptr) => ptr,
+        Err(_) => {
+            // The plugin may already have spawned threads before panicking;
+            // leak the library instead of dropping it (dlclose would unmap
+            // code those threads are still executing → SIGSEGV). Mirrors
+            // the deliberate leak in `PluginManager::unregister`.
+            std::mem::forget(lib);
+            return Err(PluginLoadError::simple(
+                "initialize",
+                "Plugin panicked in omniget_plugin_init",
+            ));
+        }
+    };
     if plugin_ptr.is_null() {
         std::mem::forget(lib);
         return Err(PluginLoadError::simple(
@@ -390,9 +385,8 @@ fn load_single_plugin(
     }
     let mut plugin = unsafe { Box::from_raw(plugin_ptr) };
 
-    let init_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        plugin.initialize(host)
-    }));
+    let init_result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| plugin.initialize(host)));
     match init_result {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
@@ -559,7 +553,15 @@ mod plugin_id_tests {
 
     #[test]
     fn aceita_os_ids_reais() {
-        for id in ["courses", "study", "telegram", "convert", "misc", "my-plugin_2", "wtf.tonho.x"] {
+        for id in [
+            "courses",
+            "study",
+            "telegram",
+            "convert",
+            "misc",
+            "my-plugin_2",
+            "wtf.tonho.x",
+        ] {
             assert!(validate_plugin_id(id).is_ok(), "recusou id valido {id:?}");
         }
     }


### PR DESCRIPTION
Wave B47 → B48 → B41 from `docs/backlog.md`. Three commits, one per item, each with its acceptance criterion verified.

**This PR is also the first test of the CI it adds** — if the checks below run at all, B47 worked.

## B47 — Have CI

There was no CI in this repository. No `pnpm check`, no `cargo test`, no clippy ran on any pull request; only `release.yml` was versioned. That is how PR #197 stayed open with two `svelte-check` errors and nothing flagged them — the errors only surfaced by running the gates by hand in a worktree.

The root cause was wider than a missing file. `.gitignore` excluded `/docs` and `/.github` wholesale, so every file in them had to be forced in with `git add -f` and any new one failed silently. Both hold real project files, so the blanket ignores are gone; `/.claude` and `claude.md` stay ignored because those really are local.

The workflow runs on `pull_request` and on push to `main`: fmt, clippy and `cargo test` across Linux/Windows/macOS, a Debian bookworm compat check, `pnpm check`, vitest, locale sync, and a check that `keys.ts` was regenerated after touching `en.json`.

Two things I did not pretend to solve:

- **Clippy is informational, not a gate.** The workspace carries pre-existing warnings, so `-D warnings` would fail every PR on day one. Making it a real gate needs a committed baseline — noted in the workflow and in the backlog.
- **`sync:locales` was removed from `package.json`** because `scripts/sync-locales.mjs` does not exist on this branch. `check:i18n` now uses `generate-i18n-keys.js --strict`, which already fails when a locale drifts from `en.json`.

*Acceptance criterion, verified locally:* injecting a deliberate type error makes `pnpm check` exit 1; reverting returns 0.

## B48 — Validate `plugin_id` before it becomes a path

`plugin_loader.rs` joined `plugin_id` onto the plugins directory unsanitised and handed the result to `remove_dir_all` on uninstall. An id containing `..` escaped the directory and deleted an arbitrary path.

The id comes from outside — the remote registry's `plugins.json`, through `installed.json`, through the marketplace page, into `uninstall_plugin`. Nothing in that chain checked it. It is **not** remotely triggerable: it needs a compromised registry or a hand-crafted `plugin.json`, which is why this is hardening rather than an isolated security release.

Sanitised at the entry point rather than at each of the ten join sites. `PluginManager::plugin_dir()` validates and is now the only way to build a plugin path, so a future call site cannot reintroduce the bug by forgetting. The validator uses an allowlist of `[A-Za-z0-9._-]` rather than a blocklist, because the set of real ids is small and known and a blocklist misses a new encoding every time.

*Acceptance criterion, covered by test:* `plugin_dir("../../etc")` fails explicitly, and every accepted id stays under the base directory.

## B41 — Fall back through player clients when YouTube forces SABR

The `web` client started returning SABR-only formats the normal download path cannot pull, so downloads failed with no legible cause.

The retry loop already rotated `player_client` on 429 and nsig errors, so this is one more branch in it rather than new machinery: when the stderr mentions SABR, walk `android → ios → tv → web_safari`. No new screen, no new setting.

The decision is a pure function so it can be tested against captured yt-dlp stderr instead of needing a live download.

*Acceptance criterion, covered by tests:* cascade order, exhaustion returning `None` rather than looping, and — the one that matters — a non-SABR failure does **not** rotate the client, which would otherwise mask the real cause and burn the retry budget.

## Gates

| Gate | Before | After |
|---|---|---|
| `cargo clippy --workspace --all-targets` | 34 / 42 / 8 / 1 | **identical** |
| `cargo test --workspace --lib` | 456 | **460** |
| `pnpm check` | 0 errors / 107 warnings | **identical** |
| `pnpm test` | 23 | 23 |

`docs/backlog.md` is updated to reflect the three items as delivered.
