### PR TITLE
B49: build the main window ourselves so portable mode stops leaking to LOCALAPPDATA

### DIFF
--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -25,6 +25,7 @@ pub mod download_log;
 pub mod events;
 pub mod host_limiter;
 pub mod path_limits;
+pub mod portable;
 pub mod queue;
 pub mod queue_history;
 pub mod recovery;

--- a/src-tauri/src/core/portable.rs
+++ b/src-tauri/src/core/portable.rs
@@ -1,0 +1,120 @@
+//! Onde o WebView2 guarda os dados dele, no modo portatil.
+//!
+//! O `WEBVIEW2_USER_DATA_FOLDER` definido no `main.rs` e codigo morto: o Tauri
+//! resolve `data_directory` para `LocalData/{identifier}` antes de a variavel
+//! ser lida (`manager/webview.rs`), cria o diretorio, e o wry recebe um caminho
+//! nao-vazio — a variavel nunca e consultada. O `tauri.conf.json` tambem nao
+//! resolve, porque so aceita caminho relativo, resolvido sob `data_local_dir()`.
+//!
+//! A saida e nao deixar o Tauri criar a janela (`"create": false`) e construi-la
+//! no `setup()` com `.data_directory(...)` explicito. Este modulo isola a parte
+//! decidivel — qual diretorio usar — para poder ser testada sem subir o app.
+
+use std::path::{Path, PathBuf};
+
+/// Diretorio de dados do WebView2 quando o app roda em modo portatil.
+///
+/// `None` quando nao e portatil: nesse caso o comportamento padrao do Tauri
+/// esta correto e nao deve ser sobrescrito.
+pub fn portable_webview_dir(data_dir: Option<&Path>) -> Option<PathBuf> {
+    data_dir.map(|d| d.join("webview"))
+}
+
+/// Le o modo portatil do ambiente, do jeito que o `main.rs` o publica.
+///
+/// Le `OMNIGET_DATA_DIR` em vez de re-detectar o `portable.txt`: a deteccao
+/// acontece uma vez so, antes de qualquer coisa subir, e duplicar a regra aqui
+/// criaria duas fontes de verdade que divergem no primeiro ajuste.
+pub fn portable_webview_dir_from_env() -> Option<PathBuf> {
+    if std::env::var("OMNIGET_PORTABLE").ok().as_deref() != Some("1") {
+        return None;
+    }
+    let data_dir = std::env::var("OMNIGET_DATA_DIR").ok()?;
+    if data_dir.trim().is_empty() {
+        return None;
+    }
+    portable_webview_dir(Some(Path::new(&data_dir)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nao_portatil_nao_sobrescreve_o_padrao_do_tauri() {
+        assert_eq!(portable_webview_dir(None), None);
+    }
+
+    #[test]
+    fn portatil_fica_ao_lado_do_executavel() {
+        let dir = PathBuf::from("/media/pendrive/OmniGet/data");
+        let got = portable_webview_dir(Some(&dir)).expect("portatil tem diretorio");
+        assert_eq!(got, dir.join("webview"));
+        // O ponto da issue #195: nada pode acabar sob o perfil do usuario.
+        assert!(got.starts_with(&dir));
+    }
+
+    #[test]
+    fn caminho_com_espaco_sobrevive() {
+        // Windows portatil vive em "C:\Users\x\Downloads\OmniGet 0.7.7\data".
+        let dir = PathBuf::from("C:/Users/x/Downloads/OmniGet 0.7.7/data");
+        let got = portable_webview_dir(Some(&dir)).expect("portatil tem diretorio");
+        assert!(got.to_string_lossy().contains("OmniGet 0.7.7"));
+        assert!(got.ends_with("webview"));
+    }
+
+    #[test]
+    fn leitor_de_ambiente_exige_as_duas_variaveis() {
+        // Um teste so, sequencial: `set_var` e global ao processo e os testes
+        // rodam em paralelo. Nenhum outro teste toca estas duas variaveis, mas
+        // dividir isto em varios seria corrida garantida.
+        let restore = (
+            std::env::var("OMNIGET_PORTABLE").ok(),
+            std::env::var("OMNIGET_DATA_DIR").ok(),
+        );
+
+        std::env::remove_var("OMNIGET_PORTABLE");
+        std::env::remove_var("OMNIGET_DATA_DIR");
+        assert_eq!(
+            portable_webview_dir_from_env(),
+            None,
+            "sem env nao e portatil"
+        );
+
+        std::env::set_var("OMNIGET_PORTABLE", "1");
+        assert_eq!(
+            portable_webview_dir_from_env(),
+            None,
+            "portatil sem data dir nao pode inventar caminho"
+        );
+
+        std::env::set_var("OMNIGET_DATA_DIR", "   ");
+        assert_eq!(
+            portable_webview_dir_from_env(),
+            None,
+            "data dir em branco nao pode virar caminho relativo"
+        );
+
+        std::env::set_var("OMNIGET_DATA_DIR", "/tmp/omniget-portatil/data");
+        assert_eq!(
+            portable_webview_dir_from_env(),
+            Some(PathBuf::from("/tmp/omniget-portatil/data/webview"))
+        );
+
+        std::env::set_var("OMNIGET_PORTABLE", "0");
+        assert_eq!(
+            portable_webview_dir_from_env(),
+            None,
+            "so a string \"1\" liga o modo portatil"
+        );
+
+        match restore.0 {
+            Some(v) => std::env::set_var("OMNIGET_PORTABLE", v),
+            None => std::env::remove_var("OMNIGET_PORTABLE"),
+        }
+        match restore.1 {
+            Some(v) => std::env::set_var("OMNIGET_DATA_DIR", v),
+            None => std::env::remove_var("OMNIGET_DATA_DIR"),
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,6 +298,42 @@ pub fn run() {
             None,
         ))
         .setup(|app| {
+            // A janela principal e criada aqui, e nao pelo `tauri.conf.json`
+            // (`"create": false`), porque so daqui da para passar
+            // `.data_directory(...)` ao WebView2. O Tauri resolve esse caminho
+            // para `LocalData/{identifier}` e cria o diretorio *antes* do setup
+            // rodar, entao a variavel de ambiente que o `main.rs` define nunca
+            // chega a ser lida — que e a causa da issue #195, o modo portatil
+            // deixando uma pasta fora do diretorio do app.
+            {
+                // `mut` so e usado no ramo Windows abaixo; sem o cfg_attr isto
+                // vira warning novo em macOS e Linux e reprova o portao de clippy.
+                #[cfg_attr(not(windows), allow(unused_mut))]
+                let mut builder = tauri::WebviewWindowBuilder::from_config(
+                    app.handle(),
+                    &app.config().app.windows[0],
+                )?;
+
+                #[cfg(windows)]
+                if let Some(webview_dir) = core::portable::portable_webview_dir_from_env() {
+                    if let Err(e) = std::fs::create_dir_all(&webview_dir) {
+                        tracing::warn!(
+                            "[portable] nao foi possivel criar {}: {} — o WebView2 vai usar o diretorio padrao",
+                            webview_dir.display(),
+                            e
+                        );
+                    } else {
+                        tracing::info!(
+                            "[portable] WebView2 apontado para {}",
+                            webview_dir.display()
+                        );
+                        builder = builder.data_directory(webview_dir);
+                    }
+                }
+
+                builder.build()?;
+            }
+
             commands::host_queue::register_event_listeners(app.handle());
             {
                 let handle = app.handle().clone();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,6 +12,8 @@
   "app": {
     "windows": [
       {
+        "label": "main",
+        "create": false,
         "title": "OmniGet",
         "width": 1100,
         "height": 720,


### PR DESCRIPTION
Closes #195 on the code side. **Read the last section before merging — CI cannot prove this one works.**

## Why the previous fix never ran

`WEBVIEW2_USER_DATA_FOLDER` is set in `main.rs` and is dead code. Tauri resolves `data_directory` to `LocalData/{identifier}` and `create_dir_all`s it *before* the setup hook runs, so wry receives a non-empty path and never consults the variable.

`tauri.conf.json` cannot express it either: it only accepts a **relative** path, resolved under `data_local_dir()` — the exact directory we are trying to escape.

## The fix

The main window is no longer created from config (`"create": false`) and is built in `setup()`, which is the only place `.data_directory()` can be passed. On Windows in portable mode it points at `<app>/data/webview`; everywhere else Tauri's default is left alone because it is correct there.

The decidable part — *which directory, given the environment* — is a pure function in `core::portable` with four tests, including a path containing a space, since a portable install realistically lives in `Downloads\OmniGet 0.7.7\data`.

It reads `OMNIGET_DATA_DIR` rather than re-detecting `portable.txt`: detection happens once in `main.rs`, and duplicating the rule would create two sources of truth that diverge on the first change.

One detail worth noting: the `mut` binding is behind `cfg_attr` because only the Windows branch mutates it. Without that it is a new warning on macOS and Linux, and the clippy baseline gate from #207 rejects it — which is the gate doing its job on the first item after landing.

## What CI proves, and what it does not

This is the part I do not want glossed over.

**Proved:** it compiles on all three platforms, and the directory logic is correct — 4 tests covering not-portable, portable, a path with a space, and the environment reader refusing to invent a path from half-set variables.

**Not proved:** the `rust (windows-latest)` job runs `cargo test`; it does not launch the app. Nothing here demonstrates that the window actually opens, or that `%LOCALAPPDATA%\wtf.tonho.omniget` stops appearing.

Moving window creation out of config into `setup()` changes app startup. If it is wrong, the app does not open at all — which is a worse failure than the bug being fixed.

**Manual validation needed before this reaches users**, on a Windows machine:

1. Build, put `portable.txt` next to the `.exe`, delete `%LOCALAPPDATA%\wtf.tonho.omniget`, launch. The window must open, and that folder must not come back. `<app>\data\webview` must exist.
2. Launch **without** `portable.txt`. The window must still open and behave exactly as before — this is the regression risk for every non-portable user, which is everyone.
3. @PaduaPlay reported the issue and could confirm case 1 on a real install.

## Gates

| Gate | Value |
|---|---|
| `cargo test --workspace --lib` | **471** (was 467) |
| clippy baseline | 92 warnings, none new — on all three platforms |
| `cargo fmt --check` | clean |