### PR TITLE
B57 + B58: neither bug was real; make the silent single-instance exit visible

### DIFF
--- a/src-tauri/src/core/portable.rs
+++ b/src-tauri/src/core/portable.rs
@@ -118,3 +118,46 @@ mod tests {
         }
     }
 }
+
+/// Linha unica de boot, emitida antes de qualquer coisa poder sair em silencio.
+///
+/// O `tauri-plugin-single-instance` chama `std::process::exit(0)` sem logar nada
+/// quando detecta outra instancia viva. Sem esta linha, um app que sai por esse
+/// caminho e indistinguivel de um que crashou: o log simplesmente para. Custou
+/// uma sessao inteira de investigacao descobrir isso, e o usuario que abrir o
+/// app duas vezes nao tem nem log para olhar.
+///
+/// Com a linha, o diagnostico vira trivial: banner presente e nada depois
+/// significa que outra instancia assumiu; banner ausente significa que o
+/// processo nem chegou a subir.
+pub fn startup_banner(version: &str, pid: u32, portable: bool, data_dir: Option<&Path>) -> String {
+    let modo = if portable { "portable" } else { "standard" };
+    let dir = data_dir
+        .map(|d| d.display().to_string())
+        .unwrap_or_else(|| "<unresolved>".to_string());
+    format!("OmniGet {version} starting — pid {pid}, {modo} mode, data dir {dir}")
+}
+
+#[cfg(test)]
+mod banner_tests {
+    use super::*;
+
+    #[test]
+    fn banner_nomeia_o_modo_e_o_diretorio() {
+        let b = startup_banner("0.7.7", 1234, true, Some(Path::new("/pendrive/data")));
+        assert!(b.contains("0.7.7"));
+        assert!(b.contains("pid 1234"));
+        assert!(b.contains("portable mode"));
+        assert!(b.contains("/pendrive/data"));
+    }
+
+    #[test]
+    fn banner_nao_esconde_diretorio_nao_resolvido() {
+        // Se o data dir nao resolveu, dizer isso vale mais do que omitir: e a
+        // primeira coisa a olhar quando o app se comporta como se nao tivesse
+        // configuracao nenhuma.
+        let b = startup_banner("0.7.7", 1, false, None);
+        assert!(b.contains("standard mode"));
+        assert!(b.contains("<unresolved>"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,6 +206,18 @@ pub struct AppState {
 pub fn run() {
     tracing_subscriber::fmt::init();
 
+    // Emitido antes do single-instance poder sair em silencio: ver
+    // core::portable::startup_banner.
+    tracing::info!(
+        "{}",
+        core::portable::startup_banner(
+            env!("CARGO_PKG_VERSION"),
+            std::process::id(),
+            std::env::var("OMNIGET_PORTABLE").ok().as_deref() == Some("1"),
+            core::paths::app_data_dir().as_deref(),
+        )
+    );
+
     let mut registry = core::registry::PlatformRegistry::new();
     // gallery-dl first: it claims bulk-listing URLs (profiles, subreddits)
     // that the single-post Twitter/Reddit downloaders would otherwise match


### PR DESCRIPTION
B57 and B58 from the backlog, both investigated. **Neither suspected bug is real.** The one real finding is much smaller than the suspicion — but it is what cost a full session of investigation.

## B57 — the feared regression does not exist

The suspicion was that B49 moving window creation into `setup()` would make the single-instance callback's `get_webview_window("main")` return `None`, and an `.unwrap()` there would kill the *first* instance.

It does not. The callback goes through `tray::show_window`, which is:

```rust
if let Some(window) = app.get_webview_window("main") {
    let _ = window.show();
    let _ = window.unminimize();
    let _ = window.set_focus();
}
```

All four `get_webview_window("main")` call sites in the codebase use `if let Some`. No unwraps. **No code change needed.**

## B58 — stale-socket takeover already works, and I had the mechanism wrong

`tauri-plugin-single-instance` connects to `/tmp/{identifier}_si.sock`. A dead owner leaves a socket that refuses connections → `ConnectionRefused` → the plugin removes it and takes over.

Verified empirically:

| Situation | errno | Plugin behaviour |
|---|---|---|
| Orphaned socket, no listener | 61 `ConnectionRefused` | cleanup + take over |
| Socket missing | 2 `NotFound` | take over |

**The app does not brick itself after `kill -9`.**

### Correcting my own report

I told #209 that repeated launches during B54 were hitting an orphaned socket. That was wrong. They were hitting **my own earlier test instance, still alive**, holding a live socket. The socket is cleaned up on exit, which is why none exists on this machine now — and that absence is what made me re-examine the claim.

## What is real

The plugin calls `std::process::exit(0)` with **no logging at all**. An app exiting that way is indistinguishable from one that crashed: the log simply stops.

That is the same shape as the `settings.json` `unwrap_or_default` bug this project has been bitten by before — a failure that does not announce itself. A user who opens OmniGet twice gets no window and no log line explaining why.

So a boot line is now emitted immediately after tracing initialises, before anything can exit quietly:

```
OmniGet 0.7.7 starting — pid 51234, standard mode, data dir /Users/x/Library/Application Support/wtf.tonho.omniget
```

Banner present and nothing after it → another instance took over. Banner absent → the process never started. Two tests, including one asserting that an unresolved data dir is *reported* rather than omitted, since that is the first thing to check when the app behaves as if it has no configuration.

## Gates

| Gate | Value |
|---|---|
| `cargo test --workspace --lib` | **475** (was 473) |
| clippy baseline | 92 warnings, none new |
| `cargo fmt --check` | clean |
