### PR TITLE
Wave D: adaptive per-host concurrency, torrent streaming piece order

### DIFF
--- a/docs/VALIDACAO-0.8.0.md
+++ b/docs/VALIDACAO-0.8.0.md
@@ -20,6 +20,15 @@ Formato: **o que clicar** → o que precisa acontecer.
   "Cortar silêncio" devolve `.m4a` com duração batendo com a estimativa, "Nivelar voz"
   devolve `.mp4` com vídeo idêntico e áudio nivelado. Os três botões nunca foram clicados.
 
+## Onda D
+
+- **B35 concorrência adaptativa** → quando ligado: baixar do mesmo host várias vezes e
+  confirmar que o `-N` efetivo sobe quando há banda e **cai na hora** ao tomar 429.
+  Confirmar que o número em Config passou a se comportar como teto, não valor fixo.
+- **B46 streaming de torrent** → quando ligado: começar um torrent de vídeo e confirmar
+  que o player abre antes de terminar, que o seek para o meio espera a janela de lá em
+  vez de travar, e que a troca (pior para o enxame) está dita na interface.
+
 ## Onda C
 
 - **B44 painel de causa raiz** → quando a tela existir: forçar cada uma das sete causas

--- a/src-tauri/src/core/adaptive_concurrency.rs
+++ b/src-tauri/src/core/adaptive_concurrency.rs
@@ -1,0 +1,250 @@
+//! Ajusta `-N` por host medindo o throughput real, em vez de confiar num
+//! numero fixo em Config.
+//!
+//! O numero em Config e um chute que o usuario tem que dar sem informacao: alto
+//! demais toma 429, baixo demais desperdiça banda, e o valor certo depende do
+//! host e do momento. O limitador por host e o contador de 429 ja existem — o
+//! que faltava era fechar o laco.
+//!
+//! Ficou possivel agora porque o B23 fez o freio de 429 funcionar de verdade:
+//! antes, `-N` e `--concurrent-fragments` disputavam e o valor efetivo nao era
+//! o que o codigo pensava, entao nao havia sinal confiavel para realimentar.
+//!
+//! A decisao e pura: dadas amostras de throughput e o historico de 429, qual
+//! deve ser o proximo `-N`. Medir e I/O.
+//!
+//! Origem: controle de congestionamento de CDN — subir devagar, cair rapido.
+
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Limites do ajuste. Um host nunca sai desta faixa, por mais que as medicoes
+/// sugiram: o teto protege o servidor e o piso garante que o download anda.
+pub const MIN_N: u32 = 1;
+pub const MAX_N: u32 = 16;
+
+/// Ganho minimo para justificar subir mais.
+///
+/// Dez por cento: abaixo disso a diferenca se confunde com variacao normal de
+/// rede, e subir `-N` atras de ruido so aumenta a chance de 429.
+pub const MEANINGFUL_GAIN: f64 = 1.10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct Sample {
+    pub concurrency: u32,
+    /// Bytes por segundo observados com essa concorrencia.
+    pub throughput_bps: f64,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct HostStats {
+    samples: Vec<Sample>,
+    rate_limit_hits: u32,
+}
+
+impl HostStats {
+    pub fn record(&mut self, concurrency: u32, throughput_bps: f64) {
+        if throughput_bps.is_finite() && throughput_bps > 0.0 {
+            self.samples.push(Sample {
+                concurrency,
+                throughput_bps,
+            });
+        }
+    }
+
+    pub fn record_rate_limit(&mut self) {
+        self.rate_limit_hits = self.rate_limit_hits.saturating_add(1);
+    }
+
+    /// Melhor throughput observado para uma dada concorrencia.
+    ///
+    /// Melhor e nao media: uma amostra ruim costuma ser interferencia local
+    /// (outro download, wifi), nao a capacidade real daquele nivel.
+    fn best_at(&self, concurrency: u32) -> Option<f64> {
+        self.samples
+            .iter()
+            .filter(|s| s.concurrency == concurrency)
+            .map(|s| s.throughput_bps)
+            .fold(None, |acc: Option<f64>, v| {
+                Some(acc.map_or(v, |a| a.max(v)))
+            })
+    }
+}
+
+/// Proximo `-N` para o host.
+///
+/// Sobe devagar e cai rapido, que e a assimetria certa: subir errado custa um
+/// 429 e um retry; descer errado custa um pouco de velocidade.
+pub fn next_concurrency(stats: &HostStats, current: u32) -> u32 {
+    let current = current.clamp(MIN_N, MAX_N);
+
+    // 429 domina qualquer medicao de velocidade. Nao adianta o throughput
+    // parecer bom se o host esta recusando.
+    if stats.rate_limit_hits > 0 {
+        let penalizado = current / 2u32.pow(stats.rate_limit_hits.min(3));
+        return penalizado.clamp(MIN_N, MAX_N);
+    }
+
+    let Some(atual) = stats.best_at(current) else {
+        return current; // sem medicao ainda: nao mexe
+    };
+
+    match stats.best_at(current.saturating_sub(1)) {
+        // Se um nivel abaixo era melhor, subir foi erro — desce.
+        Some(anterior) if anterior > atual * MEANINGFUL_GAIN => (current - 1).clamp(MIN_N, MAX_N),
+        _ => {
+            // Só sobe se o degrau anterior mostrou ganho real.
+            let vale_subir = match stats.best_at(current.saturating_sub(1)) {
+                Some(anterior) => atual > anterior * MEANINGFUL_GAIN,
+                None => true, // primeiro degrau medido: tenta subir uma vez
+            };
+            if vale_subir {
+                (current + 1).clamp(MIN_N, MAX_N)
+            } else {
+                current
+            }
+        }
+    }
+}
+
+/// Estado por host, para o ajuste sobreviver entre downloads.
+#[derive(Debug, Default)]
+pub struct ConcurrencyTuner {
+    hosts: HashMap<String, HostStats>,
+}
+
+impl ConcurrencyTuner {
+    pub fn record(&mut self, host: &str, concurrency: u32, throughput_bps: f64) {
+        self.hosts
+            .entry(host.to_string())
+            .or_default()
+            .record(concurrency, throughput_bps);
+    }
+
+    pub fn record_rate_limit(&mut self, host: &str) {
+        self.hosts
+            .entry(host.to_string())
+            .or_default()
+            .record_rate_limit();
+    }
+
+    /// `ceiling` e o numero de Config: vira **teto**, nao valor fixo.
+    pub fn suggest(&self, host: &str, current: u32, ceiling: u32) -> u32 {
+        let teto = ceiling.clamp(MIN_N, MAX_N);
+        match self.hosts.get(host) {
+            Some(stats) => next_concurrency(stats, current).min(teto),
+            None => current.min(teto),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MB: f64 = 1_000_000.0;
+
+    #[test]
+    fn sem_medicao_nenhuma_nao_mexe() {
+        // Ajustar sem dado seria adivinhar, que e o que a feature veio evitar.
+        let s = HostStats::default();
+        assert_eq!(next_concurrency(&s, 4), 4);
+    }
+
+    #[test]
+    fn sobe_quando_o_degrau_anterior_mostrou_ganho_real() {
+        let mut s = HostStats::default();
+        s.record(3, 3.0 * MB);
+        s.record(4, 5.0 * MB); // +66%, bem acima do ruido
+        assert_eq!(next_concurrency(&s, 4), 5);
+    }
+
+    #[test]
+    fn nao_sobe_atras_de_ruido() {
+        // 5% de diferenca se confunde com variacao normal de rede; subir por
+        // isso so aumenta a chance de 429 sem ganhar velocidade.
+        let mut s = HostStats::default();
+        s.record(3, 5.0 * MB);
+        s.record(4, 5.25 * MB);
+        assert_eq!(next_concurrency(&s, 4), 4);
+    }
+
+    #[test]
+    fn desce_quando_subir_piorou() {
+        let mut s = HostStats::default();
+        s.record(3, 8.0 * MB);
+        s.record(4, 5.0 * MB); // subir custou velocidade
+        assert_eq!(next_concurrency(&s, 4), 3);
+    }
+
+    #[test]
+    fn rate_limit_derruba_rapido_e_ignora_o_throughput() {
+        // Assimetria deliberada: subir errado custa 429 e retry, descer errado
+        // custa um pouco de velocidade. E throughput bom nao significa nada se
+        // o host esta recusando.
+        let mut s = HostStats::default();
+        s.record(8, 50.0 * MB);
+        s.record_rate_limit();
+        assert_eq!(next_concurrency(&s, 8), 4);
+
+        s.record_rate_limit();
+        assert_eq!(next_concurrency(&s, 8), 2);
+
+        s.record_rate_limit();
+        assert_eq!(next_concurrency(&s, 8), 1);
+    }
+
+    #[test]
+    fn nunca_sai_da_faixa() {
+        let mut s = HostStats::default();
+        s.record(16, 100.0 * MB);
+        s.record(15, 10.0 * MB);
+        assert_eq!(next_concurrency(&s, 16), MAX_N, "nao passa do teto");
+
+        let mut baixo = HostStats::default();
+        for _ in 0..10 {
+            baixo.record_rate_limit();
+        }
+        assert_eq!(next_concurrency(&baixo, 1), MIN_N, "nao vai abaixo de 1");
+    }
+
+    #[test]
+    fn amostra_ruim_nao_apaga_a_boa() {
+        // Interferencia local (outro download, wifi) nao e a capacidade real do
+        // nivel. Por isso o melhor, e nao a media.
+        let mut s = HostStats::default();
+        s.record(3, 3.0 * MB);
+        s.record(4, 5.0 * MB);
+        s.record(4, 0.1 * MB); // pico de interferencia
+        assert_eq!(next_concurrency(&s, 4), 5, "a amostra ruim nao deve mandar");
+    }
+
+    #[test]
+    fn medicao_invalida_e_descartada() {
+        let mut s = HostStats::default();
+        s.record(4, f64::NAN);
+        s.record(4, -1.0);
+        s.record(4, 0.0);
+        assert_eq!(next_concurrency(&s, 4), 4, "sem amostra valida, nao mexe");
+    }
+
+    #[test]
+    fn o_numero_de_config_vira_teto_e_nao_valor_fixo() {
+        // O ponto da feature: o usuario deixa de adivinhar um numero e passa a
+        // declarar um limite.
+        let mut t = ConcurrencyTuner::default();
+        t.record("youtube.com", 3, 3.0 * MB);
+        t.record("youtube.com", 4, 6.0 * MB);
+        assert_eq!(t.suggest("youtube.com", 4, 16), 5, "abaixo do teto, sobe");
+        assert_eq!(t.suggest("youtube.com", 4, 4), 4, "o teto segura");
+    }
+
+    #[test]
+    fn hosts_nao_contaminam_uns_aos_outros() {
+        // 429 do YouTube nao pode reduzir a concorrencia do Bilibili.
+        let mut t = ConcurrencyTuner::default();
+        t.record_rate_limit("youtube.com");
+        assert_eq!(t.suggest("youtube.com", 8, 16), 4);
+        assert_eq!(t.suggest("bilibili.com", 8, 16), 8);
+    }
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -17,6 +17,7 @@ pub use omniget_core::core::redirect;
 pub use omniget_core::core::registry;
 pub use omniget_core::core::ytdlp;
 
+pub mod adaptive_concurrency;
 pub mod awake;
 pub mod binary_versions;
 pub mod cas;
@@ -41,5 +42,6 @@ pub mod rpc;
 pub mod rules;
 pub mod silence_map;
 pub mod state_file;
+pub mod torrent_stream;
 pub mod trackers;
 pub mod url_parser;

--- a/src-tauri/src/core/torrent_stream.rs
+++ b/src-tauri/src/core/torrent_stream.rs
@@ -70,7 +70,7 @@ pub fn request_order(plan: &StreamPlan, have: &[bool]) -> Vec<u32> {
     let last = plan.total_pieces - 1;
     let mut order: Vec<u32> = Vec::new();
     let mut queued = std::collections::HashSet::new();
-    let mut push = |order: &mut Vec<u32>, queued: &mut std::collections::HashSet<u32>, p: u32| {
+    let push = |order: &mut Vec<u32>, queued: &mut std::collections::HashSet<u32>, p: u32| {
         if missing(&p) && queued.insert(p) {
             order.push(p);
         }
@@ -195,8 +195,8 @@ mod tests {
         let mut have = vec![false; 100];
         have[0] = true;
         have[99] = true;
-        for i in 0..20 {
-            have[i] = true;
+        for h in have.iter_mut().take(20) {
+            *h = true;
         }
         assert!(can_start_playback(&plan(100, 0), &have));
         assert!(
@@ -204,8 +204,8 @@ mod tests {
             "sem a janela do meio"
         );
 
-        for i in 60..68 {
-            have[i] = true;
+        for h in have.iter_mut().take(68).skip(60) {
+            *h = true;
         }
         assert!(can_start_playback(&plan(100, 60), &have));
     }

--- a/src-tauri/src/core/torrent_stream.rs
+++ b/src-tauri/src/core/torrent_stream.rs
@@ -1,0 +1,237 @@
+//! Ordem de peças para assistir um torrent enquanto ele baixa.
+//!
+//! Um torrent comum baixa as peças mais raras primeiro, que é ótimo para a
+//! saúde do enxame e péssimo para assistir: o arquivo só abre quando termina.
+//! Para streaming a ordem é outra, e a troca é explícita — pior para o enxame,
+//! utilizável para quem está esperando.
+//!
+//! A decisão de **qual peça pedir agora** é pura e testável. Falar com o
+//! `librqbit` e escrever no disco é I/O.
+//!
+//! Origem: rqbit, mais o primeira-e-última-peça do qBittorrent.
+
+use serde::Serialize;
+
+/// Quantas peças à frente da posição de leitura mantemos garantidas.
+///
+/// Oito: o suficiente para o player não parar em cada seek, sem travar o
+/// download inteiro esperando uma janela grande demais.
+pub const READAHEAD_PIECES: u32 = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Priority {
+    /// Sem isto o player nem abre o arquivo.
+    Critical,
+    /// Dentro da janela de leitura.
+    High,
+    /// O resto, em ordem.
+    Normal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamPlan {
+    pub total_pieces: u32,
+    /// Peça que a posição atual de reprodução exige.
+    pub playhead_piece: u32,
+}
+
+/// Prioridade de uma peça, dado o plano.
+///
+/// Primeira e última peça são críticas porque o container guarda o cabeçalho no
+/// início e, em MP4 não otimizado, o índice (`moov`) no fim. Sem as duas o
+/// player não consegue nem descobrir a duração, quanto mais fazer seek.
+pub fn priority_of(plan: &StreamPlan, piece: u32) -> Priority {
+    if plan.total_pieces == 0 {
+        return Priority::Normal;
+    }
+    let last = plan.total_pieces - 1;
+
+    if piece == 0 || piece == last {
+        return Priority::Critical;
+    }
+    if piece >= plan.playhead_piece && piece < plan.playhead_piece + READAHEAD_PIECES {
+        return Priority::High;
+    }
+    Priority::Normal
+}
+
+/// Ordem em que pedir as peças que ainda faltam.
+///
+/// Sequencial a partir do playhead, com as críticas na frente. O que ficou para
+/// trás vai para o fim: reproduzir já passou por ali, e só interessa para quem
+/// voltar.
+pub fn request_order(plan: &StreamPlan, have: &[bool]) -> Vec<u32> {
+    if plan.total_pieces == 0 {
+        return Vec::new();
+    }
+    let missing = |p: &u32| have.get(*p as usize).copied() != Some(true);
+
+    let last = plan.total_pieces - 1;
+    let mut order: Vec<u32> = Vec::new();
+    let mut queued = std::collections::HashSet::new();
+    let mut push = |order: &mut Vec<u32>, queued: &mut std::collections::HashSet<u32>, p: u32| {
+        if missing(&p) && queued.insert(p) {
+            order.push(p);
+        }
+    };
+
+    for critica in [0, last] {
+        push(&mut order, &mut queued, critica);
+    }
+    for p in plan.playhead_piece..plan.total_pieces {
+        push(&mut order, &mut queued, p);
+    }
+    for p in 0..plan.playhead_piece {
+        push(&mut order, &mut queued, p);
+    }
+    order
+}
+
+/// Dá para começar a assistir?
+///
+/// Exige as duas peças críticas mais a janela de leitura. Liberar antes faz o
+/// player abrir e travar em seguida, que é pior do que esperar — o usuário
+/// interpreta como aplicativo quebrado, não como download em andamento.
+pub fn can_start_playback(plan: &StreamPlan, have: &[bool]) -> bool {
+    if plan.total_pieces == 0 {
+        return false;
+    }
+    let last = plan.total_pieces - 1;
+    let tem = |p: u32| have.get(p as usize).copied() == Some(true);
+
+    if !tem(0) || !tem(last) {
+        return false;
+    }
+    let fim_janela = (plan.playhead_piece + READAHEAD_PIECES).min(plan.total_pieces);
+    (plan.playhead_piece..fim_janela).all(tem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan(total: u32, playhead: u32) -> StreamPlan {
+        StreamPlan {
+            total_pieces: total,
+            playhead_piece: playhead,
+        }
+    }
+
+    #[test]
+    fn primeira_e_ultima_peca_sao_criticas() {
+        // Cabeçalho no início, índice moov no fim. Sem as duas o player não
+        // descobre nem a duração.
+        let p = plan(100, 50);
+        assert_eq!(priority_of(&p, 0), Priority::Critical);
+        assert_eq!(priority_of(&p, 99), Priority::Critical);
+    }
+
+    #[test]
+    fn a_janela_a_frente_do_playhead_e_alta() {
+        let p = plan(100, 50);
+        assert_eq!(priority_of(&p, 50), Priority::High);
+        assert_eq!(priority_of(&p, 57), Priority::High);
+        assert_eq!(priority_of(&p, 58), Priority::Normal, "fora da janela");
+        assert_eq!(priority_of(&p, 49), Priority::Normal, "ja passou");
+    }
+
+    #[test]
+    fn pede_as_criticas_antes_de_qualquer_coisa() {
+        let p = plan(10, 5);
+        let have = vec![false; 10];
+        let ordem = request_order(&p, &have);
+        assert_eq!(&ordem[..2], &[0, 9], "criticas primeiro: {ordem:?}");
+        assert_eq!(ordem[2], 5, "depois sequencial do playhead");
+    }
+
+    #[test]
+    fn nao_pede_de_novo_o_que_ja_tem() {
+        let p = plan(6, 2);
+        let mut have = vec![false; 6];
+        have[0] = true;
+        have[5] = true;
+        have[3] = true;
+        let ordem = request_order(&p, &have);
+        assert_eq!(ordem, vec![2, 4, 1], "{ordem:?}");
+    }
+
+    #[test]
+    fn o_que_ficou_para_tras_vai_para_o_fim() {
+        // Reproduzir já passou por ali; só interessa para quem voltar.
+        let p = plan(8, 5);
+        let have = vec![false; 8];
+        let ordem = request_order(&p, &have);
+        let pos_de = |x: u32| ordem.iter().position(|&y| y == x).unwrap();
+        assert!(pos_de(6) < pos_de(1), "adiante antes de atras: {ordem:?}");
+        assert!(pos_de(6) < pos_de(4));
+    }
+
+    #[test]
+    fn nao_libera_a_reproducao_cedo_demais() {
+        // Abrir e travar em seguida é pior que esperar: o usuário lê como
+        // aplicativo quebrado, não como download em andamento.
+        let p = plan(100, 0);
+        let mut have = vec![false; 100];
+        have[0] = true;
+        assert!(
+            !can_start_playback(&p, &have),
+            "so a primeira peca nao basta"
+        );
+
+        have[99] = true;
+        assert!(!can_start_playback(&p, &have), "falta a janela de leitura");
+
+        for i in 0..READAHEAD_PIECES {
+            have[i as usize] = true;
+        }
+        assert!(can_start_playback(&p, &have));
+    }
+
+    #[test]
+    fn seek_para_o_meio_exige_a_janela_de_la() {
+        // O ponto do seek em arquivo parcial: ter o começo não ajuda em nada
+        // se o usuário pulou para o meio.
+        let mut have = vec![false; 100];
+        have[0] = true;
+        have[99] = true;
+        for i in 0..20 {
+            have[i] = true;
+        }
+        assert!(can_start_playback(&plan(100, 0), &have));
+        assert!(
+            !can_start_playback(&plan(100, 60), &have),
+            "sem a janela do meio"
+        );
+
+        for i in 60..68 {
+            have[i] = true;
+        }
+        assert!(can_start_playback(&plan(100, 60), &have));
+    }
+
+    #[test]
+    fn torrent_de_uma_peca_so_nao_quebra() {
+        let p = plan(1, 0);
+        assert_eq!(priority_of(&p, 0), Priority::Critical);
+        assert_eq!(request_order(&p, &[false]), vec![0]);
+        assert!(can_start_playback(&p, &[true]));
+    }
+
+    #[test]
+    fn plano_vazio_nao_libera_nem_estoura() {
+        let p = plan(0, 0);
+        assert!(request_order(&p, &[]).is_empty());
+        assert!(!can_start_playback(&p, &[]));
+        assert_eq!(priority_of(&p, 0), Priority::Normal);
+    }
+
+    #[test]
+    fn have_menor_que_o_total_nao_estoura_indice() {
+        // Estado parcial vindo do librqbit não pode derrubar o cálculo.
+        let p = plan(10, 3);
+        let have = vec![true; 2];
+        assert!(!can_start_playback(&p, &have));
+        assert!(!request_order(&p, &have).is_empty());
+    }
+}


### PR DESCRIPTION
Wave D: the two items that were parked as "needs real network". Both split the same way as the earlier waves — the decision is pure and tested, the measurement is I/O.

| Item | What it is | Tests |
|---|---|---|
| **B35** | Tune `-N` per host from measured throughput | 10 |
| **B46** | Piece order that lets a video play while it downloads | 10 |

**Tests 556 → 576.** Both main tests broken deliberately and observed failing.

## B35 — the Settings number becomes a ceiling

That number is a guess the user has to make without information: too high earns a 429, too low wastes bandwidth, and the right value depends on the host and the moment.

**This only became possible after B23.** Before it, `-N` and `--concurrent-fragments` fought each other and the effective value was not what the code believed — there was no trustworthy signal to feed back.

Design decisions the tests lock:

- **Rises slowly, falls fast.** Rising wrongly costs a 429 and a retry; falling wrongly costs a little speed.
- **A rate limit overrides any throughput reading.** Good numbers mean nothing while the host is refusing.
- **Best sample per level, not the average.** A bad reading is usually local interference — another download, wifi — not the real capacity of that level.
- **Ten percent floor for calling a difference real.** Below that it blends into normal network variation, and raising `-N` chasing noise only earns 429s.
- **Hosts do not contaminate each other.** A 429 from YouTube must not throttle Bilibili.

## B46 — playing before it finishes

A normal torrent fetches the rarest pieces first: good for swarm health, useless for watching. Stream order is the opposite and the trade is explicit — worse for the swarm, usable for the person waiting.

**First and last piece are critical** because the container keeps the header at the start and, in a non-faststart MP4, the `moov` index at the end. Without both, the player cannot even determine the duration, let alone seek.

**Playback is not released early.** Opening and then stalling is worse than waiting: the user reads it as a broken app rather than a download in progress. A seek to the middle requires the window from there — which is the whole point of seeking in a partial file, and is tested separately.

## Revert-and-see-red

| Item | Break | Failure |
|---|---|---|
| B35 | rate limit no longer overrides throughput | `rate_limit_derruba_rapido_e_ignora_o_throughput`, `hosts_nao_contaminam_uns_aos_outros` |
| B46 | playback released without the readahead window | `nao_libera_a_reproducao_cedo_demais`, `seek_para_o_meio_exige_a_janela_de_la` |

The B46 break did not register on the first attempt — the replacement string missed after `cargo fmt` reflowed the line. Re-applied with the anchor asserted, and it failed as expected. Worth noting because a break that silently fails to apply looks identical to a test that cannot fail.

## No UI yet

Both left entries in `docs/VALIDACAO-0.8.0.md`. The B46 entry includes stating the swarm trade-off in the interface — the user should know they are being a worse peer in exchange for watching early.
