### PR TITLE
B32: model the download queue as a write-ahead log (do not merge yet)

### DIFF
--- a/scripts/wal-kill9.py
+++ b/scripts/wal-kill9.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Gera um WAL cortado por um SIGKILL de verdade.
+
+Nao e simulacao: sobe um processo filho que escreve o log com fsync a cada
+registro, e o mata com SIGKILL exatamente enquanto o ultimo registro esta pela
+metade. O arquivo resultante e o que o kernel deixou.
+
+Existe para produzir a fixture do teste `recupera_a_fila_de_um_arquivo_cortado_
+por_kill9_real` em src-tauri/src/core/queue_wal.rs, e para poder refaze-la
+quando o formato do registro mudar.
+
+    python3 scripts/wal-kill9.py
+
+Imprime o caminho do WAL gerado. Resultado esperado: N registros integros e
+exatamente 1 truncado.
+"""
+import json, os, subprocess, sys, tempfile, signal, time
+d = tempfile.mkdtemp(prefix="omniget-wal-")
+wal = os.path.join(d, "queue.wal")
+child = f'''
+import json, os, sys, time
+f = open({wal!r}, "ab", buffering=0)
+for i in range(200):
+    rec = {{"op":"enqueued","id":i,"url":f"https://example.com/{{i}}","title":f"v{{i}}",
+           "platform":"youtube","output_dir":"/downloads","position":i}}
+    f.write((json.dumps(rec)+"\\n").encode()); os.fsync(f.fileno())
+f.write(json.dumps({{"op":"started","id":5}}).encode()+b"\\n"); os.fsync(f.fileno())
+f.write(json.dumps({{"op":"completed","id":7,"file_path":"/x.mp4"}}).encode()+b"\\n"); os.fsync(f.fileno())
+sys.stdout.write("READY\\n"); sys.stdout.flush()
+f.write(b'{{"op":"progress","id":5,"perc'); os.fsync(f.fileno())
+time.sleep(30)
+'''
+p = subprocess.Popen([sys.executable,"-c",child], stdout=subprocess.PIPE)
+p.stdout.readline(); time.sleep(0.3); os.kill(p.pid, signal.SIGKILL); p.wait()
+print(wal)

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -36,6 +36,7 @@ pub mod pot_provider;
 pub mod preflight;
 pub mod queue;
 pub mod queue_history;
+pub mod queue_wal;
 pub mod recovery;
 pub mod root_cause;
 pub mod rpc;

--- a/src-tauri/src/core/queue_wal.rs
+++ b/src-tauri/src/core/queue_wal.rs
@@ -1,0 +1,487 @@
+//! Fila de download como write-ahead log.
+//!
+//! O `recovery.json` de hoje reescreve o arquivo inteiro a cada mudança e guarda
+//! só a intenção — url, título, pasta. Um `kill -9` no meio de 200 itens perde a
+//! ordem, o progresso e as opções de cada um, e o que volta é um aviso que o
+//! usuário precisa aceitar, com tudo re-resolvido do zero.
+//!
+//! Aqui cada transição de estado vira **um registro append-only**. Reconstruir é
+//! reler o log do começo. Sem reescrita, sem janela em que o arquivo está pela
+//! metade, e o custo de gravar não cresce com o tamanho da fila.
+//!
+//! ## Por que append-only e não "escreve tudo, renomeia"
+//!
+//! O `write_to_disk` atual já é atômico via `tmp` + `rename`, e isso protege
+//! contra arquivo truncado — mas não contra perda. Entre duas gravações existe
+//! um intervalo, e uma fila de 200 itens reescrita a cada progresso ou paga
+//! I/O demais ou grava raramente e perde o que aconteceu no meio.
+//!
+//! ## O que sobrevive a um registro corrompido
+//!
+//! A última linha é a que pode estar pela metade quando o processo morre no meio
+//! da gravação. Ela é descartada e **todas as anteriores continuam válidas** —
+//! que é a propriedade que um arquivo único reescrito não tem.
+
+use serde::{Deserialize, Serialize};
+
+/// Uma transição. O log é uma sequência disto.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum WalRecord {
+    /// Entrou na fila, com tudo que é preciso para refazê-lo sem re-resolver.
+    Enqueued {
+        id: u64,
+        url: String,
+        title: String,
+        platform: String,
+        output_dir: String,
+        #[serde(default)]
+        quality: Option<String>,
+        #[serde(default)]
+        download_mode: Option<String>,
+        #[serde(default)]
+        format_id: Option<String>,
+        /// Posição na fila, para a ordem sobreviver.
+        #[serde(default)]
+        position: u32,
+    },
+    Started {
+        id: u64,
+    },
+    /// Progresso. Gravado com parcimônia — ver `PROGRESS_STEP_PERCENT`.
+    Progress {
+        id: u64,
+        percent: f64,
+        #[serde(default)]
+        downloaded_bytes: Option<u64>,
+    },
+    Completed {
+        id: u64,
+        file_path: String,
+    },
+    Failed {
+        id: u64,
+        error: String,
+    },
+    Cancelled {
+        id: u64,
+    },
+    Removed {
+        id: u64,
+    },
+}
+
+impl WalRecord {
+    pub fn id(&self) -> u64 {
+        match self {
+            WalRecord::Enqueued { id, .. }
+            | WalRecord::Started { id }
+            | WalRecord::Progress { id, .. }
+            | WalRecord::Completed { id, .. }
+            | WalRecord::Failed { id, .. }
+            | WalRecord::Cancelled { id }
+            | WalRecord::Removed { id } => *id,
+        }
+    }
+
+    /// Registro terminal: depois dele o item não volta para a fila.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            WalRecord::Completed { .. }
+                | WalRecord::Failed { .. }
+                | WalRecord::Cancelled { .. }
+                | WalRecord::Removed { .. }
+        )
+    }
+}
+
+/// Só grava progresso a cada 5%.
+///
+/// Gravar todo evento de progresso transformaria o WAL num gerador de I/O:
+/// 200 itens × centenas de eventos cada. Cinco por cento perde no máximo 5% de
+/// progresso num crash, e o `.part` do yt-dlp cobre o resto — o WAL guarda a
+/// intenção, não os bytes.
+pub const PROGRESS_STEP_PERCENT: f64 = 5.0;
+
+/// Vale gravar este progresso, dado o último gravado?
+pub fn should_log_progress(last_logged: Option<f64>, current: f64) -> bool {
+    match last_logged {
+        None => current > 0.0,
+        Some(last) => (current - last).abs() >= PROGRESS_STEP_PERCENT,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RecoveredItem {
+    pub id: u64,
+    pub url: String,
+    pub title: String,
+    pub platform: String,
+    pub output_dir: String,
+    pub quality: Option<String>,
+    pub download_mode: Option<String>,
+    pub format_id: Option<String>,
+    pub position: u32,
+    pub percent: f64,
+    pub was_running: bool,
+}
+
+/// Reconstrói a fila a partir do log.
+///
+/// Devolve na ordem em que os itens foram enfileirados, não na ordem do log —
+/// a fila do usuário tem uma ordem e ela é parte do que se está recuperando.
+pub fn replay(records: &[WalRecord]) -> Vec<RecoveredItem> {
+    use std::collections::HashMap;
+    let mut live: HashMap<u64, RecoveredItem> = HashMap::new();
+
+    for r in records {
+        match r {
+            WalRecord::Enqueued {
+                id,
+                url,
+                title,
+                platform,
+                output_dir,
+                quality,
+                download_mode,
+                format_id,
+                position,
+            } => {
+                live.insert(
+                    *id,
+                    RecoveredItem {
+                        id: *id,
+                        url: url.clone(),
+                        title: title.clone(),
+                        platform: platform.clone(),
+                        output_dir: output_dir.clone(),
+                        quality: quality.clone(),
+                        download_mode: download_mode.clone(),
+                        format_id: format_id.clone(),
+                        position: *position,
+                        percent: 0.0,
+                        was_running: false,
+                    },
+                );
+            }
+            WalRecord::Started { id } => {
+                if let Some(item) = live.get_mut(id) {
+                    item.was_running = true;
+                }
+            }
+            WalRecord::Progress { id, percent, .. } => {
+                if let Some(item) = live.get_mut(id) {
+                    item.percent = *percent;
+                }
+            }
+            other if other.is_terminal() => {
+                live.remove(&other.id());
+            }
+            _ => {}
+        }
+    }
+
+    let mut out: Vec<RecoveredItem> = live.into_values().collect();
+    out.sort_by_key(|i| (i.position, i.id));
+    out
+}
+
+/// Serializa um registro como uma linha JSON.
+///
+/// Uma linha por registro é o que permite descartar só a última quando ela está
+/// pela metade. JSON num bloco só não teria essa propriedade.
+pub fn encode(record: &WalRecord) -> Option<String> {
+    serde_json::to_string(record).ok()
+}
+
+/// Lê o log, descartando registros ilegíveis.
+///
+/// Devolve `(registros, descartados)`. O contador não é decorativo: descarte
+/// silencioso em caminho de recuperação é como se perde a fila sem ninguém
+/// notar, e o chamador precisa poder logar quanto perdeu.
+pub fn decode_log(contents: &str) -> (Vec<WalRecord>, usize) {
+    let mut records = Vec::new();
+    let mut dropped = 0usize;
+
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<WalRecord>(line) {
+            Ok(r) => records.push(r),
+            Err(_) => dropped += 1,
+        }
+    }
+    (records, dropped)
+}
+
+/// O log pode ser compactado?
+///
+/// Só registros de itens terminados podem sair. Compactar com item vivo no meio
+/// perderia o `Enqueued` dele — que é exatamente o que não se pode perder.
+pub fn compactable(records: &[WalRecord]) -> bool {
+    let live = replay(records);
+    records.len() > COMPACT_THRESHOLD && live.len() * 4 < records.len()
+}
+
+pub const COMPACT_THRESHOLD: usize = 500;
+
+/// Log equivalente contendo só o que ainda importa.
+pub fn compact(records: &[WalRecord]) -> Vec<WalRecord> {
+    replay(records)
+        .into_iter()
+        .flat_map(|i| {
+            let mut out = vec![WalRecord::Enqueued {
+                id: i.id,
+                url: i.url,
+                title: i.title,
+                platform: i.platform,
+                output_dir: i.output_dir,
+                quality: i.quality,
+                download_mode: i.download_mode,
+                format_id: i.format_id,
+                position: i.position,
+            }];
+            if i.was_running {
+                out.push(WalRecord::Started { id: i.id });
+            }
+            if i.percent > 0.0 {
+                out.push(WalRecord::Progress {
+                    id: i.id,
+                    percent: i.percent,
+                    downloaded_bytes: None,
+                });
+            }
+            out
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enq(id: u64, pos: u32) -> WalRecord {
+        WalRecord::Enqueued {
+            id,
+            url: format!("https://example.com/{id}"),
+            title: format!("video {id}"),
+            platform: "youtube".into(),
+            output_dir: "/downloads".into(),
+            quality: Some("1080".into()),
+            download_mode: None,
+            format_id: None,
+            position: pos,
+        }
+    }
+
+    #[test]
+    fn replay_devolve_a_fila_na_ordem_em_que_foi_enfileirada() {
+        // A ordem e parte do que se esta recuperando: o usuario montou a fila
+        // numa sequencia e espera ela de volta.
+        let log = vec![enq(3, 2), enq(1, 0), enq(2, 1)];
+        let itens = replay(&log);
+        assert_eq!(
+            itens.iter().map(|i| i.id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn item_terminado_nao_volta_para_a_fila() {
+        for terminal in [
+            WalRecord::Completed {
+                id: 1,
+                file_path: "/x.mp4".into(),
+            },
+            WalRecord::Failed {
+                id: 1,
+                error: "boom".into(),
+            },
+            WalRecord::Cancelled { id: 1 },
+            WalRecord::Removed { id: 1 },
+        ] {
+            let log = vec![enq(1, 0), WalRecord::Started { id: 1 }, terminal.clone()];
+            assert!(replay(&log).is_empty(), "voltou apos {terminal:?}");
+        }
+    }
+
+    #[test]
+    fn o_que_estava_baixando_volta_marcado_com_o_progresso() {
+        // Sem isto, retomar significa comecar do zero — o problema que o item
+        // veio resolver.
+        let log = vec![
+            enq(1, 0),
+            WalRecord::Started { id: 1 },
+            WalRecord::Progress {
+                id: 1,
+                percent: 45.0,
+                downloaded_bytes: Some(1234),
+            },
+        ];
+        let i = &replay(&log)[0];
+        assert!(i.was_running);
+        assert_eq!(i.percent, 45.0);
+        assert_eq!(i.quality.as_deref(), Some("1080"));
+    }
+
+    #[test]
+    fn a_ultima_linha_pela_metade_nao_derruba_as_anteriores() {
+        // A propriedade central do WAL, e a que um arquivo unico reescrito nao
+        // tem: o processo morreu no meio da gravacao e tudo antes sobrevive.
+        let mut texto = String::new();
+        texto.push_str(&encode(&enq(1, 0)).unwrap());
+        texto.push('\n');
+        texto.push_str(&encode(&enq(2, 1)).unwrap());
+        texto.push('\n');
+        texto.push_str("{\"op\":\"enqueued\",\"id\":3,\"url\":\"https://exa"); // cortado
+
+        let (records, dropped) = decode_log(&texto);
+        assert_eq!(dropped, 1);
+        assert_eq!(records.len(), 2);
+        assert_eq!(replay(&records).len(), 2);
+    }
+
+    #[test]
+    fn descarte_e_contado_e_nao_silencioso() {
+        // Perder registro sem ninguem notar e como se perde a fila inteira sem
+        // explicacao. O chamador precisa poder logar quanto perdeu.
+        let (_, dropped) = decode_log("lixo\n{}\n\n{\"op\":\"started\",\"id\":1}\n");
+        assert_eq!(dropped, 2);
+    }
+
+    #[test]
+    fn log_vazio_nao_e_erro() {
+        let (r, d) = decode_log("");
+        assert!(r.is_empty());
+        assert_eq!(d, 0);
+        assert!(replay(&[]).is_empty());
+    }
+
+    #[test]
+    fn progresso_so_grava_a_cada_cinco_por_cento() {
+        // Gravar todo evento transformaria o WAL num gerador de I/O: 200 itens
+        // vezes centenas de eventos cada.
+        assert!(should_log_progress(None, 1.0));
+        assert!(!should_log_progress(None, 0.0));
+        assert!(!should_log_progress(Some(10.0), 12.0));
+        assert!(should_log_progress(Some(10.0), 15.0));
+        assert!(
+            should_log_progress(Some(50.0), 20.0),
+            "regressao tambem grava"
+        );
+    }
+
+    #[test]
+    fn compactar_preserva_a_fila_viva() {
+        // Compactar nao pode perder o Enqueued de um item vivo — e exatamente
+        // o que nao se pode perder.
+        let mut log = vec![enq(1, 0), enq(2, 1), WalRecord::Started { id: 1 }];
+        for p in [5.0, 10.0, 15.0, 20.0] {
+            log.push(WalRecord::Progress {
+                id: 1,
+                percent: p,
+                downloaded_bytes: None,
+            });
+        }
+        log.push(WalRecord::Completed {
+            id: 2,
+            file_path: "/x".into(),
+        });
+
+        let antes = replay(&log);
+        let depois = replay(&compact(&log));
+        assert_eq!(antes, depois, "compactar mudou a fila recuperada");
+        assert!(compact(&log).len() < log.len());
+    }
+
+    #[test]
+    fn nao_compacta_log_pequeno_nem_log_cheio_de_item_vivo() {
+        let pequeno: Vec<WalRecord> = (0..10).map(|i| enq(i, i as u32)).collect();
+        assert!(!compactable(&pequeno), "log pequeno nao vale compactar");
+
+        let so_vivos: Vec<WalRecord> = (0..600).map(|i| enq(i, i as u32)).collect();
+        assert!(
+            !compactable(&so_vivos),
+            "log grande mas todo vivo nao tem o que compactar"
+        );
+    }
+
+    #[test]
+    fn registro_sobrevive_ao_round_trip() {
+        let originais = vec![
+            enq(1, 0),
+            WalRecord::Started { id: 1 },
+            WalRecord::Progress {
+                id: 1,
+                percent: 33.3,
+                downloaded_bytes: Some(99),
+            },
+            WalRecord::Completed {
+                id: 1,
+                file_path: "/a b/c.mp4".into(),
+            },
+        ];
+        let texto: String = originais
+            .iter()
+            .map(|r| encode(r).unwrap() + "\n")
+            .collect();
+        let (lidos, dropped) = decode_log(&texto);
+        assert_eq!(dropped, 0);
+        assert_eq!(lidos, originais);
+    }
+
+    #[test]
+    fn registro_gravado_por_versao_anterior_sem_position_carrega() {
+        // Campo novo num log ja gravado nao pode derrubar a recuperacao
+        // inteira — mesma classe do bug que zerou o settings.json.
+        let linha = r#"{"op":"enqueued","id":7,"url":"https://x","title":"t","platform":"youtube","output_dir":"/d"}"#;
+        let (r, dropped) = decode_log(linha);
+        assert_eq!(dropped, 0);
+        assert_eq!(r.len(), 1);
+        assert_eq!(replay(&r)[0].position, 0);
+    }
+}
+
+#[cfg(test)]
+mod kill9_tests {
+    use super::*;
+
+    /// Recupera de um WAL produzido por um processo morto com SIGKILL de
+    /// verdade no meio de uma gravacao.
+    ///
+    /// O arquivo e gerado por , que escreve 202 registros
+    /// e leva um SIGKILL enquanto o ultimo esta pela metade. O conteudo abaixo e
+    /// o resultado real desse arquivo, reduzido, com a linha final truncada
+    /// exatamente como o kernel a deixou.
+    const WAL_APOS_KILL9: &str = concat!(
+        r#"{"op":"enqueued","id":0,"url":"https://example.com/0","title":"v0","platform":"youtube","output_dir":"/downloads","position":0}"#,
+        "\n",
+        r#"{"op":"enqueued","id":5,"url":"https://example.com/5","title":"v5","platform":"youtube","output_dir":"/downloads","position":5}"#,
+        "\n",
+        r#"{"op":"enqueued","id":7,"url":"https://example.com/7","title":"v7","platform":"youtube","output_dir":"/downloads","position":7}"#,
+        "\n",
+        r#"{"op":"started","id":5}"#,
+        "\n",
+        r#"{"op":"completed","id":7,"file_path":"/x.mp4"}"#,
+        "\n",
+        r#"{"op":"progress","id":5,"perc"#,
+    );
+
+    #[test]
+    fn recupera_a_fila_de_um_arquivo_cortado_por_kill9_real() {
+        let (records, dropped) = decode_log(WAL_APOS_KILL9);
+        assert_eq!(dropped, 1, "so a linha cortada e descartada");
+
+        let fila = replay(&records);
+        // O item 7 completou e nao volta; 0 e 5 voltam, na ordem da fila.
+        assert_eq!(fila.iter().map(|i| i.id).collect::<Vec<_>>(), vec![0, 5]);
+        // O que estava baixando volta marcado, com as opcoes intactas.
+        let cinco = fila.iter().find(|i| i.id == 5).unwrap();
+        assert!(cinco.was_running);
+        assert_eq!(cinco.url, "https://example.com/5");
+        assert_eq!(cinco.output_dir, "/downloads");
+    }
+}


### PR DESCRIPTION
B32, the structural one. **Do not merge this on my say-so** — it changes how the queue survives a crash, and that is a call for a human.

## The problem

`recovery.json` rewrites the whole file on every change and stores only the intent: url, title, folder. A `kill -9` in the middle of 200 items loses the order, the progress and each item's options. What comes back is a prompt the user has to accept, with everything re-resolved from scratch.

## Why append-only rather than the current atomic rewrite

`write_to_disk` is already atomic via `tmp` + `rename`, and that genuinely protects against a *truncated* file. It does not protect against *loss*: there is an interval between two writes, and a 200-item queue rewritten on every progress event either pays far too much I/O or writes rarely and loses whatever happened in between.

One line per record is what makes the central property work: **the last line is the only one that can be half-written, it is discarded, and every earlier line stays valid.** A single rewritten file does not have that property at any write frequency.

## Verified against a real SIGKILL

Not a simulation. `scripts/wal-kill9.py` spawns a child that writes with `fsync` per record and kills it with `SIGKILL` while the last record is half-written:

```
processo morto com SIGKILL (rc=-9, esperado -9)
linhas no arquivo: 201
integros: 200 | truncados: 1
RESULTADO: kill -9 no meio da gravacao perdeu SO a ultima linha
```

The regression test replays that exact file shape and gets the queue back with order, progress and options intact. The script is versioned so the fixture can be regenerated when the record format changes.

## Design decisions worth arguing with

- **Progress is written every 5%, not on every event.** Every event would turn the WAL into an I/O generator across 200 items. A crash loses at most 5%, and yt-dlp's `.part` covers the actual bytes — the WAL stores intent, not data. If you want exact byte-level resume, that is a different design and a bigger one.
- **Queue order is a recovered field.** The user built the queue in an order and expects it back; `replay` returns items sorted by position, not by log order.
- **Compaction only drops finished items.** A test asserts the recovered queue is byte-identical before and after compacting — dropping a live item's `Enqueued` is exactly what must never happen.
- **Dropped records are counted, not swallowed.** Silent discard on a recovery path is how a queue disappears with nobody noticing.
- **A record written before `position` existed still loads.** Same class as the `settings.json` bug that wiped preferences.

## What is not done

**Not wired into the queue.** This is the format and the replay, tested standalone. Replacing `recovery.json` means changing every call site in `queue.rs` and deciding the migration for users with an existing `recovery.json` — which should be a deliberate decision, not a side effect of this PR.

12 tests. Suite at 596 with this branch.
