### PR TITLE
feat: WebView2 fixed runtime ao lado do exe (#218) + omniget-cli nas releases (#202)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,75 @@ jobs:
           }
         shell: pwsh
 
+  build-cli:
+    # O omniget-cli existe no workspace desde sempre mas nunca saiu numa
+    # release, entao a unica forma de usar era compilar da fonte (issue #202).
+    # Nao depende do publish-tauri: sao binarios independentes, e o CLI nao
+    # precisa de webkit/gtk (arvore de dependencias sem openssl-sys), so do
+    # toolchain — por isso nao ha instalacao de dependencia de sistema aqui.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build CLI
+        working-directory: src-tauri
+        run: cargo build -p omniget-cli --release --target ${{ matrix.target }}
+
+      - name: Package and upload (unix)
+        if: matrix.os != 'windows-latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          BIN="src-tauri/target/${{ matrix.target }}/release/omniget-cli"
+          # Falha alto se o binario nao existe: subir uma release sem o
+          # artefato e pior do que o job ficar vermelho.
+          test -x "$BIN"
+          "$BIN" --version
+          OUT="omniget-cli-${VERSION}-${{ matrix.target }}.tar.gz"
+          tar -czf "$OUT" -C "$(dirname "$BIN")" omniget-cli
+          gh release upload "$TAG" "$OUT" --repo "${{ github.repository }}" --clobber
+
+      - name: Package and upload (windows)
+        if: matrix.os == 'windows-latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $TAG = "${{ github.ref_name }}"
+          $VERSION = $TAG -replace '^v', ''
+          $BIN = "src-tauri/target/${{ matrix.target }}/release/omniget-cli.exe"
+          if (-not (Test-Path $BIN)) { throw "binario nao encontrado: $BIN" }
+          & $BIN --version
+          $OUT = "omniget-cli-${VERSION}-${{ matrix.target }}.zip"
+          Compress-Archive -Path $BIN -DestinationPath $OUT -Force
+          gh release upload $TAG $OUT --repo ${{ github.repository }} --clobber
+        shell: pwsh
+
   package-chrome-extension:
     needs: publish-tauri
     runs-on: ubuntu-latest

--- a/src-tauri/src/core/portable.rs
+++ b/src-tauri/src/core/portable.rs
@@ -119,6 +119,141 @@ mod tests {
     }
 }
 
+/// Nome de pasta que o instalador do Fixed Version Runtime produz.
+///
+/// O pacote da Microsoft descompacta como
+/// `Microsoft.WebView2.FixedVersionRuntime.{versao}.{arch}`. Aceitamos tambem
+/// `WebView2Runtime`, que e o nome curto que da para documentar sem pedir para
+/// o usuario digitar uma versao.
+fn parece_runtime_fixo(name: &str) -> bool {
+    name.eq_ignore_ascii_case("WebView2Runtime")
+        || name
+            .to_ascii_lowercase()
+            .starts_with("microsoft.webview2.fixedversionruntime.")
+}
+
+/// Versao embutida no nome da pasta, para ordenar quando ha mais de uma.
+///
+/// Retorna vazio para `WebView2Runtime` (sem versao no nome), o que o coloca
+/// abaixo de qualquer pasta versionada — quem descompactou uma versao explicita
+/// provavelmente quer aquela.
+fn versao_do_nome(name: &str) -> Vec<u32> {
+    name.split('.')
+        .filter_map(|p| p.parse::<u32>().ok())
+        .collect()
+}
+
+/// Procura um WebView2 Fixed Version Runtime ao lado do executavel.
+///
+/// Exige o `msedgewebview2.exe` dentro da pasta: apontar o loader para um
+/// diretorio que so parece certo pelo nome falha *depois*, na criacao da janela,
+/// e ai o app nao abre — pior do que simplesmente usar o runtime do sistema.
+///
+/// Pedido na issue #218. Funciona em conjunto com o modo portatil (#195): um
+/// pendrive com o runtime ao lado do exe roda em Windows sem WebView2 instalado.
+pub fn find_fixed_runtime(exe_dir: &Path) -> Option<PathBuf> {
+    let mut achados: Vec<(Vec<u32>, PathBuf)> = std::fs::read_dir(exe_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            if !parece_runtime_fixo(&name) {
+                return None;
+            }
+            let dir = e.path();
+            if !dir.join("msedgewebview2.exe").exists() {
+                return None;
+            }
+            Some((versao_do_nome(&name), dir))
+        })
+        .collect();
+
+    achados.sort_by(|a, b| a.0.cmp(&b.0));
+    achados.pop().map(|(_, dir)| dir)
+}
+
+#[cfg(test)]
+mod runtime_fixo_tests {
+    use super::*;
+
+    fn cria_runtime(raiz: &Path, nome: &str, com_exe: bool) {
+        let dir = raiz.join(nome);
+        std::fs::create_dir_all(&dir).expect("cria pasta");
+        if com_exe {
+            std::fs::write(dir.join("msedgewebview2.exe"), b"stub").expect("cria exe");
+        }
+    }
+
+    fn tempdir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("omniget-rt-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).expect("cria tempdir");
+        d
+    }
+
+    #[test]
+    fn sem_runtime_ao_lado_nao_inventa_caminho() {
+        let d = tempdir("vazio");
+        std::fs::write(d.join("omniget.exe"), b"stub").expect("cria exe");
+        assert_eq!(find_fixed_runtime(&d), None);
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn pasta_sem_o_binario_e_recusada() {
+        // O caso que quebra o app se aceito: nome certo, conteudo ausente.
+        let d = tempdir("sem-exe");
+        cria_runtime(&d, "WebView2Runtime", false);
+        assert_eq!(
+            find_fixed_runtime(&d),
+            None,
+            "nome certo sem msedgewebview2.exe nao pode ser aceito"
+        );
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn nome_curto_e_aceito() {
+        let d = tempdir("curto");
+        cria_runtime(&d, "WebView2Runtime", true);
+        assert_eq!(find_fixed_runtime(&d), Some(d.join("WebView2Runtime")));
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn nome_do_instalador_da_microsoft_e_aceito() {
+        let d = tempdir("ms");
+        let nome = "Microsoft.WebView2.FixedVersionRuntime.120.0.2210.91.x64";
+        cria_runtime(&d, nome, true);
+        assert_eq!(find_fixed_runtime(&d), Some(d.join(nome)));
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn com_duas_versoes_escolhe_a_maior() {
+        let d = tempdir("duas");
+        let velha = "Microsoft.WebView2.FixedVersionRuntime.109.0.1518.78.x64";
+        let nova = "Microsoft.WebView2.FixedVersionRuntime.120.0.2210.91.x64";
+        // Criada em ordem inversa para que "pegar a primeira" nao passe por acaso.
+        cria_runtime(&d, nova, true);
+        cria_runtime(&d, velha, true);
+        let got = find_fixed_runtime(&d).expect("achou runtime");
+        assert_eq!(got, d.join(nova));
+        assert_ne!(got, d.join(velha), "109 nao pode ganhar de 120");
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    #[test]
+    fn pasta_qualquer_ao_lado_e_ignorada() {
+        let d = tempdir("ruido");
+        cria_runtime(&d, "plugins", true);
+        cria_runtime(&d, "data", true);
+        assert_eq!(find_fixed_runtime(&d), None);
+        let _ = std::fs::remove_dir_all(&d);
+    }
+}
+
 /// Linha unica de boot, emitida antes de qualquer coisa poder sair em silencio.
 ///
 /// O `tauri-plugin-single-instance` chama `std::process::exit(0)` sem logar nada

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -56,8 +56,32 @@ fn setup_environment() {
     }
 }
 
+/// Usa um WebView2 Fixed Version Runtime descompactado ao lado do executavel.
+///
+/// Issue #218. O Tauri so define `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` quando o
+/// bundle e compilado em modo `fixedRuntime` (`app.rs`), e nunca a limpa — entao
+/// definir aqui funciona, ao contrario do `WEBVIEW2_USER_DATA_FOLDER`, que o
+/// Tauri sobrescrevia (ver `core/portable.rs`). Nao mexe se o usuario ja definiu.
+#[cfg(windows)]
+fn check_fixed_webview_runtime() {
+    if std::env::var_os("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER").is_some() {
+        return;
+    }
+    let Some(dir) = std::env::current_exe()
+        .ok()
+        .and_then(|e| e.parent().map(|p| p.to_path_buf()))
+    else {
+        return;
+    };
+    if let Some(runtime) = omniget_lib::core::portable::find_fixed_runtime(&dir) {
+        std::env::set_var("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER", &runtime);
+    }
+}
+
 fn main() {
     check_portable_mode();
+    #[cfg(windows)]
+    check_fixed_webview_runtime();
     setup_environment();
     omniget_lib::run()
 }


### PR DESCRIPTION
Fecha duas issues abertas.

## #218 — WebView2 Fixed Version Runtime ao lado do executável

@xmha97 pediu para o app usar um runtime WebView2 empacotado, colocado ao lado do exe. Hoje isso não é detectado.

A lição do #195 era não confiar em variável de ambiente sem checar se o Tauri a sobrescreve. Verifiquei na fonte (`tauri-2.10.2/src/app.rs:2176`):

```rust
if let WebviewInstallMode::FixedRuntime { path } = &manager.config.bundle.windows.webview_install_mode {
    std::env::set_var("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER", exe_dir.join(path));
}
```

O Tauri **só define** essa variável no modo `fixedRuntime`, e **nunca a limpa**. Ou seja: ao contrário do `WEBVIEW2_USER_DATA_FOLDER`, defini-la no boot funciona. É por isso que este item é implementável e o anterior exigiu reestruturar a criação da janela.

A pasta só é aceita se contiver `msedgewebview2.exe`. Aceitar pelo nome faria o app falhar **depois**, na criação da janela — pior do que simplesmente usar o runtime do sistema. Com duas versões ao lado, escolhe a maior.

Aceita `WebView2Runtime` (nome curto, documentável) e `Microsoft.WebView2.FixedVersionRuntime.*` (o que o instalador da Microsoft produz).

## #202 — `omniget-cli` nas releases

O binário existe no workspace com `info`/`download`/`batch`/`import-cookies` funcionando, mas nunca saiu numa release. Novo job `build-cli` para os 4 alvos.

Não depende do `publish-tauri` e não instala dependência de sistema — confirmei que a árvore não tem `openssl-sys`, `gtk` nem `webkit`, é rustls puro. Binário de 7,7 MB. O job roda `--version` antes de subir e falha alto se o artefato não existe: publicar uma release sem o binário é pior do que o job ficar vermelho.

**Os READMEs continuam dizendo "build it yourself" de propósito.** Só faz sentido tirar o aviso quando uma release realmente tiver o binário anexado — a v0.7.7 não tem. Prometer artefato inexistente é exatamente o que a issue pedia para evitar.

## Verificação

- 6 testes novos, workspace **576 → 582**, 0 falhando
- Portão de clippy: `92 warnings, none new`
- `--version` do CLI executado localmente: os 4 subcomandos aparecem
- Revert-e-veja-vermelho na ordenação de versão: inverti o `sort_by`, `com_duas_versoes_escolhe_a_maior` reprovou, restaurei

## Não verificado

**Nada disto foi visto rodando no Windows.** A lógica de descoberta é pura e testada em qualquer plataforma (`std::fs` num tempdir), mas o `set_var` está atrás de `cfg(windows)` e nunca executou numa máquina Windows. Mesma lacuna do #209 — entra na `docs/VALIDACAO-0.8.0.md`.

O job `build-cli` nunca rodou: workflow de release só dispara em tag.