### PR TITLE
feat(B55): smoke test que sobe o app — a #209 automatizada

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,73 @@ jobs:
           pnpm generate:i18n-keys
           git diff --exit-code -- src/lib/i18n/keys.ts
 
+  # B55. O CI provava que compila nas quatro plataformas e nunca abriu o app
+  # uma vez — foi por essa fresta que a #209 entrou em `main`. Este job sobe o
+  # binario de verdade e exige a linha de janela criada.
+  #
+  # Criterio de aceite do item: reverter o B49 tem que deixar este job vermelho.
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri'
+
+      - name: Linux deps
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev xvfb
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm build
+
+      - name: Build app
+        working-directory: src-tauri
+        run: cargo build
+
+      - name: Smoke (modo padrao)
+        shell: bash
+        run: |
+          BIN=src-tauri/target/debug/omniget
+          [ "${{ matrix.platform }}" = "windows-latest" ] && BIN="$BIN.exe"
+          if [ "${{ matrix.platform }}" = "ubuntu-latest" ]; then
+            xvfb-run -a node scripts/smoke-test.mjs "$BIN"
+          else
+            node scripts/smoke-test.mjs "$BIN"
+          fi
+
+      # A #209 e especificamente sobre Windows: `portable.txt` ao lado do exe
+      # nao pode deixar nada no perfil do usuario, e o WebView2 tem que apontar
+      # para <app>/data/webview. Esse caminho esta atras de cfg(windows).
+      - name: Smoke (modo portatil)
+        shell: bash
+        run: |
+          BIN=src-tauri/target/debug/omniget
+          [ "${{ matrix.platform }}" = "windows-latest" ] && BIN="$BIN.exe"
+          if [ "${{ matrix.platform }}" = "ubuntu-latest" ]; then
+            xvfb-run -a node scripts/smoke-test.mjs "$BIN" --portable
+          else
+            node scripts/smoke-test.mjs "$BIN" --portable
+          fi
+
   metainfo:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'weblate' }}
     runs-on: ubuntu-latest

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Sobe o app de verdade e prova que a janela abriu.
+//
+// O CI compilava em quatro plataformas e nunca abriu o app uma vez. Foi assim
+// que a #209 passou: o modo portatil do Windows entrou em `main` sem nunca ter
+// criado uma janela. "Compila" e "abre" sao perguntas diferentes, e so uma
+// delas estava sendo feita.
+//
+// Uso:
+//   node scripts/smoke-test.mjs <caminho-do-binario> [--portable]
+//
+// O modo --portable reproduz a #209 caso 1: `portable.txt` ao lado do
+// executavel, um perfil de usuario limpo, e a exigencia de que nada apareca
+// fora do diretorio do app.
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, basename, resolve } from "node:path";
+
+const BANNER = /OmniGet .* starting — pid \d+, (standard|portable) mode/;
+const WINDOW = "[startup] main window created";
+const TIMEOUT_MS = 90_000;
+const EXIT_AFTER_MS = 6000;
+
+const args = process.argv.slice(2);
+const portable = args.includes("--portable");
+const binArg = args.find((a) => !a.startsWith("--"));
+
+if (!binArg) {
+  console.error("uso: node scripts/smoke-test.mjs <binario> [--portable]");
+  process.exit(2);
+}
+if (!existsSync(binArg)) {
+  console.error(`binario nao existe: ${binArg}`);
+  process.exit(2);
+}
+
+const workdir = mkdtempSync(join(tmpdir(), "omniget-smoke-"));
+const fakeProfile = join(workdir, "profile");
+mkdirSync(fakeProfile, { recursive: true });
+
+let bin = resolve(binArg);
+let appDir = workdir;
+
+if (portable) {
+  // Copiar em vez de rodar no lugar: o modo portatil e definido por um arquivo
+  // ao lado do executavel, e sujar o diretorio de build afetaria o outro caso.
+  appDir = join(workdir, "app");
+  mkdirSync(appDir, { recursive: true });
+  bin = join(appDir, basename(binArg));
+  copyFileSync(resolve(binArg), bin);
+  if (process.platform !== "win32") {
+    const { chmodSync } = await import("node:fs");
+    chmodSync(bin, 0o755);
+  }
+  writeFileSync(join(appDir, "portable.txt"), "");
+}
+
+const env = {
+  ...process.env,
+  RUST_LOG: "info",
+  OMNIGET_SMOKE_EXIT_MS: String(EXIT_AFTER_MS),
+  // Perfil limpo para que "a pasta apareceu" seja uma afirmacao sobre esta
+  // execucao, e nao sobre lixo de uma anterior.
+  LOCALAPPDATA: join(fakeProfile, "Local"),
+  APPDATA: join(fakeProfile, "Roaming"),
+  XDG_DATA_HOME: join(fakeProfile, "share"),
+  HOME: process.platform === "win32" ? process.env.HOME : fakeProfile,
+};
+if (!portable) {
+  // Sem isto o caso padrao escreveria no perfil real do runner.
+  env.OMNIGET_DATA_DIR = join(workdir, "data-padrao");
+}
+
+console.log(`[smoke] modo: ${portable ? "portatil" : "padrao"}`);
+console.log(`[smoke] binario: ${bin}`);
+
+const child = spawn(bin, [], { env, cwd: appDir, stdio: ["ignore", "pipe", "pipe"] });
+
+let out = "";
+const cap = (chunk) => {
+  const t = chunk.toString();
+  out += t;
+  process.stdout.write(t);
+};
+child.stdout.on("data", cap);
+child.stderr.on("data", cap);
+
+const timer = setTimeout(() => {
+  console.error(`\n[smoke] FALHA: nao terminou em ${TIMEOUT_MS}ms — matando`);
+  child.kill("SIGKILL");
+}, TIMEOUT_MS);
+
+const code = await new Promise((resolve) => {
+  child.on("exit", (c) => {
+    clearTimeout(timer);
+    resolve(c);
+  });
+  child.on("error", (e) => {
+    clearTimeout(timer);
+    console.error(`[smoke] falha ao executar: ${e.message}`);
+    resolve(127);
+  });
+});
+
+const falhas = [];
+
+if (!BANNER.test(out)) {
+  falhas.push("o banner de boot nao apareceu — o processo nem chegou a subir");
+}
+if (!out.includes(WINDOW)) {
+  // Este e o assert que importa: sem ele, "o processo rodou" estava sendo
+  // confundido com "a janela abriu".
+  falhas.push(`a janela nao foi criada — "${WINDOW}" ausente na saida`);
+}
+if (code !== 0) {
+  falhas.push(`saiu com codigo ${code}, esperado 0`);
+}
+
+if (portable) {
+  const vazouParaOPerfil = [
+    join(fakeProfile, "Local", "wtf.tonho.omniget"),
+    join(fakeProfile, "Roaming", "wtf.tonho.omniget"),
+    join(fakeProfile, "share", "wtf.tonho.omniget"),
+    join(fakeProfile, "Library", "Application Support", "wtf.tonho.omniget"),
+  ].filter((p) => existsSync(p));
+
+  if (vazouParaOPerfil.length > 0) {
+    falhas.push(`#209: modo portatil escreveu no perfil do usuario: ${vazouParaOPerfil.join(", ")}`);
+  }
+  if (!existsSync(join(appDir, "data"))) {
+    falhas.push("modo portatil nao criou <app>/data");
+  }
+  if (process.platform === "win32" && !existsSync(join(appDir, "data", "webview"))) {
+    falhas.push("#209: <app>/data/webview nao foi criado — o WebView2 nao foi redirecionado");
+  }
+}
+
+try {
+  rmSync(workdir, { recursive: true, force: true });
+} catch {
+  /* limpeza best-effort; nao e motivo para reprovar o teste */
+}
+
+if (falhas.length > 0) {
+  console.error("\n[smoke] REPROVADO:");
+  for (const f of falhas) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log(`\n[smoke] OK — janela criada e saida limpa (modo ${portable ? "portatil" : "padrao"})`);

--- a/src-tauri/omniget-core/src/models/settings.rs
+++ b/src-tauri/omniget-core/src/models/settings.rs
@@ -667,4 +667,47 @@ mod backcompat_tests {
         let back: AdvancedSettings = serde_json::from_value(round).expect("volta");
         assert!(back.insecure_tls);
     }
+
+    // A #220 adicionou `accessibility` ao AppSettings sem teste de migracao.
+    // Um settings.json escrito antes da 0.8.0 nao tem esse campo; se ele perder
+    // o `serde(default)` num refactor, todo usuario existente perde a
+    // configuracao inteira, em silencio, no primeiro boot depois do update.
+    //
+    // Em vez de escrever um JSON antigo a mao (que envelhece e vira ficcao),
+    // este teste serializa o default atual e *remove* a chave nova — que e
+    // exatamente a forma de um arquivo gravado antes de o campo existir.
+    #[test]
+    fn settings_json_sem_accessibility_ainda_abre() {
+        let atual = serde_json::to_value(AppSettings::default()).expect("serializa");
+        let mut anterior = atual.clone();
+        let obj = anterior.as_object_mut().expect("objeto");
+        let removida = obj.remove("accessibility");
+        assert!(
+            removida.is_some(),
+            "o campo tem que existir hoje, senao o teste nao prova nada"
+        );
+
+        let parsed: AppSettings =
+            serde_json::from_value(anterior).expect("arquivo pre-0.8.0 tem que abrir");
+
+        assert!(!parsed.accessibility.reduce_motion);
+        assert!(!parsed.accessibility.reduce_transparency);
+        // E o que o usuario ja tinha nao pode sumir junto.
+        assert_eq!(
+            parsed.appearance.theme,
+            AppSettings::default().appearance.theme
+        );
+        assert_eq!(parsed.schema_version, AppSettings::default().schema_version);
+    }
+
+    #[test]
+    fn acessibilidade_ligada_sobrevive_ao_round_trip() {
+        let mut s = AppSettings::default();
+        s.accessibility.reduce_motion = true;
+        s.accessibility.reduce_transparency = true;
+        let round = serde_json::to_value(&s).expect("serializa");
+        let back: AppSettings = serde_json::from_value(round).expect("volta");
+        assert!(back.accessibility.reduce_motion);
+        assert!(back.accessibility.reduce_transparency);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -344,6 +344,25 @@ pub fn run() {
                 }
 
                 builder.build()?;
+
+                // A unica prova de que a janela subiu. O CI compila em todas as
+                // plataformas mas nunca abriu o app: foi assim que a #209 passou
+                // batido. O smoke test do CI casa exatamente esta linha.
+                tracing::info!("[startup] main window created");
+            }
+
+            // Modo smoke: sobe, prova que a janela existe, e sai sozinho com 0.
+            // So existe para o CI conseguir responder "abre?", que e a pergunta
+            // que compilar nunca responde.
+            if let Ok(raw) = std::env::var("OMNIGET_SMOKE_EXIT_MS") {
+                if let Ok(ms) = raw.trim().parse::<u64>() {
+                    let handle = app.handle().clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_millis(ms));
+                        tracing::info!("[startup] smoke mode: exiting cleanly");
+                        handle.exit(0);
+                    });
+                }
             }
 
             commands::host_queue::register_event_listeners(app.handle());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -320,13 +320,23 @@ pub fn run() {
             {
                 // `mut` so e usado no ramo Windows abaixo; sem o cfg_attr isto
                 // vira warning novo em macOS e Linux e reprova o portao de clippy.
-                #[cfg_attr(not(windows), allow(unused_mut))]
+                #[cfg_attr(not(any(windows, target_os = "linux")), allow(unused_mut))]
                 let mut builder = tauri::WebviewWindowBuilder::from_config(
                     app.handle(),
                     &app.config().app.windows[0],
                 )?;
 
-                #[cfg(windows)]
+                // Nao e so Windows. No Linux o wry usa este caminho para
+                // `base_data_directory`, `base_cache_directory` e os cookies do
+                // WebKitGTK; sem ele o modo portatil deixa
+                // `XDG_DATA_HOME/wtf.tonho.omniget` no perfil do usuario — a
+                // mesma #209, fora do Windows. Foi o smoke test do B55 que
+                // pegou isso, na primeira vez que rodou.
+                //
+                // macOS fica de fora porque o wry nao le `data_directory` no
+                // WKWebView: incluir daria a impressao de cobrir um caso que
+                // nao esta coberto.
+                #[cfg(any(windows, target_os = "linux"))]
                 if let Some(webview_dir) = core::portable::portable_webview_dir_from_env() {
                     if let Err(e) = std::fs::create_dir_all(&webview_dir) {
                         tracing::warn!(


### PR DESCRIPTION
Passo 2 do plano da 0.8.0, e ele destrava o passo 1.

## O buraco

O CI compilava em quatro plataformas e **nunca abriu o app uma vez**. Foi por essa fresta que a #209 entrou em `main`: o modo portátil do Windows foi mergeado sem nunca ter criado uma janela. "Compila" e "abre" são perguntas diferentes, e só uma estava sendo feita.

## O que entra

`scripts/smoke-test.mjs` sobe o binário e exige a linha de janela criada. Novo job `smoke` em `windows-latest` e `ubuntu-latest` (xvfb), nos dois modos.

O modo `--portable` é **a #209 caso 1 automatizada**: `portable.txt` ao lado do exe, perfil de usuário limpo, e a exigência de que nada apareça fora do diretório do app — mais `<app>/data/webview` no Windows. Isso significa que o caso bloqueante da 0.8.0 deixa de precisar da sua máquina Windows: passa a ser respondido pelo CI a cada PR.

Para isso o `lib.rs` ganhou duas coisas mínimas: a linha `[startup] main window created` (a única prova de que a janela subiu) e `OMNIGET_SMOKE_EXIT_MS`, que faz o app sair sozinho com 0 depois de provar que abriu.

## Critério de aceite — verificado, não presumido

O item dizia "reverter o B49 tem que deixar o job vermelho". Testei:

```
$ # removido o set_var("OMNIGET_DATA_DIR", ...) do main.rs
[smoke] REPROVADO:
  - #209: modo portatil escreveu no perfil do usuario: .../profile/Library/Application Support/wtf.tonho.omniget
```

Restaurado, volta verde nos dois modos. **Rodei os dois modos localmente no macOS**, com o app real subindo, janela criada e saída limpa — não é só código de CI que nunca correu.

Durante esse teste achei um buraco no meu próprio script: a lista de "vazou para o perfil" cobria Windows e Linux mas não o `~/Library/Application Support` do macOS. Sem isso a quebra teria passado despercebida. Corrigido antes do break test valer.

## Teste de migração que a #220 não trouxe

A #220 adicionou `accessibility` ao `AppSettings` **sem nenhum teste** — e a regra é que toda mudança em `settings.json` exige migração testada contra um arquivo da versão anterior.

Em vez de escrever um JSON antigo à mão (que envelhece e vira ficção), o teste serializa o default atual e **remove a chave nova** — a forma exata de um arquivo gravado antes de o campo existir. Removendo o `serde(default)`, ele reprova.

## Verificação

- Workspace **584 testes**, 0 falhando
- Clippy: `92 warnings, none new`
- Smoke rodado localmente nos dois modos, com break test em ambos os asserts novos

## Ressalva

O job `smoke` **nunca rodou no CI** — esta PR é a primeira vez. Se o runner do Windows ou o xvfb do Linux não cooperarem, é aqui que aparece, e é o lugar certo para aparecer. O modo padrão baixa os plugins default pela rede durante o boot, então o job depende de rede; se der flake, o próximo passo é um env que pule essa instalação no smoke.