### PR TITLE
fix(ci): build-cli usava o toolchain errado para instalar o alvo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,13 @@ jobs:
   build-cli:
     # O omniget-cli existe no workspace desde sempre mas nunca saiu numa
     # release, entao a unica forma de usar era compilar da fonte (issue #202).
-    # Nao depende do publish-tauri: sao binarios independentes, e o CLI nao
-    # precisa de webkit/gtk (arvore de dependencias sem openssl-sys), so do
-    # toolchain — por isso nao ha instalacao de dependencia de sistema aqui.
+    #
+    # `needs: publish-tauri` porque o upload precisa da release existir — quem a
+    # cria e o publish-tauri. A *compilacao* e independente (o CLI nao precisa de
+    # webkit/gtk: a arvore nao tem openssl-sys), e foi essa independencia que me
+    # fez omitir o needs na #221. O resultado foi `release not found` na v0.8.0,
+    # com o binario compilado e jogado fora.
+    needs: publish-tauri
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      # `@master` com a versao fixada, e nao `@stable`: o rust-toolchain.toml da
+      # raiz forca 1.97.0, entao instalar o alvo no `stable` deixa a build usando
+      # um toolchain que nao tem o alvo — `can't find crate for core` na primeira
+      # release. O publish-tauri ja fazia assim; este job nao seguiu o padrao.
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.97.0
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
A release da v0.8.0 reprovou em `build-cli (macos-latest, x86_64-apple-darwin)`:

```
error[E0463]: can't find crate for `core`
error: could not compile `cfg-if` (lib) due to 1 previous error
```

**Causa:** o job que adicionei na #221 usava `dtolnay/rust-toolchain@stable`, mas existe um `rust-toolchain.toml` na raiz fixando `1.97.0` — e por um motivo forte, documentado no próprio arquivo:

> Rust guarantees no ABI stability across compiler releases, so a host and a plugin built with different rustc versions corrupt vtables and segfault at the first plugin call.

Então o `targets:` instalava o alvo no `stable` enquanto o `cargo build` rodava no 1.97.0, que não tinha o alvo. O runner do macOS é ARM, então o x86_64 é cross-compile e precisa do std instalado — por isso só esse falhou.

O `publish-tauri`, logo acima no mesmo arquivo, já fazia certo com `@master` + `toolchain: 1.97.0`. Meu job não seguiu o padrão que estava do lado.

**Impacto na v0.8.0:** só o binário do CLI para macOS Intel. O `fail-fast: false` da matriz preservou os outros três alvos, e o `build-cli` não tem `needs`, então os artefatos do app publicaram normalmente.

Depois do merge, o CLI de macOS Intel pode ser gerado re-rodando o workflow na tag — não precisa de release nova.