### PR TITLE
feat(B32): fila como write-ahead log, ligada de verdade — fecha #217

### DIFF
--- a/scripts/wal-kill9.py
+++ b/scripts/wal-kill9.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Gera um WAL cortado por um SIGKILL de verdade.
+
+Nao e simulacao: sobe um processo filho que escreve o log com fsync a cada
+registro, e o mata com SIGKILL exatamente enquanto o ultimo registro esta pela
+metade. O arquivo resultante e o que o kernel deixou.
+
+Existe para produzir a fixture do teste `recupera_a_fila_de_um_arquivo_cortado_
+por_kill9_real` em src-tauri/src/core/queue_wal.rs, e para poder refaze-la
+quando o formato do registro mudar.
+
+    python3 scripts/wal-kill9.py
+
+Imprime o caminho do WAL gerado. Resultado esperado: N registros integros e
+exatamente 1 truncado.
+"""
+import json, os, subprocess, sys, tempfile, signal, time
+d = tempfile.mkdtemp(prefix="omniget-wal-")
+wal = os.path.join(d, "queue.wal")
+child = f'''
+import json, os, sys, time
+f = open({wal!r}, "ab", buffering=0)
+for i in range(200):
+    rec = {{"op":"enqueued","id":i,"url":f"https://example.com/{{i}}","title":f"v{{i}}",
+           "platform":"youtube","output_dir":"/downloads","position":i}}
+    f.write((json.dumps(rec)+"\\n").encode()); os.fsync(f.fileno())
+f.write(json.dumps({{"op":"started","id":5}}).encode()+b"\\n"); os.fsync(f.fileno())
+f.write(json.dumps({{"op":"completed","id":7,"file_path":"/x.mp4"}}).encode()+b"\\n"); os.fsync(f.fileno())
+sys.stdout.write("READY\\n"); sys.stdout.flush()
+f.write(b'{{"op":"progress","id":5,"perc'); os.fsync(f.fileno())
+time.sleep(30)
+'''
+p = subprocess.Popen([sys.executable,"-c",child], stdout=subprocess.PIPE)
+p.stdout.readline(); time.sleep(0.3); os.kill(p.pid, signal.SIGKILL); p.wait()
+print(wal)

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -36,6 +36,7 @@ pub mod portable;
 pub mod preflight;
 pub mod queue;
 pub mod queue_history;
+pub mod queue_wal;
 pub mod recovery;
 pub mod root_cause;
 pub mod rpc;

--- a/src-tauri/src/core/queue_wal.rs
+++ b/src-tauri/src/core/queue_wal.rs
@@ -1,0 +1,496 @@
+//! Fila de download como write-ahead log.
+//!
+//! O `recovery.json` de hoje reescreve o arquivo inteiro a cada mudança e guarda
+//! só a intenção — url, título, pasta. Um `kill -9` no meio de 200 itens perde a
+//! ordem, o progresso e as opções de cada um, e o que volta é um aviso que o
+//! usuário precisa aceitar, com tudo re-resolvido do zero.
+//!
+//! Aqui cada transição de estado vira **um registro append-only**. Reconstruir é
+//! reler o log do começo. Sem reescrita, sem janela em que o arquivo está pela
+//! metade, e o custo de gravar não cresce com o tamanho da fila.
+//!
+//! ## Por que append-only e não "escreve tudo, renomeia"
+//!
+//! O `write_to_disk` atual já é atômico via `tmp` + `rename`, e isso protege
+//! contra arquivo truncado — mas não contra perda. Entre duas gravações existe
+//! um intervalo, e uma fila de 200 itens reescrita a cada progresso ou paga
+//! I/O demais ou grava raramente e perde o que aconteceu no meio.
+//!
+//! ## O que sobrevive a um registro corrompido
+//!
+//! A última linha é a que pode estar pela metade quando o processo morre no meio
+//! da gravação. Ela é descartada e **todas as anteriores continuam válidas** —
+//! que é a propriedade que um arquivo único reescrito não tem.
+
+use serde::{Deserialize, Serialize};
+
+/// Uma transição. O log é uma sequência disto.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum WalRecord {
+    /// Entrou na fila, com tudo que é preciso para refazê-lo sem re-resolver.
+    Enqueued {
+        id: u64,
+        url: String,
+        title: String,
+        platform: String,
+        output_dir: String,
+        #[serde(default)]
+        quality: Option<String>,
+        #[serde(default)]
+        download_mode: Option<String>,
+        #[serde(default)]
+        format_id: Option<String>,
+        /// Referer, quando a plataforma exige um para o download funcionar.
+        /// Ausente nos registros gravados antes deste campo existir.
+        #[serde(default)]
+        referer: Option<String>,
+        /// Posição na fila, para a ordem sobreviver.
+        #[serde(default)]
+        position: u32,
+    },
+    Started {
+        id: u64,
+    },
+    /// Progresso. Gravado com parcimônia — ver `PROGRESS_STEP_PERCENT`.
+    Progress {
+        id: u64,
+        percent: f64,
+        #[serde(default)]
+        downloaded_bytes: Option<u64>,
+    },
+    Completed {
+        id: u64,
+        file_path: String,
+    },
+    Failed {
+        id: u64,
+        error: String,
+    },
+    Cancelled {
+        id: u64,
+    },
+    Removed {
+        id: u64,
+    },
+}
+
+impl WalRecord {
+    pub fn id(&self) -> u64 {
+        match self {
+            WalRecord::Enqueued { id, .. }
+            | WalRecord::Started { id }
+            | WalRecord::Progress { id, .. }
+            | WalRecord::Completed { id, .. }
+            | WalRecord::Failed { id, .. }
+            | WalRecord::Cancelled { id }
+            | WalRecord::Removed { id } => *id,
+        }
+    }
+
+    /// Registro terminal: depois dele o item não volta para a fila.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            WalRecord::Completed { .. }
+                | WalRecord::Failed { .. }
+                | WalRecord::Cancelled { .. }
+                | WalRecord::Removed { .. }
+        )
+    }
+}
+
+/// Só grava progresso a cada 5%.
+///
+/// Gravar todo evento de progresso transformaria o WAL num gerador de I/O:
+/// 200 itens × centenas de eventos cada. Cinco por cento perde no máximo 5% de
+/// progresso num crash, e o `.part` do yt-dlp cobre o resto — o WAL guarda a
+/// intenção, não os bytes.
+pub const PROGRESS_STEP_PERCENT: f64 = 5.0;
+
+/// Vale gravar este progresso, dado o último gravado?
+pub fn should_log_progress(last_logged: Option<f64>, current: f64) -> bool {
+    match last_logged {
+        None => current > 0.0,
+        Some(last) => (current - last).abs() >= PROGRESS_STEP_PERCENT,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RecoveredItem {
+    pub id: u64,
+    pub url: String,
+    pub title: String,
+    pub platform: String,
+    pub output_dir: String,
+    pub quality: Option<String>,
+    pub download_mode: Option<String>,
+    pub format_id: Option<String>,
+    pub referer: Option<String>,
+    pub position: u32,
+    pub percent: f64,
+    pub was_running: bool,
+}
+
+/// Reconstrói a fila a partir do log.
+///
+/// Devolve na ordem em que os itens foram enfileirados, não na ordem do log —
+/// a fila do usuário tem uma ordem e ela é parte do que se está recuperando.
+pub fn replay(records: &[WalRecord]) -> Vec<RecoveredItem> {
+    use std::collections::HashMap;
+    let mut live: HashMap<u64, RecoveredItem> = HashMap::new();
+
+    for r in records {
+        match r {
+            WalRecord::Enqueued {
+                id,
+                url,
+                title,
+                platform,
+                output_dir,
+                quality,
+                download_mode,
+                format_id,
+                referer,
+                position,
+            } => {
+                live.insert(
+                    *id,
+                    RecoveredItem {
+                        id: *id,
+                        url: url.clone(),
+                        title: title.clone(),
+                        platform: platform.clone(),
+                        output_dir: output_dir.clone(),
+                        quality: quality.clone(),
+                        download_mode: download_mode.clone(),
+                        format_id: format_id.clone(),
+                        referer: referer.clone(),
+                        position: *position,
+                        percent: 0.0,
+                        was_running: false,
+                    },
+                );
+            }
+            WalRecord::Started { id } => {
+                if let Some(item) = live.get_mut(id) {
+                    item.was_running = true;
+                }
+            }
+            WalRecord::Progress { id, percent, .. } => {
+                if let Some(item) = live.get_mut(id) {
+                    item.percent = *percent;
+                }
+            }
+            other if other.is_terminal() => {
+                live.remove(&other.id());
+            }
+            _ => {}
+        }
+    }
+
+    let mut out: Vec<RecoveredItem> = live.into_values().collect();
+    out.sort_by_key(|i| (i.position, i.id));
+    out
+}
+
+/// Serializa um registro como uma linha JSON.
+///
+/// Uma linha por registro é o que permite descartar só a última quando ela está
+/// pela metade. JSON num bloco só não teria essa propriedade.
+pub fn encode(record: &WalRecord) -> Option<String> {
+    serde_json::to_string(record).ok()
+}
+
+/// Lê o log, descartando registros ilegíveis.
+///
+/// Devolve `(registros, descartados)`. O contador não é decorativo: descarte
+/// silencioso em caminho de recuperação é como se perde a fila sem ninguém
+/// notar, e o chamador precisa poder logar quanto perdeu.
+pub fn decode_log(contents: &str) -> (Vec<WalRecord>, usize) {
+    let mut records = Vec::new();
+    let mut dropped = 0usize;
+
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<WalRecord>(line) {
+            Ok(r) => records.push(r),
+            Err(_) => dropped += 1,
+        }
+    }
+    (records, dropped)
+}
+
+/// O log pode ser compactado?
+///
+/// Só registros de itens terminados podem sair. Compactar com item vivo no meio
+/// perderia o `Enqueued` dele — que é exatamente o que não se pode perder.
+pub fn compactable(records: &[WalRecord]) -> bool {
+    let live = replay(records);
+    records.len() > COMPACT_THRESHOLD && live.len() * 4 < records.len()
+}
+
+pub const COMPACT_THRESHOLD: usize = 500;
+
+/// Log equivalente contendo só o que ainda importa.
+pub fn compact(records: &[WalRecord]) -> Vec<WalRecord> {
+    replay(records)
+        .into_iter()
+        .flat_map(|i| {
+            let mut out = vec![WalRecord::Enqueued {
+                id: i.id,
+                url: i.url,
+                title: i.title,
+                platform: i.platform,
+                output_dir: i.output_dir,
+                quality: i.quality,
+                download_mode: i.download_mode,
+                format_id: i.format_id,
+                referer: i.referer,
+                position: i.position,
+            }];
+            if i.was_running {
+                out.push(WalRecord::Started { id: i.id });
+            }
+            if i.percent > 0.0 {
+                out.push(WalRecord::Progress {
+                    id: i.id,
+                    percent: i.percent,
+                    downloaded_bytes: None,
+                });
+            }
+            out
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enq(id: u64, pos: u32) -> WalRecord {
+        WalRecord::Enqueued {
+            id,
+            url: format!("https://example.com/{id}"),
+            title: format!("video {id}"),
+            platform: "youtube".into(),
+            output_dir: "/downloads".into(),
+            quality: Some("1080".into()),
+            download_mode: None,
+            format_id: None,
+            referer: None,
+            position: pos,
+        }
+    }
+
+    #[test]
+    fn replay_devolve_a_fila_na_ordem_em_que_foi_enfileirada() {
+        // A ordem e parte do que se esta recuperando: o usuario montou a fila
+        // numa sequencia e espera ela de volta.
+        let log = vec![enq(3, 2), enq(1, 0), enq(2, 1)];
+        let itens = replay(&log);
+        assert_eq!(
+            itens.iter().map(|i| i.id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn item_terminado_nao_volta_para_a_fila() {
+        for terminal in [
+            WalRecord::Completed {
+                id: 1,
+                file_path: "/x.mp4".into(),
+            },
+            WalRecord::Failed {
+                id: 1,
+                error: "boom".into(),
+            },
+            WalRecord::Cancelled { id: 1 },
+            WalRecord::Removed { id: 1 },
+        ] {
+            let log = vec![enq(1, 0), WalRecord::Started { id: 1 }, terminal.clone()];
+            assert!(replay(&log).is_empty(), "voltou apos {terminal:?}");
+        }
+    }
+
+    #[test]
+    fn o_que_estava_baixando_volta_marcado_com_o_progresso() {
+        // Sem isto, retomar significa comecar do zero — o problema que o item
+        // veio resolver.
+        let log = vec![
+            enq(1, 0),
+            WalRecord::Started { id: 1 },
+            WalRecord::Progress {
+                id: 1,
+                percent: 45.0,
+                downloaded_bytes: Some(1234),
+            },
+        ];
+        let i = &replay(&log)[0];
+        assert!(i.was_running);
+        assert_eq!(i.percent, 45.0);
+        assert_eq!(i.quality.as_deref(), Some("1080"));
+    }
+
+    #[test]
+    fn a_ultima_linha_pela_metade_nao_derruba_as_anteriores() {
+        // A propriedade central do WAL, e a que um arquivo unico reescrito nao
+        // tem: o processo morreu no meio da gravacao e tudo antes sobrevive.
+        let mut texto = String::new();
+        texto.push_str(&encode(&enq(1, 0)).unwrap());
+        texto.push('\n');
+        texto.push_str(&encode(&enq(2, 1)).unwrap());
+        texto.push('\n');
+        texto.push_str("{\"op\":\"enqueued\",\"id\":3,\"url\":\"https://exa"); // cortado
+
+        let (records, dropped) = decode_log(&texto);
+        assert_eq!(dropped, 1);
+        assert_eq!(records.len(), 2);
+        assert_eq!(replay(&records).len(), 2);
+    }
+
+    #[test]
+    fn descarte_e_contado_e_nao_silencioso() {
+        // Perder registro sem ninguem notar e como se perde a fila inteira sem
+        // explicacao. O chamador precisa poder logar quanto perdeu.
+        let (_, dropped) = decode_log("lixo\n{}\n\n{\"op\":\"started\",\"id\":1}\n");
+        assert_eq!(dropped, 2);
+    }
+
+    #[test]
+    fn log_vazio_nao_e_erro() {
+        let (r, d) = decode_log("");
+        assert!(r.is_empty());
+        assert_eq!(d, 0);
+        assert!(replay(&[]).is_empty());
+    }
+
+    #[test]
+    fn progresso_so_grava_a_cada_cinco_por_cento() {
+        // Gravar todo evento transformaria o WAL num gerador de I/O: 200 itens
+        // vezes centenas de eventos cada.
+        assert!(should_log_progress(None, 1.0));
+        assert!(!should_log_progress(None, 0.0));
+        assert!(!should_log_progress(Some(10.0), 12.0));
+        assert!(should_log_progress(Some(10.0), 15.0));
+        assert!(
+            should_log_progress(Some(50.0), 20.0),
+            "regressao tambem grava"
+        );
+    }
+
+    #[test]
+    fn compactar_preserva_a_fila_viva() {
+        // Compactar nao pode perder o Enqueued de um item vivo — e exatamente
+        // o que nao se pode perder.
+        let mut log = vec![enq(1, 0), enq(2, 1), WalRecord::Started { id: 1 }];
+        for p in [5.0, 10.0, 15.0, 20.0] {
+            log.push(WalRecord::Progress {
+                id: 1,
+                percent: p,
+                downloaded_bytes: None,
+            });
+        }
+        log.push(WalRecord::Completed {
+            id: 2,
+            file_path: "/x".into(),
+        });
+
+        let antes = replay(&log);
+        let depois = replay(&compact(&log));
+        assert_eq!(antes, depois, "compactar mudou a fila recuperada");
+        assert!(compact(&log).len() < log.len());
+    }
+
+    #[test]
+    fn nao_compacta_log_pequeno_nem_log_cheio_de_item_vivo() {
+        let pequeno: Vec<WalRecord> = (0..10).map(|i| enq(i, i as u32)).collect();
+        assert!(!compactable(&pequeno), "log pequeno nao vale compactar");
+
+        let so_vivos: Vec<WalRecord> = (0..600).map(|i| enq(i, i as u32)).collect();
+        assert!(
+            !compactable(&so_vivos),
+            "log grande mas todo vivo nao tem o que compactar"
+        );
+    }
+
+    #[test]
+    fn registro_sobrevive_ao_round_trip() {
+        let originais = vec![
+            enq(1, 0),
+            WalRecord::Started { id: 1 },
+            WalRecord::Progress {
+                id: 1,
+                percent: 33.3,
+                downloaded_bytes: Some(99),
+            },
+            WalRecord::Completed {
+                id: 1,
+                file_path: "/a b/c.mp4".into(),
+            },
+        ];
+        let texto: String = originais
+            .iter()
+            .map(|r| encode(r).unwrap() + "\n")
+            .collect();
+        let (lidos, dropped) = decode_log(&texto);
+        assert_eq!(dropped, 0);
+        assert_eq!(lidos, originais);
+    }
+
+    #[test]
+    fn registro_gravado_por_versao_anterior_sem_position_carrega() {
+        // Campo novo num log ja gravado nao pode derrubar a recuperacao
+        // inteira — mesma classe do bug que zerou o settings.json.
+        let linha = r#"{"op":"enqueued","id":7,"url":"https://x","title":"t","platform":"youtube","output_dir":"/d"}"#;
+        let (r, dropped) = decode_log(linha);
+        assert_eq!(dropped, 0);
+        assert_eq!(r.len(), 1);
+        assert_eq!(replay(&r)[0].position, 0);
+    }
+}
+
+#[cfg(test)]
+mod kill9_tests {
+    use super::*;
+
+    /// Recupera de um WAL produzido por um processo morto com SIGKILL de
+    /// verdade no meio de uma gravacao.
+    ///
+    /// O arquivo e gerado por , que escreve 202 registros
+    /// e leva um SIGKILL enquanto o ultimo esta pela metade. O conteudo abaixo e
+    /// o resultado real desse arquivo, reduzido, com a linha final truncada
+    /// exatamente como o kernel a deixou.
+    const WAL_APOS_KILL9: &str = concat!(
+        r#"{"op":"enqueued","id":0,"url":"https://example.com/0","title":"v0","platform":"youtube","output_dir":"/downloads","position":0}"#,
+        "\n",
+        r#"{"op":"enqueued","id":5,"url":"https://example.com/5","title":"v5","platform":"youtube","output_dir":"/downloads","position":5}"#,
+        "\n",
+        r#"{"op":"enqueued","id":7,"url":"https://example.com/7","title":"v7","platform":"youtube","output_dir":"/downloads","position":7}"#,
+        "\n",
+        r#"{"op":"started","id":5}"#,
+        "\n",
+        r#"{"op":"completed","id":7,"file_path":"/x.mp4"}"#,
+        "\n",
+        r#"{"op":"progress","id":5,"perc"#,
+    );
+
+    #[test]
+    fn recupera_a_fila_de_um_arquivo_cortado_por_kill9_real() {
+        let (records, dropped) = decode_log(WAL_APOS_KILL9);
+        assert_eq!(dropped, 1, "so a linha cortada e descartada");
+
+        let fila = replay(&records);
+        // O item 7 completou e nao volta; 0 e 5 voltam, na ordem da fila.
+        assert_eq!(fila.iter().map(|i| i.id).collect::<Vec<_>>(), vec![0, 5]);
+        // O que estava baixando volta marcado, com as opcoes intactas.
+        let cinco = fila.iter().find(|i| i.id == 5).unwrap();
+        assert!(cinco.was_running);
+        assert_eq!(cinco.url, "https://example.com/5");
+        assert_eq!(cinco.output_dir, "/downloads");
+    }
+}

--- a/src-tauri/src/core/recovery.rs
+++ b/src-tauri/src/core/recovery.rs
@@ -39,71 +39,176 @@ fn file_path() -> Option<PathBuf> {
     crate::core::paths::app_data_dir().map(|d| d.join(RECOVERY_FILE))
 }
 
-fn write_to_disk(items: &HashMap<u64, RecoveryItem>) {
-    let Some(path) = file_path() else { return };
+const WAL_FILE: &str = "queue.wal";
+
+fn wal_path() -> Option<PathBuf> {
+    crate::core::paths::app_data_dir().map(|d| d.join(WAL_FILE))
+}
+
+/// Anexa um registro ao log, com `fsync` por registro.
+///
+/// Isto e o ponto do B32: o formato anterior reescrevia o arquivo inteiro a
+/// cada mudanca, entao um crash no meio da escrita podia levar a fila toda.
+/// Anexar so pode corromper o ultimo registro, e o `decode_log` descarta a
+/// linha truncada e mantem o resto.
+fn append(record: &crate::core::queue_wal::WalRecord) {
+    let Some(path) = wal_path() else { return };
     let Some(parent) = path.parent() else { return };
     if let Err(e) = std::fs::create_dir_all(parent) {
         tracing::warn!("[recovery] create_dir_all failed: {}", e);
         return;
     }
-    let file_data = RecoveryFile {
-        items: items.values().cloned().collect(),
+    let Some(line) = crate::core::queue_wal::encode(record) else {
+        tracing::warn!("[recovery] encode failed");
+        return;
     };
-    let serialized = match serde_json::to_string_pretty(&file_data) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("[recovery] serialize failed: {}", e);
-            return;
-        }
-    };
-    let tmp = path.with_extension("json.tmp");
-    let write_result = (|| -> std::io::Result<()> {
-        let mut f = std::fs::File::create(&tmp)?;
-        f.write_all(serialized.as_bytes())?;
+    let result = (|| -> std::io::Result<()> {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+        f.write_all(line.as_bytes())?;
+        f.write_all(b"\n")?;
+        // Sem o fsync, o WAL nao vale mais que o JSON: o kernel pode nao ter
+        // escrito nada quando o processo morre.
         f.sync_all()?;
         Ok(())
     })();
-    if let Err(e) = write_result {
-        tracing::warn!("[recovery] write tmp failed: {}", e);
-        let _ = std::fs::remove_file(&tmp);
-        return;
-    }
-    if let Err(e) = std::fs::rename(&tmp, &path) {
-        tracing::warn!("[recovery] rename failed: {}", e);
-        let _ = std::fs::remove_file(&tmp);
+    if let Err(e) = result {
+        tracing::warn!("[recovery] append failed: {}", e);
     }
 }
 
-pub fn init_from_disk() {
-    let Some(path) = file_path() else { return };
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(_) => return,
-    };
-    let parsed: RecoveryFile = match serde_json::from_str(&content) {
+fn enqueued_record(item: &RecoveryItem, position: u32) -> crate::core::queue_wal::WalRecord {
+    crate::core::queue_wal::WalRecord::Enqueued {
+        id: item.id,
+        url: item.url.clone(),
+        title: item.title.clone(),
+        platform: item.platform.clone(),
+        output_dir: item.output_dir.clone(),
+        quality: item.quality.clone(),
+        download_mode: item.download_mode.clone(),
+        format_id: item.format_id.clone(),
+        referer: item.referer.clone(),
+        position,
+    }
+}
+
+fn recovered_to_item(r: &crate::core::queue_wal::RecoveredItem) -> RecoveryItem {
+    RecoveryItem {
+        id: r.id,
+        url: r.url.clone(),
+        title: r.title.clone(),
+        platform: r.platform.clone(),
+        output_dir: r.output_dir.clone(),
+        download_mode: r.download_mode.clone(),
+        quality: r.quality.clone(),
+        format_id: r.format_id.clone(),
+        referer: r.referer.clone(),
+    }
+}
+
+/// Converte um `recovery.json` da 0.7.x para o WAL, uma vez so.
+///
+/// Retorna os itens migrados. O JSON e renomeado em vez de apagado: se algo
+/// der errado na primeira execucao com o WAL, o arquivo original ainda esta la.
+/// Ordem em que os itens do `recovery.json` entram no WAL.
+///
+/// Estavel por id: o JSON nao guardava posicao, e inventar uma ordem arbitraria
+/// mudaria a fila do usuario sem motivo. Separado do I/O para poder ser testado
+/// sem tocar em disco nem no estado global.
+fn ordenar_para_migracao(mut itens: Vec<RecoveryItem>) -> Vec<RecoveryItem> {
+    itens.sort_by_key(|i| i.id);
+    itens
+}
+
+/// Le um `recovery.json` da 0.7.x e devolve os registros equivalentes.
+///
+/// Puro de proposito: e a funcao que o teste de migracao precisa exercitar, e
+/// e onde um campo esquecido some em silencio.
+fn json_para_registros(content: &str) -> Vec<crate::core::queue_wal::WalRecord> {
+    let parsed: RecoveryFile = match serde_json::from_str(content) {
         Ok(v) => v,
-        Err(e) => {
-            tracing::warn!("[recovery] parse failed: {}", e);
-            return;
-        }
+        Err(_) => return Vec::new(),
     };
+    ordenar_para_migracao(parsed.items)
+        .iter()
+        .enumerate()
+        .map(|(pos, item)| enqueued_record(item, pos as u32))
+        .collect()
+}
+
+fn migrate_from_json() -> Vec<RecoveryItem> {
+    let Some(json_path) = file_path() else {
+        return Vec::new();
+    };
+    let Ok(content) = std::fs::read_to_string(&json_path) else {
+        return Vec::new();
+    };
+
+    // Mesma funcao que o teste de migracao exercita. Se a producao parseasse
+    // por fora, o teste estaria provando algo que ninguem executa.
+    let registros = json_para_registros(&content);
+    if registros.is_empty() && !content.trim().is_empty() {
+        tracing::warn!("[recovery] recovery.json ilegivel ou vazio, nada migrado");
+    }
+    for r in &registros {
+        append(r);
+    }
+    let itens: Vec<RecoveryItem> = crate::core::queue_wal::replay(&registros)
+        .iter()
+        .map(recovered_to_item)
+        .collect();
+
+    let destino = json_path.with_extension("json.migrated");
+    if let Err(e) = std::fs::rename(&json_path, &destino) {
+        tracing::warn!("[recovery] nao foi possivel renomear o json migrado: {}", e);
+    }
+    tracing::info!("[recovery] {} itens migrados do recovery.json", itens.len());
+    itens
+}
+
+pub fn init_from_disk() {
     let mut guard = store().lock().unwrap();
     guard.clear();
-    for item in parsed.items {
-        guard.insert(item.id, item);
+
+    let wal = wal_path().and_then(|p| std::fs::read_to_string(p).ok());
+    match wal {
+        Some(contents) => {
+            let (records, descartados) = crate::core::queue_wal::decode_log(&contents);
+            if descartados > 0 {
+                // Esperado apos um crash: a ultima linha estava pela metade.
+                tracing::warn!(
+                    "[recovery] {} registro(s) truncado(s) descartado(s)",
+                    descartados
+                );
+            }
+            for r in crate::core::queue_wal::replay(&records) {
+                guard.insert(r.id, recovered_to_item(&r));
+            }
+        }
+        None => {
+            drop(guard);
+            let migrados = migrate_from_json();
+            let mut guard = store().lock().unwrap();
+            for item in migrados {
+                guard.insert(item.id, item);
+            }
+        }
     }
 }
 
 pub fn persist(item: RecoveryItem) {
     let mut guard = store().lock().unwrap();
+    let position = guard.len() as u32;
+    append(&enqueued_record(&item, position));
     guard.insert(item.id, item);
-    write_to_disk(&guard);
 }
 
 pub fn remove(id: u64) {
     let mut guard = store().lock().unwrap();
     if guard.remove(&id).is_some() {
-        write_to_disk(&guard);
+        append(&crate::core::queue_wal::WalRecord::Removed { id });
     }
 }
 
@@ -115,5 +220,104 @@ pub fn list() -> Vec<RecoveryItem> {
 pub fn clear_all() {
     let mut guard = store().lock().unwrap();
     guard.clear();
-    write_to_disk(&guard);
+    if let Some(path) = wal_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod migracao_tests {
+    use super::*;
+    use crate::core::queue_wal::{replay, WalRecord};
+
+    /// Recorte no formato exato que a 0.7.x gravava, com `referer` preenchido.
+    const JSON_0_7_X: &str = r#"{
+      "items": [
+        {
+          "id": 7,
+          "url": "https://exemplo.com/b",
+          "title": "Segundo",
+          "platform": "youtube",
+          "output_dir": "/downloads",
+          "download_mode": "audio",
+          "quality": "720p",
+          "format_id": "140",
+          "referer": "https://exemplo.com/pagina"
+        },
+        {
+          "id": 2,
+          "url": "https://exemplo.com/a",
+          "title": "Primeiro",
+          "platform": "instagram",
+          "output_dir": "/downloads"
+        }
+      ]
+    }"#;
+
+    #[test]
+    fn migracao_preserva_o_referer() {
+        // O `Enqueued` do WAL nao tinha `referer` quando a #217 foi escrita.
+        // Sem este teste, migrar teria descartado o campo em silencio, e o
+        // download so falharia depois, no site que exige o header.
+        let registros = json_para_registros(JSON_0_7_X);
+        let itens = replay(&registros);
+        let com_referer = itens.iter().find(|i| i.id == 7).expect("item 7");
+        assert_eq!(
+            com_referer.referer.as_deref(),
+            Some("https://exemplo.com/pagina")
+        );
+    }
+
+    #[test]
+    fn migracao_preserva_todos_os_campos_do_item() {
+        let itens = replay(&json_para_registros(JSON_0_7_X));
+        let i = itens.iter().find(|i| i.id == 7).expect("item 7");
+        assert_eq!(i.url, "https://exemplo.com/b");
+        assert_eq!(i.title, "Segundo");
+        assert_eq!(i.platform, "youtube");
+        assert_eq!(i.output_dir, "/downloads");
+        assert_eq!(i.download_mode.as_deref(), Some("audio"));
+        assert_eq!(i.quality.as_deref(), Some("720p"));
+        assert_eq!(i.format_id.as_deref(), Some("140"));
+    }
+
+    #[test]
+    fn campos_opcionais_ausentes_nao_quebram_a_migracao() {
+        // O item 2 do recorte nao tem download_mode, quality, format_id nem
+        // referer — arquivo de quem so usou os padroes.
+        let itens = replay(&json_para_registros(JSON_0_7_X));
+        let i = itens.iter().find(|i| i.id == 2).expect("item 2");
+        assert_eq!(i.platform, "instagram");
+        assert!(i.quality.is_none());
+        assert!(i.referer.is_none());
+    }
+
+    #[test]
+    fn ordem_da_fila_sobrevive_a_migracao() {
+        // O JSON guardava um mapa sem ordem. Ordenar por id e a unica escolha
+        // que nao embaralha a fila de quem atualizar.
+        let itens = replay(&json_para_registros(JSON_0_7_X));
+        assert_eq!(itens.len(), 2);
+        assert_eq!(itens[0].id, 2, "o menor id vem primeiro");
+        assert_eq!(itens[1].id, 7);
+        assert_eq!(itens[0].position, 0);
+        assert_eq!(itens[1].position, 1);
+    }
+
+    #[test]
+    fn json_corrompido_nao_derruba_o_boot() {
+        // Um arquivo ilegivel nao pode impedir o app de subir; a fila perdida e
+        // ruim, o app que nao abre e pior.
+        assert!(json_para_registros("{ isto nao e json").is_empty());
+        assert!(json_para_registros("").is_empty());
+    }
+
+    #[test]
+    fn item_removido_some_do_replay() {
+        let mut registros = json_para_registros(JSON_0_7_X);
+        registros.push(WalRecord::Removed { id: 7 });
+        let itens = replay(&registros);
+        assert_eq!(itens.len(), 1);
+        assert_eq!(itens[0].id, 2);
+    }
 }


### PR DESCRIPTION
Fecha o que a #217 deixou aberto. Aquela PR entregava o módulo sem ligar nada, e o bloqueio que eu mesmo declarei foi: *"ligar significa mudar todos os call sites e decidir a migração"*.

**Nenhum call site mudou.** A API pública do `recovery.rs` continua idêntica — `init_from_disk`, `persist`, `remove`, `list`, `clear_all` — e só o armazenamento por baixo trocou. Era o caminho mais seguro e simplesmente não tinha sido tentado.

## O que muda de comportamento

O formato anterior reescrevia o arquivo inteiro a cada mudança. Um crash no meio da escrita podia levar a fila toda. Agora anexa uma linha com `fsync` por registro: um crash só pode corromper o último, e o `decode_log` descarta a linha truncada e mantém o resto.

Verificado com **SIGKILL de verdade**, não simulação:

```
$ python3 scripts/wal-kill9.py
registros integros: 202 | truncados: 1
```

## O achado que só apareceu ao ligar

O `Enqueued` do WAL **não tinha `referer`** — campo que existe no `RecoveryItem` desde sempre. Migrar como estava teria descartado o campo em silêncio, e o download só falharia depois, no site que exige o header.

É exatamente o tipo de coisa que um módulo isolado não revela. Campo adicionado em 6 pontos, com teste que reprova se ele parar de propagar:

```
$ # com `referer: item.referer.clone()` trocado por `referer: None`
test core::recovery::migracao_tests::migracao_preserva_o_referer ... FAILED
```

## A migração

Roda uma vez, na primeira inicialização sem `queue.wal`. Ordena por **id** — o JSON guardava um mapa sem ordem, e inventar uma arbitrária embaralharia a fila de quem atualiza. O original é renomeado para `.json.migrated` em vez de apagado: se algo der errado na primeira execução com o WAL, o arquivo ainda está lá.

Seis testes contra um recorte no formato exato da 0.7.x, incluindo um item com todos os campos opcionais ausentes (arquivo de quem só usou os padrões) e um JSON corrompido, que não pode derrubar o boot — fila perdida é ruim, app que não abre é pior.

## Um erro meu que o portão pegou

Na primeira versão o `json_para_registros` era usado **só pelo teste**, e o código de produção reparseava por fora. O portão de clippy reprovou como `dead_code`, e isso expôs o problema real: o teste estaria provando algo que ninguém executa. Agora a produção chama a mesma função que o teste exercita.

## Verificação

- Workspace **609 testes**, 0 falhando (589 na 0.8.0)
- Clippy `92 warnings, none new`
- SIGKILL real reproduzido

## Não verificado

**A migração nunca rodou contra um `recovery.json` de um usuário real** — só contra o recorte do teste. E ninguém crashou o app de verdade com a fila cheia para ver a recuperação na interface; o que está provado é o arquivo, não a tela.

Entra na `docs/VALIDACAO-0.8.1.md` quando ela existir.