### PR TITLE
fix(portable): avisar que o macOS não redireciona o WebView (#227)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -353,6 +353,22 @@ pub fn run() {
                     }
                 }
 
+                // macOS nao tem para onde apontar: o wry nao le `data_directory`
+                // no WKWebView (nenhuma referencia em `src/wkwebview/`), ao
+                // contrario do webkitgtk, que a usa para base_data_directory,
+                // base_cache_directory e cookies.
+                //
+                // Entao o modo portatil nao cumpre o que promete aqui, e dizer
+                // isso e melhor do que deixar o usuario achar que o pendrive nao
+                // deixou rastro. Issue #227.
+                #[cfg(target_os = "macos")]
+                if core::portable::portable_webview_dir_from_env().is_some() {
+                    tracing::warn!(
+                        "[portable] no macOS o WebView guarda dados em ~/Library mesmo em modo \
+                         portatil — o wry nao permite redirecionar. Ver github.com/tonhowtf/omniget/issues/227"
+                    );
+                }
+
                 builder.build()?;
 
                 // A unica prova de que a janela subiu. O CI compila em todas as


### PR DESCRIPTION
Metade acionável da #227.

O modo portátil promete não deixar rastro na máquina. No macOS ele **não cumpre**, e hoje não há como cumprir: o `wry` não lê `data_directory` no WKWebView.

```
$ grep -rn "data_directory" wry-0.54.2/src/wkwebview/*.rs
(nenhum resultado)

$ grep -rn "data_directory" wry-0.54.2/src/webkitgtk/web_context.rs
32:  pub fn new(data_directory: Option<&Path>) -> Self {
38:        .base_cache_directory(...)
39:        .base_data_directory(...)
43:          &data_directory.join("cookies")...
```

Passar `.data_directory()` no macOS seria no-op — pior que não fazer nada, porque daria a impressão de estar coberto. Por isso o `cfg` continua em `any(windows, target_os = "linux")`.

O que dá para fazer hoje é **dizer**. Um `warn!` no boot quando o modo portátil está ligado no macOS, apontando para a issue. Não conserta, mas troca uma promessa quebrada silenciosa por uma limitação declarada — e é a diferença entre o usuário achar que o pendrive saiu limpo e saber que não saiu.

A issue continua aberta para o conserto de verdade, que provavelmente passa por upstream (`WKWebsiteDataStore` com diretório customizado, API que o `wry` não expõe).

**Não testado no macOS rodando de fato** — o ramo está atrás de `cfg(target_os = "macos")` e compila aqui, mas eu não subi o app em modo portátil no macOS para ver a linha sair. É um `warn!` de uma linha; o risco é baixo e está declarado.