### PR TITLE
feat(league): usar o registro de features nos estados vazios e nos badges

### DIFF
--- a/src/components/league/AnalysisTab.svelte
+++ b/src/components/league/AnalysisTab.svelte
@@ -3,6 +3,7 @@
   import { t } from "$lib/i18n";
   import { CDRAGON, TAG_KEYS, type Champion, type RankedEntry, type ScoutPlayer } from "./shared";
   import { markedPlayers, winrateSquad } from "$lib/league-scouting";
+  import { availability, featureById, type Platform } from "./registry";
   import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 
   let {
@@ -18,6 +19,8 @@
     notes,
     onSaveNote,
     timesSeenBefore,
+    platform,
+    clientConnected,
   }: {
     analysis: any;
     analysisLoading: boolean;
@@ -31,7 +34,19 @@
     notes: Record<string, string>;
     onSaveNote: (puuid: string, text: string) => void;
     timesSeenBefore: (puuid: string) => number;
+    platform?: Platform;
+    clientConnected?: boolean;
   } = $props();
+
+  let analysisFeature = featureById("analysis");
+  let analysisAvailability = $derived.by(() => {
+    if (!analysisFeature) return { available: true as const };
+    return availability(analysisFeature, {
+      platform: platform ?? "macos",
+      clientConnected: clientConnected ?? true,
+      inGame: phase === "ChampSelect" || phase === "InProgress",
+    });
+  });
 
   let marked = $derived(markedPlayers(scoutPlayers, notes));
   let squadSide = $derived(winrateSquad(scoutPlayers, analysis?.premades ?? [], scoutReports));
@@ -144,7 +159,7 @@
   </section>
 {:else}
   <div class="guard-card">
-    <p>{$t("league.win_unavailable")}</p>
+    <p>{analysisAvailability.available ? $t("league.win_unavailable") : $t(analysisAvailability.reasonKey)}</p>
     <button class="button" onclick={onRefreshAnalysis} disabled={analysisLoading}>{$t("league.refresh")}</button>
   </div>
 {/if}

--- a/src/components/league/LiveTab.svelte
+++ b/src/components/league/LiveTab.svelte
@@ -1,18 +1,39 @@
 <script lang="ts">
   import { t } from "$lib/i18n";
   import { CDRAGON, ROLES, assetUrl, formatGameTime, type GoalKey, type Role } from "./shared";
+  import { availability, featureById, needsBadge, type Platform } from "./registry";
 
   let {
     liveMetrics,
     cooldowns,
     liveEvents,
     goalValue,
+    platform,
+    clientConnected,
   }: {
     liveMetrics: any;
     cooldowns: any;
     liveEvents: any;
     goalValue: (role: Role, key: GoalKey) => number;
+    platform?: Platform;
+    clientConnected?: boolean;
   } = $props();
+
+  let context = $derived({
+    platform: platform ?? "macos",
+    clientConnected: clientConnected ?? true,
+    inGame: Boolean(liveMetrics?.players?.length),
+  });
+
+  let objectivesFeature = featureById("objectives");
+  let objectivesAvailability = $derived(
+    objectivesFeature ? availability(objectivesFeature, context) : { available: true as const },
+  );
+
+  let liveFeature = featureById("live-metrics");
+  let liveAvailability = $derived(
+    liveFeature ? availability(liveFeature, context) : { available: true as const },
+  );
 
   let selfRow = $derived(liveMetrics?.players?.find((r: any) => r.isSelf) ?? null);
   let myTeam = $derived(selfRow?.team ?? "ORDER");
@@ -239,7 +260,12 @@
   {#if objectives.length > 0 || feed.length > 0}
     <section class="card">
       <div class="card-head">
-        <h3>{$t("league.objectives_title")}</h3>
+        <h3>
+          {$t("league.objectives_title")}
+          {#if objectivesFeature && needsBadge(objectivesFeature)}
+            <span class="feature-badge">{$t(`league.badge_${objectivesFeature.state}`)}</span>
+          {/if}
+        </h3>
       </div>
       {#if objectives.length > 0}
         <div class="objective-row">
@@ -289,6 +315,6 @@
   {/if}
 {:else}
   <div class="guard-card">
-    <p>{$t("league.gold_unavailable")}</p>
+    <p>{liveAvailability.available ? $t("league.gold_unavailable") : $t(liveAvailability.reasonKey)}</p>
   </div>
 {/if}

--- a/src/components/league/MetaTab.svelte
+++ b/src/components/league/MetaTab.svelte
@@ -3,6 +3,7 @@
   import { invoke } from "@tauri-apps/api/core";
   import { t } from "$lib/i18n";
   import { translateBackendError } from "$lib/error-translate";
+  import { featureById, needsBadge } from "./registry";
   import { getSettings, updateSettings } from "$lib/stores/settings-store.svelte";
   import { CDRAGON, type Champion } from "./shared";
 
@@ -125,6 +126,7 @@
     }
   });
 
+  const buildFeature = featureById("build-reference");
   let metaInfo = $state<any>(null);
   let metaLoading = $state(false);
   let metaError = $state("");
@@ -335,7 +337,12 @@
   {/if}
   <div class="divider"></div>
   <div class="card-head">
-    <h4 class="section-title">{$t("league.meta_reference")}</h4>
+    <h4 class="section-title">
+      {$t("league.meta_reference")}
+      {#if buildFeature && needsBadge(buildFeature)}
+        <span class="feature-badge">{$t(`league.badge_${buildFeature.state}`)}</span>
+      {/if}
+    </h4>
     <button
       class="button"
       onclick={() => loadMeta(champSelectChampionId || (buildChampionId ?? 0))}

--- a/src/routes/league/+page.svelte
+++ b/src/routes/league/+page.svelte
@@ -20,6 +20,7 @@
   import AutomationTab from "$components/league/AutomationTab.svelte";
   import HistoryTab from "$components/league/HistoryTab.svelte";
   import type { Champion, GoalKey, LobbyQueue, RankedEntry, Role, ScoutPlayer } from "$components/league/shared";
+  import type { Platform } from "$components/league/registry";
 
   type LeagueStatus = { connected: boolean; port: number | null; region: string | null };
 
@@ -136,6 +137,15 @@
   let liveMetrics = $state<any>(null);
   let cooldowns = $state<any>(null);
   let liveEvents = $state<any>(null);
+
+  // The registry needs to know where it runs to explain platform limits.
+  let platform = $derived<Platform>(
+    navigator.userAgent.includes("Windows")
+      ? "windows"
+      : navigator.userAgent.includes("Mac")
+        ? "macos"
+        : "linux",
+  );
 
   const GOALS_KEY = "league-role-goals";
 
@@ -453,7 +463,7 @@
         <OverviewTab {summoner} {ranked} {phase} {champSelect} {liveGame} {lobby} {queues} {actionError} {champions} {championById} {championByAlias} onAction={action} />
       </div>
       <div class="tab-panel" class:active={tab === "analysis"}>
-        <AnalysisTab {analysis} {analysisLoading} onRefreshAnalysis={loadAnalysis} {phase} {scoutPlayers} {scoutReports} {scoutLoading} onRefreshScouting={loadScouting} {championById} {notes} onSaveNote={saveNote} {timesSeenBefore} />
+        <AnalysisTab {analysis} {analysisLoading} onRefreshAnalysis={loadAnalysis} {phase} {scoutPlayers} {scoutReports} {scoutLoading} onRefreshScouting={loadScouting} {championById} {notes} onSaveNote={saveNote} {timesSeenBefore} {platform} clientConnected={status.connected} />
       </div>
       <div class="tab-panel" class:active={tab === "meta"}>
         <MetaTab {champSelectChampionId} {myAssignedPosition} {championById} {champions} region={status.region} />
@@ -462,7 +472,7 @@
         <SearchTab {championById} />
       </div>
       <div class="tab-panel" class:active={tab === "live"}>
-        <LiveTab {liveMetrics} {cooldowns} {liveEvents} {goalValue} />
+        <LiveTab {liveMetrics} {cooldowns} {liveEvents} {goalValue} {platform} clientConnected={status.connected} />
       </div>
       <div class="tab-panel" class:active={tab === "goals"}>
         <GoalsTab {goalValue} {setGoal} {resetGoals} />
@@ -1920,6 +1930,17 @@
   .league-page :global(.button.subtle:hover) {
     color: var(--text);
     background: var(--surface-hover);
+    }
+
+  .league-page :global(.feature-badge) {
+    font-size: 10px;
+    font-weight: 400;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 1px 6px;
+    margin-left: 6px;
+    vertical-align: middle;
     }
 
   .league-page :global(.profile-tools) {


### PR DESCRIPTION
## O que

As abas **Ao vivo**, **Análise** e **Meta** passam a consumir o registro de features do PR #251: o estado vazio explica o motivo real (plataforma não suportada, cliente fechado, fora de partida) em vez de uma frase genérica, e as seções `beta` ganham um badge discreto.

## Origem / inspiração

Fecha o ciclo do `feature-gating` do `LeagueAkari` e a exigência da missão de que "estados de indisponibilidade explicam **por quê** e o que fazer". Nenhum código copiado.

Nota de design (skill `omniget-design`): o badge é um chip de 10px em `--text-muted` com borda, não um banner amarelo — experimentais são marcados "sem alarmismo", como pede a diretriz.

## Como testar

1. Fechar o cliente de LoL e abrir a aba Análise: a mensagem passa a ser "Abra o cliente de League of Legends para usar isto" em vez de "Disponível durante a seleção de campeões e em jogo".
2. Com o cliente aberto e fora de partida, a aba Ao vivo diz "Disponível durante uma partida".
3. A seção "Referência de build" (Meta) e "Objetivos e eventos" (Ao vivo) mostram o badge `beta`.
4. `pnpm test` — 58 testes passando (a lógica de `availability()` já foi coberta no #251).

## Plataformas

- [x] Windows: a plataforma é detectada pelo user agent do WebView; features declaradas só para desktop continuam disponíveis nos dois SOs
- [x] macOS testado (`pnpm check` 0 erros, `pnpm test` 58 passando)

## Estado

`stable` — sem flag: troca texto genérico por texto específico.

## Risco & rollback

Risco ToS: nenhum. Rollback: reverter o commit único.

## Débito deixado

- A plataforma vem do **user agent do WebView**, que é o único jeito de sabê-la no frontend sem uma ida ao backend. Funciona, mas o backend sabe melhor; se algum dia precisar ser confiável (e não apenas informativo), deve vir de um comando.
- Só três abas foram migradas. Overview, Search, Goals, Automation e History continuam com seus guards próprios — que funcionam, mas duplicam a decisão. Migrar as cinco restantes é um PR mecânico.
- O registro declara `platforms: ["windows", "macos"]` para as features que dependem do cliente. No Linux (onde o LoL roda via Wine) elas apareceriam como indisponíveis por plataforma, o que é honesto mas talvez pessimista demais — o `locator` não tenta caminhos de prefixo Wine.

## Depende de

- #251 (branch empilhada)
