### PR TITLE
fix(league): parar de redesenhar os oito paineis a cada evento

### DIFF
--- a/src-tauri/src/commands/league/mod.rs
+++ b/src-tauri/src/commands/league/mod.rs
@@ -48,12 +48,13 @@ async fn discover_client() -> Option<LcuClient> {
 }
 
 async fn get_client() -> Result<LcuClient, String> {
-    {
-        let cached = CACHED_CLIENT.lock().await;
-        if let Some(client) = cached.as_ref() {
-            if lcu_reachable(client).await {
-                return Ok(client.clone());
-            }
+    // The cached client is copied out before the reachability probe: holding the
+    // lock across a request would put every league command in a single file
+    // behind one network round trip, and a slow client stalls all of them.
+    let cached = { CACHED_CLIENT.lock().await.clone() };
+    if let Some(client) = cached {
+        if lcu_reachable(&client).await {
+            return Ok(client);
         }
     }
     let discovered = discover_client()
@@ -249,8 +250,33 @@ async fn lcu_post_raw(client: &LcuClient, path: &str) -> Result<Value, String> {
     lcu_send(client, reqwest::Method::POST, path, None).await
 }
 
+/// Settings are read on every websocket event, and reading them means parsing the
+/// settings file from disk. A short cache keeps that off the hot path while still
+/// picking up a toggle the user just flipped.
+static SETTINGS_CACHE: Lazy<
+    std::sync::Mutex<
+        Option<(
+            omniget_core::models::settings::LeagueSettings,
+            std::time::Instant,
+        )>,
+    >,
+> = Lazy::new(|| std::sync::Mutex::new(None));
+
+const SETTINGS_TTL: std::time::Duration = std::time::Duration::from_millis(2000);
+
 fn league_settings() -> omniget_core::models::settings::LeagueSettings {
-    crate::storage::config::load_settings_standalone().league
+    if let Ok(cache) = SETTINGS_CACHE.lock() {
+        if let Some((settings, at)) = cache.as_ref() {
+            if at.elapsed() < SETTINGS_TTL {
+                return settings.clone();
+            }
+        }
+    }
+    let settings = crate::storage::config::load_settings_standalone().league;
+    if let Ok(mut cache) = SETTINGS_CACHE.lock() {
+        *cache = Some((settings.clone(), std::time::Instant::now()));
+    }
+    settings
 }
 
 fn league_enabled() -> bool {

--- a/src-tauri/src/commands/league/ws.rs
+++ b/src-tauri/src/commands/league/ws.rs
@@ -17,9 +17,9 @@ static MESSAGE_SENT: AtomicBool = AtomicBool::new(false);
 static ACCEPT_PENDING: AtomicBool = AtomicBool::new(false);
 static NOTIFIED_READY_CHECK: AtomicBool = AtomicBool::new(false);
 #[allow(clippy::type_complexity)]
-static LAST_CHAMP_SELECT: once_cell::sync::Lazy<
-    tokio::sync::Mutex<Option<(String, std::time::Instant)>>,
-> = once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(None));
+static LAST_EMITTED: once_cell::sync::Lazy<
+    tokio::sync::Mutex<std::collections::HashMap<&'static str, (String, std::time::Instant)>>,
+> = once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(std::collections::HashMap::new()));
 static TRADES_HANDLED: once_cell::sync::Lazy<tokio::sync::Mutex<std::collections::HashSet<i64>>> =
     once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(std::collections::HashSet::new()));
 #[allow(clippy::type_complexity)]
@@ -177,6 +177,12 @@ async fn run_session(client: &LcuClient) -> Result<(), String> {
                 if text.is_empty() {
                     continue;
                 }
+                // The subscription is the whole firehose, and the client emits from
+                // every plugin it runs. Scanning the raw text for a uri we handle is
+                // far cheaper than parsing megabytes of JSON we would discard.
+                if !is_interesting(&text) {
+                    continue;
+                }
                 if let Ok(value) = serde_json::from_str::<Value>(&text) {
                     handle_event(client, &value).await;
                 }
@@ -283,19 +289,86 @@ fn champ_select_fingerprint(session: &Value) -> String {
     parts.join("|")
 }
 
-/// True when this session is worth pushing to the UI: something the panels read
-/// changed, or the heartbeat window elapsed.
-async fn should_emit_champ_select(session: &Value) -> bool {
+/// True when a payload is worth pushing to the UI: its fingerprint changed, or
+/// the heartbeat window elapsed. Every hot event goes through here — the client
+/// republishes lobby and ready-check state as often as champion select, and each
+/// one that reaches the webview forces a re-render.
+async fn should_emit(event: &'static str, fingerprint: String) -> bool {
     const HEARTBEAT: std::time::Duration = std::time::Duration::from_millis(1500);
-    let fingerprint = champ_select_fingerprint(session);
-    let mut last = LAST_CHAMP_SELECT.lock().await;
-    match last.as_ref() {
+    let mut seen = LAST_EMITTED.lock().await;
+    match seen.get(event) {
         Some((previous, at)) if previous == &fingerprint && at.elapsed() < HEARTBEAT => false,
         _ => {
-            *last = Some((fingerprint, std::time::Instant::now()));
+            seen.insert(event, (fingerprint, std::time::Instant::now()));
             true
         }
     }
+}
+
+/// The lobby republishes on every queue-estimate tick while searching, so the
+/// fingerprint covers the membership and the queue, not the countdown.
+fn lobby_fingerprint(lobby: &Value) -> String {
+    let mut parts = vec![
+        lobby
+            .get("gameConfig")
+            .and_then(|c| c.get("queueId"))
+            .and_then(Value::as_i64)
+            .unwrap_or(-1)
+            .to_string(),
+        lobby
+            .get("localMember")
+            .and_then(|m| m.get("isLeader"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            .to_string(),
+    ];
+    for member in lobby
+        .get("members")
+        .and_then(Value::as_array)
+        .unwrap_or(&vec![])
+    {
+        parts.push(format!(
+            "{}:{}:{}",
+            member
+                .get("summonerId")
+                .and_then(Value::as_i64)
+                .unwrap_or(0),
+            member
+                .get("firstPositionPreference")
+                .and_then(Value::as_str)
+                .unwrap_or(""),
+            member
+                .get("ready")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        ));
+    }
+    parts.join("|")
+}
+
+/// The ready check ticks its own timer; only the state and the answer matter.
+fn ready_check_fingerprint(data: &Value) -> String {
+    format!(
+        "{}:{}",
+        data.get("state").and_then(Value::as_str).unwrap_or(""),
+        data.get("playerResponse")
+            .and_then(Value::as_str)
+            .unwrap_or(""),
+    )
+}
+
+/// Uris this client acts on. Anything else the League client publishes is noise
+/// for us.
+const HANDLED_URIS: [&str; 5] = [
+    "/lol-gameflow/v1/gameflow-phase",
+    "/lol-matchmaking/v1/ready-check",
+    "/lol-champ-select/v1/session",
+    "/lol-lobby/v2/lobby",
+    "/lol-honor-v2/v1/ballot",
+];
+
+fn is_interesting(text: &str) -> bool {
+    HANDLED_URIS.iter().any(|uri| text.contains(uri))
 }
 
 async fn handle_event(client: &LcuClient, value: &Value) {
@@ -322,7 +395,9 @@ async fn handle_event(client: &LcuClient, value: &Value) {
                 .get("playerResponse")
                 .and_then(Value::as_str)
                 .unwrap_or("");
-            emit("league-ready-check", data.clone());
+            if should_emit("league-ready-check", ready_check_fingerprint(&data)).await {
+                emit("league-ready-check", data.clone());
+            }
             if !pending_ready_check(state) {
                 ACCEPT_PENDING.store(false, Ordering::SeqCst);
                 NOTIFIED_READY_CHECK.store(false, Ordering::SeqCst);
@@ -376,11 +451,11 @@ async fn handle_event(client: &LcuClient, value: &Value) {
                 TRADES_HANDLED.lock().await.clear();
                 SWAPS_HANDLED.lock().await.clear();
                 MESSAGE_SENT.store(false, Ordering::SeqCst);
-                *LAST_CHAMP_SELECT.lock().await = None;
+                LAST_EMITTED.lock().await.remove("league-champ-select");
                 emit("league-champ-select", Value::Null);
                 return;
             }
-            if should_emit_champ_select(&data).await {
+            if should_emit("league-champ-select", champ_select_fingerprint(&data)).await {
                 emit("league-champ-select", data.clone());
             }
             let settings = league_settings();
@@ -394,14 +469,12 @@ async fn handle_event(client: &LcuClient, value: &Value) {
             send_auto_message(client, &settings);
         }
         "/lol-lobby/v2/lobby" => {
-            emit(
-                "league-lobby",
-                if event_type == "Delete" {
-                    Value::Null
-                } else {
-                    data.clone()
-                },
-            );
+            if event_type == "Delete" {
+                LAST_EMITTED.lock().await.remove("league-lobby");
+                emit("league-lobby", Value::Null);
+            } else if should_emit("league-lobby", lobby_fingerprint(&data)).await {
+                emit("league-lobby", data.clone());
+            }
         }
         "/lol-honor-v2/v1/ballot" => {
             if event_type != "Delete" && league_settings().auto_honor {
@@ -749,5 +822,61 @@ mod tests {
     fn an_empty_session_is_fingerprinted_without_panicking() {
         assert!(!champ_select_fingerprint(&json!({})).is_empty());
         assert!(!champ_select_fingerprint(&Value::Null).is_empty());
+    }
+
+    #[test]
+    fn only_messages_for_a_handled_uri_are_parsed() {
+        assert!(is_interesting(
+            r#"[8,"OnJsonApiEvent",{"uri":"/lol-champ-select/v1/session","eventType":"Update"}]"#
+        ));
+        assert!(is_interesting(
+            r#"[8,"OnJsonApiEvent",{"uri":"/lol-lobby/v2/lobby"}]"#
+        ));
+        // The client publishes from every plugin it runs; none of this is ours.
+        assert!(!is_interesting(
+            r#"[8,"OnJsonApiEvent",{"uri":"/lol-hovercard/v1/friend-info/42"}]"#
+        ));
+        assert!(!is_interesting(
+            r#"[8,"OnJsonApiEvent",{"uri":"/lol-loot/v1/player-loot-map"}]"#
+        ));
+        assert!(!is_interesting(""));
+    }
+
+    #[test]
+    fn the_lobby_fingerprint_ignores_the_queue_countdown() {
+        let base = json!({
+            "gameConfig": { "queueId": 420 },
+            "localMember": { "isLeader": true },
+            "members": [{ "summonerId": 7, "firstPositionPreference": "JUNGLE", "ready": true }]
+        });
+        let mut ticked = base.clone();
+        ticked["gameConfig"]["queueEstimate"] = json!(93);
+        assert_eq!(lobby_fingerprint(&base), lobby_fingerprint(&ticked));
+
+        let mut joined = base.clone();
+        joined["members"][0]["summonerId"] = json!(8);
+        assert_ne!(lobby_fingerprint(&base), lobby_fingerprint(&joined));
+
+        let mut role = base.clone();
+        role["members"][0]["firstPositionPreference"] = json!("MIDDLE");
+        assert_ne!(lobby_fingerprint(&base), lobby_fingerprint(&role));
+    }
+
+    #[test]
+    fn the_ready_check_fingerprint_tracks_the_answer_not_the_clock() {
+        let base = json!({ "state": "InProgress", "playerResponse": "None", "timer": 8.4 });
+        let mut ticked = base.clone();
+        ticked["timer"] = json!(3.1);
+        assert_eq!(
+            ready_check_fingerprint(&base),
+            ready_check_fingerprint(&ticked)
+        );
+
+        let mut accepted = base.clone();
+        accepted["playerResponse"] = json!("Accepted");
+        assert_ne!(
+            ready_check_fingerprint(&base),
+            ready_check_fingerprint(&accepted)
+        );
     }
 }

--- a/src/components/league/AnalysisTab.svelte
+++ b/src/components/league/AnalysisTab.svelte
@@ -21,6 +21,7 @@
     timesSeenBefore,
     platform,
     clientConnected,
+    active,
   }: {
     analysis: any;
     analysisLoading: boolean;
@@ -36,6 +37,7 @@
     timesSeenBefore: (puuid: string) => number;
     platform?: Platform;
     clientConnected?: boolean;
+    active?: boolean;
   } = $props();
 
   let analysisFeature = featureById("analysis");
@@ -111,160 +113,162 @@
   }
 </script>
 
-{#if analysis}
-  <section class="card">
-    <div class="card-head">
-      <h3>{$t("league.win_title")}</h3>
-      <button class="button" onclick={onRefreshAnalysis} disabled={analysisLoading}>{$t("league.refresh")}</button>
-    </div>
-    <div class="winbar-wrap">
-      <div class="winbar" role="img" aria-label={`${$t("league.win_allies")} ${analysis.winProbability}%`}>
-        <div class="winbar-fill" style={`width:${analysis.winProbability}%`}></div>
-        <div class="winbar-range" style={`left:${analysis.winLow}%;width:${Math.max(analysis.winHigh - analysis.winLow, 0)}%`}></div>
+{#if active !== false}
+  {#if analysis}
+    <section class="card">
+      <div class="card-head">
+        <h3>{$t("league.win_title")}</h3>
+        <button class="button" onclick={onRefreshAnalysis} disabled={analysisLoading}>{$t("league.refresh")}</button>
       </div>
-      <div class="winbar-legend">
-        <span class="win-value">{analysis.winProbability}%</span>
-        <span class="win-range">{$t("league.win_interval")} {analysis.winLow}%–{analysis.winHigh}%</span>
+      <div class="winbar-wrap">
+        <div class="winbar" role="img" aria-label={`${$t("league.win_allies")} ${analysis.winProbability}%`}>
+          <div class="winbar-fill" style={`width:${analysis.winProbability}%`}></div>
+          <div class="winbar-range" style={`left:${analysis.winLow}%;width:${Math.max(analysis.winHigh - analysis.winLow, 0)}%`}></div>
+        </div>
+        <div class="winbar-legend">
+          <span class="win-value">{analysis.winProbability}%</span>
+          <span class="win-range">{$t("league.win_interval")} {analysis.winLow}%–{analysis.winHigh}%</span>
+        </div>
       </div>
-    </div>
-    <p class="win-note">
-      {$t("league.win_gap")} {analysis.ratingGap > 0 ? "+" : ""}{analysis.ratingGap} · {analysis.knownPlayers}/{analysis.totalPlayers} {$t("league.win_known")}
-    </p>
-    <p class="win-disclaimer">{$t("league.win_disclaimer")}</p>
-    {#if chatError}
-      <p class="action-error" role="alert">{chatError}</p>
-    {/if}
-    <div class="chat-send">
-      <input
-        class="input-text"
-        placeholder={$t("league.chat_placeholder") as string}
-        bind:value={chatPreview}
-      />
-      <button class="button" onclick={() => (chatPreview = buildChatSummary())}>{$t("league.chat_build")}</button>
-      <button class="button primary" onclick={sendChatSummary} disabled={chatSending || !chatPreview.trim()}>{$t("league.chat_send")}</button>
-    </div>
-    {#if analysis.premades?.length}
-      <div class="premade-row">
-        <span class="bench-label">{$t("league.premades")}</span>
-        {#each analysis.premades as group (group.label)}
-          <span class="scout-tag">{group.label}: {group.puuids.length} {$t("league.players")}</span>
-        {/each}
-        <span class="premade-source">
-          {analysis.premadeSource === "party"
-            ? $t("league.premade_source_party")
-            : $t("league.premade_source_history")}
-        </span>
+      <p class="win-note">
+        {$t("league.win_gap")} {analysis.ratingGap > 0 ? "+" : ""}{analysis.ratingGap} · {analysis.knownPlayers}/{analysis.totalPlayers} {$t("league.win_known")}
+      </p>
+      <p class="win-disclaimer">{$t("league.win_disclaimer")}</p>
+      {#if chatError}
+        <p class="action-error" role="alert">{chatError}</p>
+      {/if}
+      <div class="chat-send">
+        <input
+          class="input-text"
+          placeholder={$t("league.chat_placeholder") as string}
+          bind:value={chatPreview}
+        />
+        <button class="button" onclick={() => (chatPreview = buildChatSummary())}>{$t("league.chat_build")}</button>
+        <button class="button primary" onclick={sendChatSummary} disabled={chatSending || !chatPreview.trim()}>{$t("league.chat_send")}</button>
       </div>
-    {/if}
-  </section>
-{:else}
-  <div class="guard-card">
-    <p>{analysisAvailability.available ? $t("league.win_unavailable") : $t(analysisAvailability.reasonKey)}</p>
-    <button class="button" onclick={onRefreshAnalysis} disabled={analysisLoading}>{$t("league.refresh")}</button>
-  </div>
-{/if}
-
-{#if (phase === "ChampSelect" || phase === "InProgress") && scoutPlayers.length > 0}
-  <section class="card">
-    <div class="card-head">
-      <h3>{$t("league.scout_title")}</h3>
-      <button class="button" onclick={onRefreshScouting} disabled={scoutLoading}>{$t("league.refresh")}</button>
-    </div>
-    <div class="scout-teams">
-      {#if marked.ally.length > 0 || marked.enemy.length > 0 || squadSide}
-        <div class="scout-notices">
-          {#if marked.ally.length > 0}
-            <p class="scout-notice">
-              {$t("league.marked_in_allies")} <strong>{marked.ally.join(", ")}</strong>
-            </p>
-          {/if}
-          {#if marked.enemy.length > 0}
-            <p class="scout-notice">
-              {$t("league.marked_in_enemies")} <strong>{marked.enemy.join(", ")}</strong>
-            </p>
-          {/if}
-          {#if squadSide}
-            <p class="scout-notice">
-              {squadSide === "enemy" ? $t("league.squad_enemy") : $t("league.squad_ally")}
-            </p>
-          {/if}
+      {#if analysis.premades?.length}
+        <div class="premade-row">
+          <span class="bench-label">{$t("league.premades")}</span>
+          {#each analysis.premades as group (group.label)}
+            <span class="scout-tag">{group.label}: {group.puuids.length} {$t("league.players")}</span>
+          {/each}
+          <span class="premade-source">
+            {analysis.premadeSource === "party"
+              ? $t("league.premade_source_party")
+              : $t("league.premade_source_history")}
+          </span>
         </div>
       {/if}
-      {#each scoutGroups() as group (group.label)}
-        <div class="scout-team">
-          <h4 class="scout-team-title" class:enemy={!group.ally}>{group.label}</h4>
-          {#if group.list.length === 0}
-            <p class="empty-hint">{$t("league.scout_enemies_hidden")}</p>
-          {:else}
-            {#each group.list as p (p.puuid || String(p.cellId))}
-              {@const r = p.puuid ? scoutReports[p.puuid] : null}
-              <div class="scout-row">
-                <div class="scout-main">
-                  {#if p.championId > 0}
-                    <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${p.championId}.png`} alt="" title={championById.get(p.championId)?.name ?? ""} loading="lazy" />
-                  {:else}
-                    <div class="champ-icon small champ-empty" aria-hidden="true"></div>
-                  {/if}
-                  <div class="scout-id">
-                    <span class="scout-name">
-                      {p.gameName || "—"}{#if p.tagLine}<span class="tag">#{p.tagLine}</span>{/if}
-                      {#if p.puuid && timesSeenBefore(p.puuid) > 0}
-                        <span class="seen-badge" title={$t("league.seen_before_hint") as string}>{$t("league.seen_before")} ×{timesSeenBefore(p.puuid)}</span>
-                      {/if}
-                    </span>
-                    <span class="scout-rank">{r ? rankLabel(r.solo) : "…"}</span>
-                  </div>
-                  {#if r?.stats?.games > 0}
-                    <div class="scout-stats">
-                      <span class="scout-wr" class:good={r.stats.winrate >= 55} class:bad={r.stats.winrate <= 45}>{r.stats.winrate}% WR</span>
-                      <span class="scout-kda">
-                        {r.stats.kda} KDA{#if r.impact !== null && r.impact !== undefined} · <span class="impact" title={$t("league.impact_hint") as string}>{r.impact}</span>{/if}
+    </section>
+  {:else}
+    <div class="guard-card">
+      <p>{analysisAvailability.available ? $t("league.win_unavailable") : $t(analysisAvailability.reasonKey)}</p>
+      <button class="button" onclick={onRefreshAnalysis} disabled={analysisLoading}>{$t("league.refresh")}</button>
+    </div>
+  {/if}
+
+  {#if (phase === "ChampSelect" || phase === "InProgress") && scoutPlayers.length > 0}
+    <section class="card">
+      <div class="card-head">
+        <h3>{$t("league.scout_title")}</h3>
+        <button class="button" onclick={onRefreshScouting} disabled={scoutLoading}>{$t("league.refresh")}</button>
+      </div>
+      <div class="scout-teams">
+        {#if marked.ally.length > 0 || marked.enemy.length > 0 || squadSide}
+          <div class="scout-notices">
+            {#if marked.ally.length > 0}
+              <p class="scout-notice">
+                {$t("league.marked_in_allies")} <strong>{marked.ally.join(", ")}</strong>
+              </p>
+            {/if}
+            {#if marked.enemy.length > 0}
+              <p class="scout-notice">
+                {$t("league.marked_in_enemies")} <strong>{marked.enemy.join(", ")}</strong>
+              </p>
+            {/if}
+            {#if squadSide}
+              <p class="scout-notice">
+                {squadSide === "enemy" ? $t("league.squad_enemy") : $t("league.squad_ally")}
+              </p>
+            {/if}
+          </div>
+        {/if}
+        {#each scoutGroups() as group (group.label)}
+          <div class="scout-team">
+            <h4 class="scout-team-title" class:enemy={!group.ally}>{group.label}</h4>
+            {#if group.list.length === 0}
+              <p class="empty-hint">{$t("league.scout_enemies_hidden")}</p>
+            {:else}
+              {#each group.list as p (p.puuid || String(p.cellId))}
+                {@const r = p.puuid ? scoutReports[p.puuid] : null}
+                <div class="scout-row">
+                  <div class="scout-main">
+                    {#if p.championId > 0}
+                      <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${p.championId}.png`} alt="" title={championById.get(p.championId)?.name ?? ""} loading="lazy" />
+                    {:else}
+                      <div class="champ-icon small champ-empty" aria-hidden="true"></div>
+                    {/if}
+                    <div class="scout-id">
+                      <span class="scout-name">
+                        {p.gameName || "—"}{#if p.tagLine}<span class="tag">#{p.tagLine}</span>{/if}
+                        {#if p.puuid && timesSeenBefore(p.puuid) > 0}
+                          <span class="seen-badge" title={$t("league.seen_before_hint") as string}>{$t("league.seen_before")} ×{timesSeenBefore(p.puuid)}</span>
+                        {/if}
                       </span>
-                      {#if r.stats.score !== null && r.stats.score !== undefined}
-                        <span class="scout-score" title={`${$t("league.score_hint")} (${r.stats.scoredGames})`}>
-                          {$t("league.score_label")} {r.stats.score.toFixed(1)}
-                        </span>
-                      {/if}
+                      <span class="scout-rank">{r ? rankLabel(r.solo) : "…"}</span>
                     </div>
-                  {:else if r?.privateProfile}
-                    <span class="scout-private">{$t("league.scout_private")}</span>
-                  {:else if r?.historyUnavailable}
-                    <span class="scout-private">{$t("league.scout_no_history")}</span>
-                  {:else if r}
-                    <span class="scout-private">…</span>
-                  {/if}
-                  {#if p.gameName}
-                    <button class="note-toggle" onclick={() => copyRiotId(p)} aria-label={$t("league.copy_riot_id") as string} title={$t("league.copy_riot_id") as string}>
-                      {copied === (p.puuid ?? p.gameName) ? "✓" : "⧉"}
-                    </button>
-                  {/if}
-                  {#if p.puuid}
-                    <button class="note-toggle" class:has-note={(notes[p.puuid] ?? "").trim() !== ""} onclick={() => { openNotes = { ...openNotes, [p.puuid]: !openNotes[p.puuid] }; }} aria-label={$t("league.scout_note_placeholder") as string} aria-expanded={openNotes[p.puuid] ?? false}>✎</button>
-                  {/if}
-                </div>
-                {#if r?.stats?.topChampions?.length}
-                  <div class="scout-champs">
-                    {#each r.stats.topChampions as tc (tc.championId)}
-                      <span class="scout-champ">
-                        <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${tc.championId}.png`} alt="" title={championById.get(tc.championId)?.name ?? ""} loading="lazy" />
-                        <span class="scout-champ-record">{tc.wins}/{tc.games}</span>
-                      </span>
-                    {/each}
-                    {#if r?.stats?.insights?.length}
-                      {#each r.stats.insights as tag (tag)}
-                        <span class="scout-tag">{$t(TAG_KEYS[tag] ?? tag)}</span>
-                      {/each}
+                    {#if r?.stats?.games > 0}
+                      <div class="scout-stats">
+                        <span class="scout-wr" class:good={r.stats.winrate >= 55} class:bad={r.stats.winrate <= 45}>{r.stats.winrate}% WR</span>
+                        <span class="scout-kda">
+                          {r.stats.kda} KDA{#if r.impact !== null && r.impact !== undefined} · <span class="impact" title={$t("league.impact_hint") as string}>{r.impact}</span>{/if}
+                        </span>
+                        {#if r.stats.score !== null && r.stats.score !== undefined}
+                          <span class="scout-score" title={`${$t("league.score_hint")} (${r.stats.scoredGames})`}>
+                            {$t("league.score_label")} {r.stats.score.toFixed(1)}
+                          </span>
+                        {/if}
+                      </div>
+                    {:else if r?.privateProfile}
+                      <span class="scout-private">{$t("league.scout_private")}</span>
+                    {:else if r?.historyUnavailable}
+                      <span class="scout-private">{$t("league.scout_no_history")}</span>
+                    {:else if r}
+                      <span class="scout-private">…</span>
+                    {/if}
+                    {#if p.gameName}
+                      <button class="note-toggle" onclick={() => copyRiotId(p)} aria-label={$t("league.copy_riot_id") as string} title={$t("league.copy_riot_id") as string}>
+                        {copied === (p.puuid ?? p.gameName) ? "✓" : "⧉"}
+                      </button>
+                    {/if}
+                    {#if p.puuid}
+                      <button class="note-toggle" class:has-note={(notes[p.puuid] ?? "").trim() !== ""} onclick={() => { openNotes = { ...openNotes, [p.puuid]: !openNotes[p.puuid] }; }} aria-label={$t("league.scout_note_placeholder") as string} aria-expanded={openNotes[p.puuid] ?? false}>✎</button>
                     {/if}
                   </div>
-                {/if}
-                {#if p.puuid && (openNotes[p.puuid] || (notes[p.puuid] ?? "").trim() !== "")}
-                  <input class="input-text note-input" placeholder={$t("league.scout_note_placeholder") as string} value={notes[p.puuid] ?? ""} onchange={(e) => onSaveNote(p.puuid, e.currentTarget.value)} />
-                {/if}
-              </div>
-            {/each}
-          {/if}
-        </div>
-      {/each}
-    </div>
-  </section>
+                  {#if r?.stats?.topChampions?.length}
+                    <div class="scout-champs">
+                      {#each r.stats.topChampions as tc (tc.championId)}
+                        <span class="scout-champ">
+                          <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${tc.championId}.png`} alt="" title={championById.get(tc.championId)?.name ?? ""} loading="lazy" />
+                          <span class="scout-champ-record">{tc.wins}/{tc.games}</span>
+                        </span>
+                      {/each}
+                      {#if r?.stats?.insights?.length}
+                        {#each r.stats.insights as tag (tag)}
+                          <span class="scout-tag">{$t(TAG_KEYS[tag] ?? tag)}</span>
+                        {/each}
+                      {/if}
+                    </div>
+                  {/if}
+                  {#if p.puuid && (openNotes[p.puuid] || (notes[p.puuid] ?? "").trim() !== "")}
+                    <input class="input-text note-input" placeholder={$t("league.scout_note_placeholder") as string} value={notes[p.puuid] ?? ""} onchange={(e) => onSaveNote(p.puuid, e.currentTarget.value)} />
+                  {/if}
+                </div>
+              {/each}
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
 {/if}

--- a/src/components/league/AutomationTab.svelte
+++ b/src/components/league/AutomationTab.svelte
@@ -8,9 +8,11 @@
   let {
     champions,
     championById,
+    active,
   }: {
     champions: Champion[];
     championById: Map<number, Champion>;
+    active?: boolean;
   } = $props();
 
   let settings = $derived(getSettings());
@@ -102,251 +104,253 @@
   });
 </script>
 
-<section class="card">
-  <div class="card-head">
-    <h3>{$t("league.automation_title")}</h3>
-  </div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_accept")}</span>
-      <span class="action-hint">{$t("league.auto_accept_desc")}</span>
+{#if active !== false}
+  <section class="card">
+    <div class="card-head">
+      <h3>{$t("league.automation_title")}</h3>
     </div>
-    <button class="toggle" class:on={autoAccept} onclick={toggleAutoAccept} role="switch" aria-checked={autoAccept} aria-label={$t("league.auto_accept") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  {#if autoAccept}
-    <div class="delay-block">
-      <span class="list-label">
-        {$t("league.accept_delay")}
-        <span class="list-hint">
-          {acceptDelay === 0 ? $t("league.accept_delay_instant") : `${acceptDelay}s`}
-        </span>
-      </span>
-      <div class="slider-row">
-        <span class="slider-edge">0s</span>
-        <input
-          type="range"
-          min="0"
-          max="11"
-          step="1"
-          value={acceptDelay}
-          oninput={changeAcceptDelay}
-          aria-label={$t("league.accept_delay") as string}
-        />
-        <span class="slider-edge">11s</span>
-      </div>
-      <span class="action-hint">{$t("league.accept_delay_desc")}</span>
-    </div>
-  {/if}
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.notify_ready")}</span>
-      <span class="action-hint">{$t("league.notify_ready_desc")}</span>
-    </div>
-    <button class="toggle" class:on={settings?.league?.notify_ready_check ?? true} onclick={() => toggleLeagueFlag("notify_ready_check")} role="switch" aria-checked={settings?.league?.notify_ready_check ?? true} aria-label={$t("league.notify_ready") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_pick")}</span>
-      <span class="action-hint">{$t("league.auto_pick_desc")}</span>
-    </div>
-    <button class="toggle" class:on={settings?.league?.auto_pick} onclick={() => toggleLeagueFlag("auto_pick")} role="switch" aria-checked={settings?.league?.auto_pick ?? false} aria-label={$t("league.auto_pick") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  {#if settings?.league?.auto_pick}
-    <div class="champ-list-block">
-      <span class="list-label">{$t("league.pick_list")} <span class="list-hint">({$t("league.list_hint")})</span></span>
-      <div class="champ-chips">
-        {#each listFor("pick") as id (id)}
-          <span class="champ-chip">
-            <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${id}.png`} alt="" loading="lazy" />
-            {championById.get(id)?.name ?? id}
-            <button class="chip-remove" onclick={() => removeFromList("pick", id)} aria-label={`${$t("league.remove")} ${championById.get(id)?.name ?? id}`}>×</button>
-          </span>
-        {/each}
-      </div>
-      <div class="champ-search">
-        <input type="text" class="input-text" placeholder={$t("league.search_champion") as string} bind:value={pickSearch} />
-        {#if searchResults(pickSearch, "pick").length > 0}
-          <div class="search-results">
-            {#each searchResults(pickSearch, "pick") as c (c.id)}
-              <button class="search-result" onclick={() => addToList("pick", c.id)}>
-                <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${c.id}.png`} alt="" loading="lazy" />
-                {c.name}
-              </button>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    </div>
-  {/if}
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_ban")}</span>
-      <span class="action-hint">{$t("league.auto_ban_desc")}</span>
-    </div>
-    <button class="toggle" class:on={settings?.league?.auto_ban} onclick={() => toggleLeagueFlag("auto_ban")} role="switch" aria-checked={settings?.league?.auto_ban ?? false} aria-label={$t("league.auto_ban") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  {#if settings?.league?.auto_ban}
-    <div class="delay-block">
-      <span class="list-label">
-        {$t("league.ban_delay")}
-        <span class="list-hint">
-          {banDelay === 0 ? $t("league.accept_delay_instant") : `${banDelay}s`}
-        </span>
-      </span>
-      <div class="slider-row">
-        <span class="slider-edge">0s</span>
-        <input
-          type="range"
-          min="0"
-          max="25"
-          step="1"
-          value={banDelay}
-          oninput={changeBanDelay}
-          aria-label={$t("league.ban_delay") as string}
-        />
-        <span class="slider-edge">25s</span>
-      </div>
-      <span class="action-hint">{$t("league.ban_delay_desc")}</span>
-    </div>
-    <div class="champ-list-block">
-      <span class="list-label">{$t("league.ban_list")} <span class="list-hint">({$t("league.list_hint")})</span></span>
-      <div class="champ-chips">
-        {#each listFor("ban") as id (id)}
-          <span class="champ-chip">
-            <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${id}.png`} alt="" loading="lazy" />
-            {championById.get(id)?.name ?? id}
-            <button class="chip-remove" onclick={() => removeFromList("ban", id)} aria-label={`${$t("league.remove")} ${championById.get(id)?.name ?? id}`}>×</button>
-          </span>
-        {/each}
-      </div>
-      <div class="champ-search">
-        <input type="text" class="input-text" placeholder={$t("league.search_champion") as string} bind:value={banSearch} />
-        {#if searchResults(banSearch, "ban").length > 0}
-          <div class="search-results">
-            {#each searchResults(banSearch, "ban") as c (c.id)}
-              <button class="search-result" onclick={() => addToList("ban", c.id)}>
-                <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${c.id}.png`} alt="" loading="lazy" />
-                {c.name}
-              </button>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    </div>
-  {/if}
-  {#if settings?.league?.auto_pick}
-    <div class="divider"></div>
     <div class="action-row">
       <div class="action-col">
-        <span class="action-label">{$t("league.pick_confirm")}</span>
-        <span class="action-hint">{$t("league.pick_confirm_desc")}</span>
+        <span class="action-label">{$t("league.auto_accept")}</span>
+        <span class="action-hint">{$t("league.auto_accept_desc")}</span>
       </div>
-      <div class="seg-group" role="radiogroup" aria-label={$t("league.pick_confirm") as string}>
-        {#each ["declare", "timeout", "immediate"] as mode (mode)}
-          <button
-            class="seg"
-            class:on={pickConfirmMode === mode}
-            role="radio"
-            aria-checked={pickConfirmMode === mode}
-            onclick={() => setPickConfirm(mode)}
-          >{$t(`league.pick_confirm_${mode}`)}</button>
-        {/each}
-      </div>
-    </div>
-  {/if}
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_honor")}</span>
-      <span class="action-hint">{$t("league.auto_honor_desc")}</span>
-    </div>
-    <button class="toggle" class:on={settings?.league?.auto_honor} onclick={() => toggleLeagueFlag("auto_honor")} role="switch" aria-checked={settings?.league?.auto_honor ?? false} aria-label={$t("league.auto_honor") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_play_again")}</span>
-      <span class="action-hint">{$t("league.auto_play_again_desc")}</span>
-    </div>
-    <button class="toggle" class:on={settings?.league?.auto_play_again} onclick={() => toggleLeagueFlag("auto_play_again")} role="switch" aria-checked={settings?.league?.auto_play_again ?? false} aria-label={$t("league.auto_play_again") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_reconnect")}</span>
-      <span class="action-hint">{$t("league.auto_reconnect_desc")}</span>
-    </div>
-    <button class="toggle" class:on={settings?.league?.auto_reconnect} onclick={() => toggleLeagueFlag("auto_reconnect")} role="switch" aria-checked={settings?.league?.auto_reconnect ?? false} aria-label={$t("league.auto_reconnect") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_trade")}</span>
-      <span class="action-hint">{$t("league.auto_trade_desc")}</span>
-    </div>
-    <div class="seg-group" role="radiogroup" aria-label={$t("league.auto_trade") as string}>
-      {#each [["", "auto_trade_off"], ["accept", "auto_trade_accept"], ["decline", "auto_trade_decline"]] as [value, key] (value)}
-        <button
-          class="seg"
-          class:on={(settings?.league?.auto_trade ?? "") === value}
-          role="radio"
-          aria-checked={(settings?.league?.auto_trade ?? "") === value}
-          onclick={() => updateSettings({ league: { auto_trade: value } })}
-        >{$t(`league.${key}`)}</button>
-      {/each}
-    </div>
-  </div>
-  {#if settings?.league?.auto_play_again}
-    <div class="action-row">
-      <div class="action-col">
-        <span class="action-label">{$t("league.auto_requeue")}</span>
-        <span class="action-hint">{$t("league.auto_requeue_desc")}</span>
-      </div>
-      <button class="toggle" class:on={settings?.league?.auto_requeue} onclick={() => toggleLeagueFlag("auto_requeue")} role="switch" aria-checked={settings?.league?.auto_requeue ?? false} aria-label={$t("league.auto_requeue") as string}>
+      <button class="toggle" class:on={autoAccept} onclick={toggleAutoAccept} role="switch" aria-checked={autoAccept} aria-label={$t("league.auto_accept") as string}>
         <span class="toggle-knob"></span>
       </button>
     </div>
-  {/if}
-  <div class="divider"></div>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_swaps")}</span>
-      <span class="action-hint">{$t("league.auto_swaps_desc")}</span>
+    {#if autoAccept}
+      <div class="delay-block">
+        <span class="list-label">
+          {$t("league.accept_delay")}
+          <span class="list-hint">
+            {acceptDelay === 0 ? $t("league.accept_delay_instant") : `${acceptDelay}s`}
+          </span>
+        </span>
+        <div class="slider-row">
+          <span class="slider-edge">0s</span>
+          <input
+            type="range"
+            min="0"
+            max="11"
+            step="1"
+            value={acceptDelay}
+            oninput={changeAcceptDelay}
+            aria-label={$t("league.accept_delay") as string}
+          />
+          <span class="slider-edge">11s</span>
+        </div>
+        <span class="action-hint">{$t("league.accept_delay_desc")}</span>
+      </div>
+    {/if}
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.notify_ready")}</span>
+        <span class="action-hint">{$t("league.notify_ready_desc")}</span>
+      </div>
+      <button class="toggle" class:on={settings?.league?.notify_ready_check ?? true} onclick={() => toggleLeagueFlag("notify_ready_check")} role="switch" aria-checked={settings?.league?.notify_ready_check ?? true} aria-label={$t("league.notify_ready") as string}>
+        <span class="toggle-knob"></span>
+      </button>
     </div>
-    <button class="toggle" class:on={settings?.league?.auto_accept_swaps} onclick={() => toggleLeagueFlag("auto_accept_swaps")} role="switch" aria-checked={settings?.league?.auto_accept_swaps ?? false} aria-label={$t("league.auto_swaps") as string}>
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  <div class="divider"></div>
-  <div class="action-row stacked">
-    <div class="action-col">
-      <span class="action-label">{$t("league.auto_message")}</span>
-      <span class="action-hint">{$t("league.auto_message_desc")}</span>
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_pick")}</span>
+        <span class="action-hint">{$t("league.auto_pick_desc")}</span>
+      </div>
+      <button class="toggle" class:on={settings?.league?.auto_pick} onclick={() => toggleLeagueFlag("auto_pick")} role="switch" aria-checked={settings?.league?.auto_pick ?? false} aria-label={$t("league.auto_pick") as string}>
+        <span class="toggle-knob"></span>
+      </button>
     </div>
-    <input
-      class="input-text message-input"
-      type="text"
-      maxlength="120"
-      placeholder={$t("league.auto_message_placeholder") as string}
-      value={settings?.league?.auto_message ?? ""}
-      onchange={(e) => updateSettings({ league: { auto_message: e.currentTarget.value } })}
-    />
-  </div>
-</section>
+    {#if settings?.league?.auto_pick}
+      <div class="champ-list-block">
+        <span class="list-label">{$t("league.pick_list")} <span class="list-hint">({$t("league.list_hint")})</span></span>
+        <div class="champ-chips">
+          {#each listFor("pick") as id (id)}
+            <span class="champ-chip">
+              <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${id}.png`} alt="" loading="lazy" />
+              {championById.get(id)?.name ?? id}
+              <button class="chip-remove" onclick={() => removeFromList("pick", id)} aria-label={`${$t("league.remove")} ${championById.get(id)?.name ?? id}`}>×</button>
+            </span>
+          {/each}
+        </div>
+        <div class="champ-search">
+          <input type="text" class="input-text" placeholder={$t("league.search_champion") as string} bind:value={pickSearch} />
+          {#if searchResults(pickSearch, "pick").length > 0}
+            <div class="search-results">
+              {#each searchResults(pickSearch, "pick") as c (c.id)}
+                <button class="search-result" onclick={() => addToList("pick", c.id)}>
+                  <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${c.id}.png`} alt="" loading="lazy" />
+                  {c.name}
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {/if}
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_ban")}</span>
+        <span class="action-hint">{$t("league.auto_ban_desc")}</span>
+      </div>
+      <button class="toggle" class:on={settings?.league?.auto_ban} onclick={() => toggleLeagueFlag("auto_ban")} role="switch" aria-checked={settings?.league?.auto_ban ?? false} aria-label={$t("league.auto_ban") as string}>
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
+    {#if settings?.league?.auto_ban}
+      <div class="delay-block">
+        <span class="list-label">
+          {$t("league.ban_delay")}
+          <span class="list-hint">
+            {banDelay === 0 ? $t("league.accept_delay_instant") : `${banDelay}s`}
+          </span>
+        </span>
+        <div class="slider-row">
+          <span class="slider-edge">0s</span>
+          <input
+            type="range"
+            min="0"
+            max="25"
+            step="1"
+            value={banDelay}
+            oninput={changeBanDelay}
+            aria-label={$t("league.ban_delay") as string}
+          />
+          <span class="slider-edge">25s</span>
+        </div>
+        <span class="action-hint">{$t("league.ban_delay_desc")}</span>
+      </div>
+      <div class="champ-list-block">
+        <span class="list-label">{$t("league.ban_list")} <span class="list-hint">({$t("league.list_hint")})</span></span>
+        <div class="champ-chips">
+          {#each listFor("ban") as id (id)}
+            <span class="champ-chip">
+              <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${id}.png`} alt="" loading="lazy" />
+              {championById.get(id)?.name ?? id}
+              <button class="chip-remove" onclick={() => removeFromList("ban", id)} aria-label={`${$t("league.remove")} ${championById.get(id)?.name ?? id}`}>×</button>
+            </span>
+          {/each}
+        </div>
+        <div class="champ-search">
+          <input type="text" class="input-text" placeholder={$t("league.search_champion") as string} bind:value={banSearch} />
+          {#if searchResults(banSearch, "ban").length > 0}
+            <div class="search-results">
+              {#each searchResults(banSearch, "ban") as c (c.id)}
+                <button class="search-result" onclick={() => addToList("ban", c.id)}>
+                  <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${c.id}.png`} alt="" loading="lazy" />
+                  {c.name}
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {/if}
+    {#if settings?.league?.auto_pick}
+      <div class="divider"></div>
+      <div class="action-row">
+        <div class="action-col">
+          <span class="action-label">{$t("league.pick_confirm")}</span>
+          <span class="action-hint">{$t("league.pick_confirm_desc")}</span>
+        </div>
+        <div class="seg-group" role="radiogroup" aria-label={$t("league.pick_confirm") as string}>
+          {#each ["declare", "timeout", "immediate"] as mode (mode)}
+            <button
+              class="seg"
+              class:on={pickConfirmMode === mode}
+              role="radio"
+              aria-checked={pickConfirmMode === mode}
+              onclick={() => setPickConfirm(mode)}
+            >{$t(`league.pick_confirm_${mode}`)}</button>
+          {/each}
+        </div>
+      </div>
+    {/if}
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_honor")}</span>
+        <span class="action-hint">{$t("league.auto_honor_desc")}</span>
+      </div>
+      <button class="toggle" class:on={settings?.league?.auto_honor} onclick={() => toggleLeagueFlag("auto_honor")} role="switch" aria-checked={settings?.league?.auto_honor ?? false} aria-label={$t("league.auto_honor") as string}>
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_play_again")}</span>
+        <span class="action-hint">{$t("league.auto_play_again_desc")}</span>
+      </div>
+      <button class="toggle" class:on={settings?.league?.auto_play_again} onclick={() => toggleLeagueFlag("auto_play_again")} role="switch" aria-checked={settings?.league?.auto_play_again ?? false} aria-label={$t("league.auto_play_again") as string}>
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_reconnect")}</span>
+        <span class="action-hint">{$t("league.auto_reconnect_desc")}</span>
+      </div>
+      <button class="toggle" class:on={settings?.league?.auto_reconnect} onclick={() => toggleLeagueFlag("auto_reconnect")} role="switch" aria-checked={settings?.league?.auto_reconnect ?? false} aria-label={$t("league.auto_reconnect") as string}>
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_trade")}</span>
+        <span class="action-hint">{$t("league.auto_trade_desc")}</span>
+      </div>
+      <div class="seg-group" role="radiogroup" aria-label={$t("league.auto_trade") as string}>
+        {#each [["", "auto_trade_off"], ["accept", "auto_trade_accept"], ["decline", "auto_trade_decline"]] as [value, key] (value)}
+          <button
+            class="seg"
+            class:on={(settings?.league?.auto_trade ?? "") === value}
+            role="radio"
+            aria-checked={(settings?.league?.auto_trade ?? "") === value}
+            onclick={() => updateSettings({ league: { auto_trade: value } })}
+          >{$t(`league.${key}`)}</button>
+        {/each}
+      </div>
+    </div>
+    {#if settings?.league?.auto_play_again}
+      <div class="action-row">
+        <div class="action-col">
+          <span class="action-label">{$t("league.auto_requeue")}</span>
+          <span class="action-hint">{$t("league.auto_requeue_desc")}</span>
+        </div>
+        <button class="toggle" class:on={settings?.league?.auto_requeue} onclick={() => toggleLeagueFlag("auto_requeue")} role="switch" aria-checked={settings?.league?.auto_requeue ?? false} aria-label={$t("league.auto_requeue") as string}>
+          <span class="toggle-knob"></span>
+        </button>
+      </div>
+    {/if}
+    <div class="divider"></div>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_swaps")}</span>
+        <span class="action-hint">{$t("league.auto_swaps_desc")}</span>
+      </div>
+      <button class="toggle" class:on={settings?.league?.auto_accept_swaps} onclick={() => toggleLeagueFlag("auto_accept_swaps")} role="switch" aria-checked={settings?.league?.auto_accept_swaps ?? false} aria-label={$t("league.auto_swaps") as string}>
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
+    <div class="divider"></div>
+    <div class="action-row stacked">
+      <div class="action-col">
+        <span class="action-label">{$t("league.auto_message")}</span>
+        <span class="action-hint">{$t("league.auto_message_desc")}</span>
+      </div>
+      <input
+        class="input-text message-input"
+        type="text"
+        maxlength="120"
+        placeholder={$t("league.auto_message_placeholder") as string}
+        value={settings?.league?.auto_message ?? ""}
+        onchange={(e) => updateSettings({ league: { auto_message: e.currentTarget.value } })}
+      />
+    </div>
+  </section>
+{/if}

--- a/src/components/league/GoalsTab.svelte
+++ b/src/components/league/GoalsTab.svelte
@@ -6,39 +6,43 @@
     goalValue,
     setGoal,
     resetGoals,
+    active,
   }: {
     goalValue: (role: Role, key: GoalKey) => number;
     setGoal: (role: Role, key: GoalKey, value: number) => void;
     resetGoals: (role: Role) => void;
+    active?: boolean;
   } = $props();
 
   let goalRole = $state<Role>("MIDDLE");
 </script>
 
-<section class="card">
-  <div class="card-head">
-    <h3>{$t("league.goals_title")}</h3>
-    <select class="select-role" bind:value={goalRole} aria-label={$t("league.goals_role") as string}>
-      {#each ROLES as r (r)}
-        <option value={r}>{$t(`league.role_${r.toLowerCase()}`)}</option>
+{#if active !== false}
+  <section class="card">
+    <div class="card-head">
+      <h3>{$t("league.goals_title")}</h3>
+      <select class="select-role" bind:value={goalRole} aria-label={$t("league.goals_role") as string}>
+        {#each ROLES as r (r)}
+          <option value={r}>{$t(`league.role_${r.toLowerCase()}`)}</option>
+        {/each}
+      </select>
+    </div>
+    <p class="win-disclaimer">{$t("league.goals_desc")}</p>
+    <div class="goal-config">
+      {#each GOAL_FIELDS as field (field.key)}
+        <label class="goal-field">
+          <span class="goal-field-label">{$t(field.labelKey)}</span>
+          <input
+            type="number"
+            class="input-text"
+            min="0"
+            step={field.step}
+            value={goalValue(goalRole, field.key)}
+            onchange={(e) => setGoal(goalRole, field.key, Number(e.currentTarget.value))}
+          />
+        </label>
       {/each}
-    </select>
-  </div>
-  <p class="win-disclaimer">{$t("league.goals_desc")}</p>
-  <div class="goal-config">
-    {#each GOAL_FIELDS as field (field.key)}
-      <label class="goal-field">
-        <span class="goal-field-label">{$t(field.labelKey)}</span>
-        <input
-          type="number"
-          class="input-text"
-          min="0"
-          step={field.step}
-          value={goalValue(goalRole, field.key)}
-          onchange={(e) => setGoal(goalRole, field.key, Number(e.currentTarget.value))}
-        />
-      </label>
-    {/each}
-  </div>
-  <button class="button" onclick={() => resetGoals(goalRole)}>{$t("league.goals_reset")}</button>
-</section>
+    </div>
+    <button class="button" onclick={() => resetGoals(goalRole)}>{$t("league.goals_reset")}</button>
+  </section>
+{/if}

--- a/src/components/league/HistoryTab.svelte
+++ b/src/components/league/HistoryTab.svelte
@@ -11,11 +11,13 @@
     loading,
     onRefresh,
     championById,
+    active,
   }: {
     games: any[];
     loading: boolean;
     onRefresh: () => void;
     championById: Map<number, Champion>;
+    active?: boolean;
   } = $props();
 
   const QUEUE_NAMES: Record<number, string> = {
@@ -163,182 +165,184 @@
   }
 </script>
 
-<section class="history-section">
-  <div class="history-head">
-    <h3>{$t("league.history_title")}</h3>
-    <button class="button" onclick={onRefresh} disabled={loading}>{$t("league.refresh")}</button>
-  </div>
-  {#if games.length === 0}
-    <p class="empty-hint">{$t("league.history_empty")}</p>
-  {:else}
-    {#if availableQueues.length > 1}
-      <div class="queue-filter" role="group" aria-label={$t("league.filter_queue") as string}>
-        <button class="queue-chip" class:on={queueFilter === null} onclick={() => (queueFilter = null)} aria-pressed={queueFilter === null}>
-          {$t("league.filter_all")}
-        </button>
-        {#each availableQueues as id (id)}
-          <button class="queue-chip" class:on={queueFilter === id} onclick={() => (queueFilter = id)} aria-pressed={queueFilter === id}>
-            {queueName(id, "")}
-          </button>
-        {/each}
-      </div>
-    {/if}
-    <p class="history-summary">
-      {summary.counted}
-      {$t("league.summary_games")}
-      {#if summary.winrate !== null}
-        · <strong>{summary.wins}{$t("league.summary_win_short")} {summary.losses}{$t("league.summary_loss_short")}</strong> · {summary.winrate}%
-      {/if}
-      {#if summary.kda !== null}
-        · KDA {summary.kda.toFixed(2)}
-      {/if}
-      {#if summary.remakes > 0}
-        · <span class="dim">{summary.remakes} {$t("league.summary_remakes")}</span>
-      {/if}
-    </p>
-    <div class="game-list">
-      {#each visibleGames as game (game.gameId)}
-        {@const p = playerStats(game)}
-        <button
-          class="game-row"
-          class:expanded={expandedGame === game.gameId}
-          onclick={() => toggleGameDetail(game.gameId)}
-          aria-expanded={expandedGame === game.gameId}
-        >
-          <img class="champ-icon" src={`${CDRAGON}/champion-icons/${p.championId}.png`} alt="" loading="lazy" />
-          <div class="game-info">
-            <span class="game-result" class:win={p.win} class:loss={!p.win}>{p.win ? $t("league.victory") : $t("league.defeat")}</span>
-            <span class="game-mode">{queueName(game.queueId, game.gameMode)}</span>
-          </div>
-          <span class="game-kda">{p.kills} / {p.deaths} / {p.assists}</span>
-          <span class="game-time">{timeAgo(game.gameCreation, $locale)}</span>
-          <span class="game-chevron" aria-hidden="true">{expandedGame === game.gameId ? "▾" : "▸"}</span>
-        </button>
-        {#if expandedGame === game.gameId}
-          {#if gameDetailLoading === game.gameId}
-            <p class="empty-hint">…</p>
-          {:else if gameDetails[game.gameId]}
-            <div class="scoreboard">
-              {#each scoreboardTeams(gameDetails[game.gameId]) as team (team.teamId)}
-                {@const objectives = teamObjectives(findTeam(gameDetails[game.gameId]?.teams, team.teamId))}
-                {@const bans = teamBans(findTeam(gameDetails[game.gameId]?.teams, team.teamId))}
-                <div class="scoreboard-team">
-                  <span class="scoreboard-result" class:win={team.players[0]?.win} class:loss={!team.players[0]?.win}>
-                    {team.players[0]?.win ? $t("league.victory") : $t("league.defeat")}
-                  </span>
-                  {#if objectives}
-                    <div class="objective-line">
-                      <span>{$t("league.obj_towers")} <strong>{objectives.towers}</strong></span>
-                      <span>{$t("league.obj_inhibitors")} <strong>{objectives.inhibitors}</strong></span>
-                      <span>{$t("league.objective_baron")} <strong>{objectives.barons}</strong></span>
-                      <span>{$t("league.objective_dragon")} <strong>{objectives.dragons}</strong></span>
-                      <span>{$t("league.obj_heralds")} <strong>{objectives.heralds}</strong></span>
-                    </div>
-                  {/if}
-                  {#if bans.length > 0}
-                    <div class="ban-line">
-                      <span class="dim">{$t("league.obj_bans")}</span>
-                      {#each bans as banId, i (`${banId}-${i}`)}
-                        <img
-                          class="champ-icon tiny"
-                          src={`${CDRAGON}/champion-icons/${banId}.png`}
-                          alt=""
-                          title={championById.get(banId)?.name ?? ""}
-                          loading="lazy"
-                        />
-                      {/each}
-                    </div>
-                  {/if}
-                  {#each team.players as sp (sp.participantId)}
-                    <div class="scoreboard-row full">
-                      <div class="sb-identity">
-                        <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${sp.championId}.png`} alt="" title={championById.get(sp.championId)?.name ?? ""} loading="lazy" />
-                        <div class="sb-spells">
-                          {#each sp.spells ?? [] as spell (spell)}
-                            <img class="sb-spell" src={spellIcon(spell)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
-                          {/each}
-                        </div>
-                        {#if sp.runes}
-                          <div class="sb-runes">
-                            {#if perkIcons[sp.runes.perks?.[0]]}
-                              <img class="sb-rune keystone" src={perkIcons[sp.runes.perks[0]]} alt="" loading="lazy" />
-                            {/if}
-                            {#if sp.runes.subStyle}
-                              <img class="sb-rune" src={`${CDRAGON}/perk-images/styles/${sp.runes.subStyle}.png`} alt="" loading="lazy" />
-                            {/if}
-                          </div>
-                        {/if}
-                        {#if sp.puuid}
-                          <button class="sb-name link" onclick={() => openPlayer(sp)} title={$t("league.open_player") as string}>
-                            {sp.gameName || championById.get(sp.championId)?.name || "—"}
-                          </button>
-                        {:else}
-                          <span class="sb-name">{sp.gameName || championById.get(sp.championId)?.name || "—"}</span>
-                        {/if}
-                        <span class="scoreboard-kda">{sp.kills}/{sp.deaths}/{sp.assists}</span>
-                        <span class="dim">{$t("league.stat_level")} {sp.level}</span>
-                        <span class="scoreboard-cs dim">{sp.cs} CS</span>
-                        <span class="scoreboard-gold dim">{(sp.gold / 1000).toFixed(1)}k</span>
-                      </div>
-                      <div class="sb-items">
-                        {#each sp.items ?? [] as item, idx (`${idx}-${item}`)}
-                          {#if item > 0}
-                            <img class="item-icon tiny" src={itemIcon(item)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
-                          {:else}
-                            <span class="item-empty" aria-hidden="true"></span>
-                          {/if}
-                        {/each}
-                      </div>
-                      <div class="sb-stats">
-                        {#each statLine(sp) as stat (stat.key)}
-                          <span class="sb-stat"><span class="dim">{$t(stat.label)}</span> {stat.value}</span>
-                        {/each}
-                        {#if sp.pentaKills > 0}<span class="sb-flag">{$t("league.stat_penta")}</span>{/if}
-                        {#if sp.quadraKills > 0}<span class="sb-flag">{$t("league.stat_quadra")}</span>{/if}
-                        {#if sp.tripleKills > 0}<span class="sb-flag">{$t("league.stat_triple")}</span>{/if}
-                        {#if sp.firstBlood}<span class="sb-flag">{$t("league.stat_first_blood")}</span>{/if}
-                        {#if sp.firstTower}<span class="sb-flag">{$t("league.stat_first_tower")}</span>{/if}
-                      </div>
-                    </div>
-                  {/each}
-                </div>
-              {/each}
-            </div>
-          {:else}
-            <p class="empty-hint">{$t("league.match_detail_unavailable")}</p>
-          {/if}
-        {/if}
-      {/each}
+{#if active !== false}
+  <section class="history-section">
+    <div class="history-head">
+      <h3>{$t("league.history_title")}</h3>
+      <button class="button" onclick={onRefresh} disabled={loading}>{$t("league.refresh")}</button>
     </div>
-  {/if}
-  {#if lookupPuuid}
-    <div class="lookup-drawer">
-      <div class="card-head">
-        <h4 class="section-title">{lookupName}</h4>
-        <button class="button" onclick={closeLookup}>{$t("league.close")}</button>
-      </div>
-      {#if lookupLoading}
-        <p class="empty-hint">…</p>
-      {:else if lookupError}
-        <p class="action-error" role="alert">{lookupError}</p>
-      {:else if lookupGames.length === 0}
-        <p class="empty-hint">{$t("league.history_empty")}</p>
-      {:else}
-        <div class="game-list">
-          {#each lookupGames as g (g.gameId)}
-            {@const lp = playerStats(g)}
-            <div class="game-row static">
-              <img class="champ-icon" src={`${CDRAGON}/champion-icons/${lp.championId}.png`} alt="" loading="lazy" />
-              <div class="game-info">
-                <span class="game-result" class:win={lp.win} class:loss={!lp.win}>{lp.win ? $t("league.victory") : $t("league.defeat")}</span>
-                <span class="game-mode">{queueName(g.queueId, g.gameMode)}</span>
-              </div>
-              <span class="game-kda">{lp.kills} / {lp.deaths} / {lp.assists}</span>
-              <span class="game-time">{timeAgo(g.gameCreation, $locale)}</span>
-            </div>
+    {#if games.length === 0}
+      <p class="empty-hint">{$t("league.history_empty")}</p>
+    {:else}
+      {#if availableQueues.length > 1}
+        <div class="queue-filter" role="group" aria-label={$t("league.filter_queue") as string}>
+          <button class="queue-chip" class:on={queueFilter === null} onclick={() => (queueFilter = null)} aria-pressed={queueFilter === null}>
+            {$t("league.filter_all")}
+          </button>
+          {#each availableQueues as id (id)}
+            <button class="queue-chip" class:on={queueFilter === id} onclick={() => (queueFilter = id)} aria-pressed={queueFilter === id}>
+              {queueName(id, "")}
+            </button>
           {/each}
         </div>
       {/if}
-    </div>
-  {/if}
-</section>
+      <p class="history-summary">
+        {summary.counted}
+        {$t("league.summary_games")}
+        {#if summary.winrate !== null}
+          · <strong>{summary.wins}{$t("league.summary_win_short")} {summary.losses}{$t("league.summary_loss_short")}</strong> · {summary.winrate}%
+        {/if}
+        {#if summary.kda !== null}
+          · KDA {summary.kda.toFixed(2)}
+        {/if}
+        {#if summary.remakes > 0}
+          · <span class="dim">{summary.remakes} {$t("league.summary_remakes")}</span>
+        {/if}
+      </p>
+      <div class="game-list">
+        {#each visibleGames as game (game.gameId)}
+          {@const p = playerStats(game)}
+          <button
+            class="game-row"
+            class:expanded={expandedGame === game.gameId}
+            onclick={() => toggleGameDetail(game.gameId)}
+            aria-expanded={expandedGame === game.gameId}
+          >
+            <img class="champ-icon" src={`${CDRAGON}/champion-icons/${p.championId}.png`} alt="" loading="lazy" />
+            <div class="game-info">
+              <span class="game-result" class:win={p.win} class:loss={!p.win}>{p.win ? $t("league.victory") : $t("league.defeat")}</span>
+              <span class="game-mode">{queueName(game.queueId, game.gameMode)}</span>
+            </div>
+            <span class="game-kda">{p.kills} / {p.deaths} / {p.assists}</span>
+            <span class="game-time">{timeAgo(game.gameCreation, $locale)}</span>
+            <span class="game-chevron" aria-hidden="true">{expandedGame === game.gameId ? "▾" : "▸"}</span>
+          </button>
+          {#if expandedGame === game.gameId}
+            {#if gameDetailLoading === game.gameId}
+              <p class="empty-hint">…</p>
+            {:else if gameDetails[game.gameId]}
+              <div class="scoreboard">
+                {#each scoreboardTeams(gameDetails[game.gameId]) as team (team.teamId)}
+                  {@const objectives = teamObjectives(findTeam(gameDetails[game.gameId]?.teams, team.teamId))}
+                  {@const bans = teamBans(findTeam(gameDetails[game.gameId]?.teams, team.teamId))}
+                  <div class="scoreboard-team">
+                    <span class="scoreboard-result" class:win={team.players[0]?.win} class:loss={!team.players[0]?.win}>
+                      {team.players[0]?.win ? $t("league.victory") : $t("league.defeat")}
+                    </span>
+                    {#if objectives}
+                      <div class="objective-line">
+                        <span>{$t("league.obj_towers")} <strong>{objectives.towers}</strong></span>
+                        <span>{$t("league.obj_inhibitors")} <strong>{objectives.inhibitors}</strong></span>
+                        <span>{$t("league.objective_baron")} <strong>{objectives.barons}</strong></span>
+                        <span>{$t("league.objective_dragon")} <strong>{objectives.dragons}</strong></span>
+                        <span>{$t("league.obj_heralds")} <strong>{objectives.heralds}</strong></span>
+                      </div>
+                    {/if}
+                    {#if bans.length > 0}
+                      <div class="ban-line">
+                        <span class="dim">{$t("league.obj_bans")}</span>
+                        {#each bans as banId, i (`${banId}-${i}`)}
+                          <img
+                            class="champ-icon tiny"
+                            src={`${CDRAGON}/champion-icons/${banId}.png`}
+                            alt=""
+                            title={championById.get(banId)?.name ?? ""}
+                            loading="lazy"
+                          />
+                        {/each}
+                      </div>
+                    {/if}
+                    {#each team.players as sp (sp.participantId)}
+                      <div class="scoreboard-row full">
+                        <div class="sb-identity">
+                          <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${sp.championId}.png`} alt="" title={championById.get(sp.championId)?.name ?? ""} loading="lazy" />
+                          <div class="sb-spells">
+                            {#each sp.spells ?? [] as spell (spell)}
+                              <img class="sb-spell" src={spellIcon(spell)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
+                            {/each}
+                          </div>
+                          {#if sp.runes}
+                            <div class="sb-runes">
+                              {#if perkIcons[sp.runes.perks?.[0]]}
+                                <img class="sb-rune keystone" src={perkIcons[sp.runes.perks[0]]} alt="" loading="lazy" />
+                              {/if}
+                              {#if sp.runes.subStyle}
+                                <img class="sb-rune" src={`${CDRAGON}/perk-images/styles/${sp.runes.subStyle}.png`} alt="" loading="lazy" />
+                              {/if}
+                            </div>
+                          {/if}
+                          {#if sp.puuid}
+                            <button class="sb-name link" onclick={() => openPlayer(sp)} title={$t("league.open_player") as string}>
+                              {sp.gameName || championById.get(sp.championId)?.name || "—"}
+                            </button>
+                          {:else}
+                            <span class="sb-name">{sp.gameName || championById.get(sp.championId)?.name || "—"}</span>
+                          {/if}
+                          <span class="scoreboard-kda">{sp.kills}/{sp.deaths}/{sp.assists}</span>
+                          <span class="dim">{$t("league.stat_level")} {sp.level}</span>
+                          <span class="scoreboard-cs dim">{sp.cs} CS</span>
+                          <span class="scoreboard-gold dim">{(sp.gold / 1000).toFixed(1)}k</span>
+                        </div>
+                        <div class="sb-items">
+                          {#each sp.items ?? [] as item, idx (`${idx}-${item}`)}
+                            {#if item > 0}
+                              <img class="item-icon tiny" src={itemIcon(item)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
+                            {:else}
+                              <span class="item-empty" aria-hidden="true"></span>
+                            {/if}
+                          {/each}
+                        </div>
+                        <div class="sb-stats">
+                          {#each statLine(sp) as stat (stat.key)}
+                            <span class="sb-stat"><span class="dim">{$t(stat.label)}</span> {stat.value}</span>
+                          {/each}
+                          {#if sp.pentaKills > 0}<span class="sb-flag">{$t("league.stat_penta")}</span>{/if}
+                          {#if sp.quadraKills > 0}<span class="sb-flag">{$t("league.stat_quadra")}</span>{/if}
+                          {#if sp.tripleKills > 0}<span class="sb-flag">{$t("league.stat_triple")}</span>{/if}
+                          {#if sp.firstBlood}<span class="sb-flag">{$t("league.stat_first_blood")}</span>{/if}
+                          {#if sp.firstTower}<span class="sb-flag">{$t("league.stat_first_tower")}</span>{/if}
+                        </div>
+                      </div>
+                    {/each}
+                  </div>
+                {/each}
+              </div>
+            {:else}
+              <p class="empty-hint">{$t("league.match_detail_unavailable")}</p>
+            {/if}
+          {/if}
+        {/each}
+      </div>
+    {/if}
+    {#if lookupPuuid}
+      <div class="lookup-drawer">
+        <div class="card-head">
+          <h4 class="section-title">{lookupName}</h4>
+          <button class="button" onclick={closeLookup}>{$t("league.close")}</button>
+        </div>
+        {#if lookupLoading}
+          <p class="empty-hint">…</p>
+        {:else if lookupError}
+          <p class="action-error" role="alert">{lookupError}</p>
+        {:else if lookupGames.length === 0}
+          <p class="empty-hint">{$t("league.history_empty")}</p>
+        {:else}
+          <div class="game-list">
+            {#each lookupGames as g (g.gameId)}
+              {@const lp = playerStats(g)}
+              <div class="game-row static">
+                <img class="champ-icon" src={`${CDRAGON}/champion-icons/${lp.championId}.png`} alt="" loading="lazy" />
+                <div class="game-info">
+                  <span class="game-result" class:win={lp.win} class:loss={!lp.win}>{lp.win ? $t("league.victory") : $t("league.defeat")}</span>
+                  <span class="game-mode">{queueName(g.queueId, g.gameMode)}</span>
+                </div>
+                <span class="game-kda">{lp.kills} / {lp.deaths} / {lp.assists}</span>
+                <span class="game-time">{timeAgo(g.gameCreation, $locale)}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </section>
+{/if}

--- a/src/components/league/LiveTab.svelte
+++ b/src/components/league/LiveTab.svelte
@@ -10,6 +10,7 @@
     goalValue,
     platform,
     clientConnected,
+    active,
   }: {
     liveMetrics: any;
     cooldowns: any;
@@ -17,6 +18,7 @@
     goalValue: (role: Role, key: GoalKey) => number;
     platform?: Platform;
     clientConnected?: boolean;
+    active?: boolean;
   } = $props();
 
   let context = $derived({
@@ -164,158 +166,160 @@
   );
 </script>
 
-{#if liveMetrics?.players?.length}
-  <section class="card">
-    <div class="card-head">
-      <h3>{$t("league.gold_title")}</h3>
-      <span class="phase-tag">{formatGameTime(liveMetrics.gameTime ?? 0)}</span>
-    </div>
-    <p class="win-disclaimer">{$t("league.col_gold_hint")}</p>
-    <div class="gold-summary">
-      <span class="gold-team">{$t("league.your_team")}: <strong>{liveMetrics.teamGold?.[myTeam] ?? 0}</strong></span>
-      <span class="gold-diff" class:good={teamGoldLead > 0} class:bad={teamGoldLead < 0}>
-        {teamGoldLead > 0 ? "+" : ""}{teamGoldLead}
-      </span>
-      <span class="gold-team">{$t("league.enemy_team")}: <strong>{liveMetrics.teamGold?.[enemyTeam] ?? 0}</strong></span>
-    </div>
-    <div class="metric-table" role="table">
-      <div class="metric-head" role="row">
-        <span role="columnheader">{$t("league.col_player")}</span>
-        <span role="columnheader">KDA</span>
-        <span role="columnheader">CS</span>
-        <span role="columnheader" title={$t("league.col_gold_hint") as string}>{$t("league.col_gold")}</span>
-        <span role="columnheader">{$t("league.col_diff")}</span>
-      </div>
-      {#each liveMetrics.players as row (row.riotId)}
-        <div class="metric-row" role="row" class:self={row.isSelf}>
-          <span class="metric-name" role="cell">
-            <span class="pos-chip">{(row.position ?? "?").slice(0, 3)}</span>
-            {row.championName}
-          </span>
-          <span role="cell">{row.kills}/{row.deaths}/{row.assists}</span>
-          <span role="cell">{row.cs} <span class="dim">({row.csPerMin}/m)</span></span>
-          <span role="cell">{row.itemGold}</span>
-          <span role="cell" class="diff" class:good={(row.goldDiff ?? 0) > 0} class:bad={(row.goldDiff ?? 0) < 0}>
-            {#if row.goldDiff !== undefined && row.goldDiff !== null}
-              {row.goldDiff > 0 ? "+" : ""}{row.goldDiff}g
-              <span class="dim">{(row.csDiff ?? 0) > 0 ? "+" : ""}{Math.round(row.csDiff ?? 0)}cs</span>
-            {:else}—{/if}
-          </span>
-        </div>
-      {/each}
-    </div>
-  </section>
-
-  {#if enemyCooldowns.length > 0}
+{#if active !== false}
+  {#if liveMetrics?.players?.length}
     <section class="card">
       <div class="card-head">
-        <h3>{$t("league.cd_title")}</h3>
-        <span class="phase-tag">{$t("league.cd_estimated")}</span>
+        <h3>{$t("league.gold_title")}</h3>
+        <span class="phase-tag">{formatGameTime(liveMetrics.gameTime ?? 0)}</span>
       </div>
-      <p class="win-disclaimer">{$t("league.cd_desc")}</p>
-      <div class="cd-list">
-        {#each enemyCooldowns as p (p.riotId)}
-          <div class="cd-row">
-            <div class="cd-champ">
-              {#if p.championId > 0}
-                <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${p.championId}.png`} alt="" loading="lazy" />
-              {/if}
-              <div class="cd-id">
-                <span class="cd-name">{p.championName}</span>
-                <span class="dim">{$t("league.cd_haste")} {p.abilityHaste} · lv{p.level}</span>
+      <p class="win-disclaimer">{$t("league.col_gold_hint")}</p>
+      <div class="gold-summary">
+        <span class="gold-team">{$t("league.your_team")}: <strong>{liveMetrics.teamGold?.[myTeam] ?? 0}</strong></span>
+        <span class="gold-diff" class:good={teamGoldLead > 0} class:bad={teamGoldLead < 0}>
+          {teamGoldLead > 0 ? "+" : ""}{teamGoldLead}
+        </span>
+        <span class="gold-team">{$t("league.enemy_team")}: <strong>{liveMetrics.teamGold?.[enemyTeam] ?? 0}</strong></span>
+      </div>
+      <div class="metric-table" role="table">
+        <div class="metric-head" role="row">
+          <span role="columnheader">{$t("league.col_player")}</span>
+          <span role="columnheader">KDA</span>
+          <span role="columnheader">CS</span>
+          <span role="columnheader" title={$t("league.col_gold_hint") as string}>{$t("league.col_gold")}</span>
+          <span role="columnheader">{$t("league.col_diff")}</span>
+        </div>
+        {#each liveMetrics.players as row (row.riotId)}
+          <div class="metric-row" role="row" class:self={row.isSelf}>
+            <span class="metric-name" role="cell">
+              <span class="pos-chip">{(row.position ?? "?").slice(0, 3)}</span>
+              {row.championName}
+            </span>
+            <span role="cell">{row.kills}/{row.deaths}/{row.assists}</span>
+            <span role="cell">{row.cs} <span class="dim">({row.csPerMin}/m)</span></span>
+            <span role="cell">{row.itemGold}</span>
+            <span role="cell" class="diff" class:good={(row.goldDiff ?? 0) > 0} class:bad={(row.goldDiff ?? 0) < 0}>
+              {#if row.goldDiff !== undefined && row.goldDiff !== null}
+                {row.goldDiff > 0 ? "+" : ""}{row.goldDiff}g
+                <span class="dim">{(row.csDiff ?? 0) > 0 ? "+" : ""}{Math.round(row.csDiff ?? 0)}cs</span>
+              {:else}—{/if}
+            </span>
+          </div>
+        {/each}
+      </div>
+    </section>
+
+    {#if enemyCooldowns.length > 0}
+      <section class="card">
+        <div class="card-head">
+          <h3>{$t("league.cd_title")}</h3>
+          <span class="phase-tag">{$t("league.cd_estimated")}</span>
+        </div>
+        <p class="win-disclaimer">{$t("league.cd_desc")}</p>
+        <div class="cd-list">
+          {#each enemyCooldowns as p (p.riotId)}
+            <div class="cd-row">
+              <div class="cd-champ">
+                {#if p.championId > 0}
+                  <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${p.championId}.png`} alt="" loading="lazy" />
+                {/if}
+                <div class="cd-id">
+                  <span class="cd-name">{p.championName}</span>
+                  <span class="dim">{$t("league.cd_haste")} {p.abilityHaste} · lv{p.level}</span>
+                </div>
+              </div>
+              <div class="cd-abilities">
+                {#each p.abilities as ab (ab.key)}
+                  <span class="cd-ability" title={`${ab.name ?? ""} (${ab.key})`}>
+                    {#if ab.iconPath}
+                      <img class="ability-icon" src={assetUrl(ab.iconPath)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
+                    {/if}
+                    <span class="cd-key">{ab.key}</span>
+                    <span class="cd-value">{ab.cooldown > 0 ? `${ab.cooldown}s` : "—"}</span>
+                  </span>
+                {/each}
+                {#each p.spellTimers ?? [] as sp (sp.name)}
+                  {@const remaining = spellRemaining(p.riotId, sp)}
+                  <button
+                    class="cd-ability spell-timer"
+                    class:running={remaining !== null}
+                    onclick={() => toggleSpellTimer(p.riotId, sp)}
+                    title={`${sp.name} — ${$t("league.spell_timer_hint")}`}
+                    aria-pressed={remaining !== null}
+                  >
+                    {#if sp.iconPath}
+                      <img class="ability-icon" src={assetUrl(sp.iconPath)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
+                    {/if}
+                    <span class="cd-value">{remaining !== null ? `${remaining}s` : sp.cooldown > 0 ? `${sp.cooldown}s` : "—"}</span>
+                  </button>
+                {/each}
               </div>
             </div>
-            <div class="cd-abilities">
-              {#each p.abilities as ab (ab.key)}
-                <span class="cd-ability" title={`${ab.name ?? ""} (${ab.key})`}>
-                  {#if ab.iconPath}
-                    <img class="ability-icon" src={assetUrl(ab.iconPath)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
-                  {/if}
-                  <span class="cd-key">{ab.key}</span>
-                  <span class="cd-value">{ab.cooldown > 0 ? `${ab.cooldown}s` : "—"}</span>
-                </span>
-              {/each}
-              {#each p.spellTimers ?? [] as sp (sp.name)}
-                {@const remaining = spellRemaining(p.riotId, sp)}
-                <button
-                  class="cd-ability spell-timer"
-                  class:running={remaining !== null}
-                  onclick={() => toggleSpellTimer(p.riotId, sp)}
-                  title={`${sp.name} — ${$t("league.spell_timer_hint")}`}
-                  aria-pressed={remaining !== null}
-                >
-                  {#if sp.iconPath}
-                    <img class="ability-icon" src={assetUrl(sp.iconPath)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
-                  {/if}
-                  <span class="cd-value">{remaining !== null ? `${remaining}s` : sp.cooldown > 0 ? `${sp.cooldown}s` : "—"}</span>
-                </button>
-              {/each}
-            </div>
-          </div>
-        {/each}
-      </div>
-    </section>
-  {/if}
-
-  {#if objectives.length > 0 || feed.length > 0}
-    <section class="card">
-      <div class="card-head">
-        <h3>
-          {$t("league.objectives_title")}
-          {#if objectivesFeature && needsBadge(objectivesFeature)}
-            <span class="feature-badge">{$t(`league.badge_${objectivesFeature.state}`)}</span>
-          {/if}
-        </h3>
-        <h3>{$t("league.objectives_title")}</h3>
-      </div>
-      {#if objectives.length > 0}
-        <div class="objective-row">
-          {#each objectives as objective (objective.kind)}
-            <span class="objective-chip">
-              <strong>{$t(`league.objective_${objective.kind}`)}</strong>
-              {formatGameTime(objective.left)}
-            </span>
           {/each}
         </div>
-        <p class="win-disclaimer">{$t("league.objectives_estimate")}</p>
-      {/if}
-      {#if feed.length > 0}
-        <ul class="event-feed">
-          {#each feed as event (`${event.id}:${event.at}`)}
-            <li class="event-item">
-              <span class="event-time">{formatGameTime(event.at)}</span>
-              <span class="event-text">
-                {$t(EVENT_LABELS[event.name])}
-                {#if event.actor}<strong>{event.actor}</strong>{/if}
-                {#if event.target}<span class="dim">→ {event.target}</span>{/if}
-                {#if event.detail}<span class="dim">({event.detail})</span>{/if}
-              </span>
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </section>
-  {/if}
+      </section>
+    {/if}
 
-  {#if selfRow}
-    <section class="card">
-      <div class="card-head">
-        <h3>{$t("league.goals_live")}</h3>
-        <span class="phase-tag">{selfRow.position ?? "?"}</span>
-      </div>
-      <div class="goal-list">
-        {#each liveGoals as goal (goal.key)}
-          <div class="goal-row">
-            <span class="goal-name">{$t(goal.labelKey)}</span>
-            <div class="goal-bar"><div class="goal-fill" class:met={goal.ratio >= 1} style={`width:${Math.min(goal.ratio * 100, 100)}%`}></div></div>
-            <span class="goal-value" class:met={goal.ratio >= 1}>{goal.current} <span class="dim">/ {goal.target}</span></span>
+    {#if objectives.length > 0 || feed.length > 0}
+      <section class="card">
+        <div class="card-head">
+          <h3>
+            {$t("league.objectives_title")}
+            {#if objectivesFeature && needsBadge(objectivesFeature)}
+              <span class="feature-badge">{$t(`league.badge_${objectivesFeature.state}`)}</span>
+            {/if}
+          </h3>
+          <h3>{$t("league.objectives_title")}</h3>
+        </div>
+        {#if objectives.length > 0}
+          <div class="objective-row">
+            {#each objectives as objective (objective.kind)}
+              <span class="objective-chip">
+                <strong>{$t(`league.objective_${objective.kind}`)}</strong>
+                {formatGameTime(objective.left)}
+              </span>
+            {/each}
           </div>
-        {/each}
-      </div>
-    </section>
+          <p class="win-disclaimer">{$t("league.objectives_estimate")}</p>
+        {/if}
+        {#if feed.length > 0}
+          <ul class="event-feed">
+            {#each feed as event (`${event.id}:${event.at}`)}
+              <li class="event-item">
+                <span class="event-time">{formatGameTime(event.at)}</span>
+                <span class="event-text">
+                  {$t(EVENT_LABELS[event.name])}
+                  {#if event.actor}<strong>{event.actor}</strong>{/if}
+                  {#if event.target}<span class="dim">→ {event.target}</span>{/if}
+                  {#if event.detail}<span class="dim">({event.detail})</span>{/if}
+                </span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
+    {/if}
+
+    {#if selfRow}
+      <section class="card">
+        <div class="card-head">
+          <h3>{$t("league.goals_live")}</h3>
+          <span class="phase-tag">{selfRow.position ?? "?"}</span>
+        </div>
+        <div class="goal-list">
+          {#each liveGoals as goal (goal.key)}
+            <div class="goal-row">
+              <span class="goal-name">{$t(goal.labelKey)}</span>
+              <div class="goal-bar"><div class="goal-fill" class:met={goal.ratio >= 1} style={`width:${Math.min(goal.ratio * 100, 100)}%`}></div></div>
+              <span class="goal-value" class:met={goal.ratio >= 1}>{goal.current} <span class="dim">/ {goal.target}</span></span>
+            </div>
+          {/each}
+        </div>
+      </section>
+    {/if}
+  {:else}
+    <div class="guard-card">
+      <p>{liveAvailability.available ? $t("league.gold_unavailable") : $t(liveAvailability.reasonKey)}</p>
+    </div>
   {/if}
-{:else}
-  <div class="guard-card">
-    <p>{liveAvailability.available ? $t("league.gold_unavailable") : $t(liveAvailability.reasonKey)}</p>
-  </div>
 {/if}

--- a/src/components/league/MetaTab.svelte
+++ b/src/components/league/MetaTab.svelte
@@ -13,12 +13,14 @@
     championById,
     champions,
     region,
+    active,
   }: {
     champSelectChampionId: number;
     myAssignedPosition: string;
     championById: Map<number, Champion>;
     champions: Champion[];
     region: string | null;
+    active?: boolean;
   } = $props();
 
   let settings = $derived(getSettings());
@@ -236,198 +238,200 @@
   });
 </script>
 
-<section class="card">
-  <div class="card-head">
-    <h3>{$t("league.runes_title")}</h3>
-    {#if champSelectChampionId > 0}
-      <span class="phase-tag">{championById.get(champSelectChampionId)?.name ?? champSelectChampionId}</span>
-    {/if}
-  </div>
-  <p class="win-disclaimer">{$t("league.runes_desc")}</p>
-  <div class="action-row">
-    <div class="action-col">
-      <span class="action-label">{$t("league.runes_auto")}</span>
-      <span class="action-hint">{$t("league.runes_auto_desc")}</span>
-    </div>
-    <button
-      class="toggle"
-      class:on={settings?.league?.auto_runes}
-      onclick={toggleAutoRunes}
-      role="switch"
-      aria-checked={settings?.league?.auto_runes ?? false}
-      aria-label={$t("league.runes_auto") as string}
-    >
-      <span class="toggle-knob"></span>
-    </button>
-  </div>
-  {#if runeError}
-    <p class="action-error" role="alert">{runeError}</p>
-  {/if}
-  {#if runePages.length > 0}
-    <div class="rune-list">
-      {#each runePages as page, i (page.recommendationId ?? i)}
-        <div class="rune-card" class:applied={appliedRuneIndex === i}>
-          <div class="rune-head">
-            <span class="rune-keystone">{page.keystoneName ?? page.keystoneId}</span>
-            {#if page.isDefault}
-              <span class="scout-tag">{$t("league.runes_default")}</span>
-            {/if}
-          </div>
-          <div class="rune-perks">
-            {#each page.selectedPerkIds as perkId (perkId)}
-              <img
-                class="perk-icon"
-                src={`${CDRAGON}/perk-images/styles/${perkId}.png`}
-                alt=""
-                title={perkName(perkId)}
-                loading="lazy"
-                onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }}
-              />
-            {/each}
-          </div>
-          <div class="rune-foot">
-            <span class="dim">{$t("league.runes_spells")}: {(page.summonerSpellIds ?? []).map(spellName).join(" + ")}</span>
-            <button class="button" onclick={() => applyRunePage(i)} disabled={runeApplying}>
-              {$t("league.runes_apply")}
-            </button>
-          </div>
-        </div>
-      {/each}
-    </div>
-  {:else}
-    <p class="empty-hint">{$t("league.runes_empty")}</p>
-  {/if}
-</section>
-
-<section class="card">
-  <div class="card-head">
-    <h3>{$t("league.build_title")}</h3>
-    <button
-      class="button"
-      onclick={() => loadBuild(champSelectChampionId || (buildChampionId ?? 0))}
-      disabled={buildLoading || (!champSelectChampionId && !buildChampionId)}
-    >{$t("league.refresh")}</button>
-  </div>
-  <p class="win-disclaimer">{$t("league.build_desc")}</p>
-  <div class="build-picker">
-    <select class="select-role" bind:value={buildChampionId} aria-label={$t("league.build_champion") as string}>
-      <option value={0}>{$t("league.build_champion")}</option>
-      {#each champions as ch (ch.id)}
-        <option value={ch.id}>{ch.name}</option>
-      {/each}
-    </select>
-  </div>
-  {#if buildInfo && buildInfo.gamesSeen > 0}
-    <p class="win-note">
-      {buildInfo.gamesSeen} {$t("league.build_samples")} · {buildInfo.winrate}% {$t("league.stat_winrate")}
-    </p>
-    <div class="build-items">
-      {#each buildInfo.items as it (it.itemId)}
-        <span class="build-item">
-          <img class="item-icon" src={`${CDRAGON}/../../game/assets/items/icons2d/${it.itemId}.png`} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
-          <span class="dim">{it.pickRate}%</span>
-        </span>
-      {/each}
-    </div>
-    {#if buildInfo.spells?.length}
-      <p class="win-note">{$t("league.runes_spells")}: {buildInfo.spells.map((s: any) => s.spellIds.map(spellName).join(" + ")).join(" / ")}</p>
-    {/if}
-  {:else if buildInfo}
-    <p class="empty-hint">{$t("league.build_empty")}</p>
-  {/if}
-  <div class="divider"></div>
-  <div class="card-head">
-    <h4 class="section-title">
-      {$t("league.meta_reference")}
-      {#if buildFeature && needsBadge(buildFeature)}
-        <span class="feature-badge">{$t(`league.badge_${buildFeature.state}`)}</span>
+{#if active !== false}
+  <section class="card">
+    <div class="card-head">
+      <h3>{$t("league.runes_title")}</h3>
+      {#if champSelectChampionId > 0}
+        <span class="phase-tag">{championById.get(champSelectChampionId)?.name ?? champSelectChampionId}</span>
       {/if}
-    </h4>
-    <h4 class="section-title">{$t("league.meta_reference")}</h4>
-    <button
-      class="button"
-      onclick={() => loadMeta(champSelectChampionId || (buildChampionId ?? 0))}
-      disabled={metaLoading || (!champSelectChampionId && !buildChampionId)}
-    >{$t("league.refresh")}</button>
-  </div>
-  {#if metaError}
-    <p class="action-error" role="alert">{metaError}</p>
-  {:else if metaLoading}
-    <p class="empty-hint">…</p>
-  {:else if metaInfo}
-    {#if metaInfo.skillPriority?.length}
-      <p class="win-note">
-        {$t("league.skill_priority")}: <strong>{metaInfo.skillPriority.join(" › ")}</strong>
-      </p>
-      <div class="skill-order">
-        {#each metaInfo.skillOrder as skill, i (`${i}-${skill}`)}
-          <span class="skill-step" class:ult={skill === "R"}>{skill}</span>
+    </div>
+    <p class="win-disclaimer">{$t("league.runes_desc")}</p>
+    <div class="action-row">
+      <div class="action-col">
+        <span class="action-label">{$t("league.runes_auto")}</span>
+        <span class="action-hint">{$t("league.runes_auto_desc")}</span>
+      </div>
+      <button
+        class="toggle"
+        class:on={settings?.league?.auto_runes}
+        onclick={toggleAutoRunes}
+        role="switch"
+        aria-checked={settings?.league?.auto_runes ?? false}
+        aria-label={$t("league.runes_auto") as string}
+      >
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
+    {#if runeError}
+      <p class="action-error" role="alert">{runeError}</p>
+    {/if}
+    {#if runePages.length > 0}
+      <div class="rune-list">
+        {#each runePages as page, i (page.recommendationId ?? i)}
+          <div class="rune-card" class:applied={appliedRuneIndex === i}>
+            <div class="rune-head">
+              <span class="rune-keystone">{page.keystoneName ?? page.keystoneId}</span>
+              {#if page.isDefault}
+                <span class="scout-tag">{$t("league.runes_default")}</span>
+              {/if}
+            </div>
+            <div class="rune-perks">
+              {#each page.selectedPerkIds as perkId (perkId)}
+                <img
+                  class="perk-icon"
+                  src={`${CDRAGON}/perk-images/styles/${perkId}.png`}
+                  alt=""
+                  title={perkName(perkId)}
+                  loading="lazy"
+                  onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }}
+                />
+              {/each}
+            </div>
+            <div class="rune-foot">
+              <span class="dim">{$t("league.runes_spells")}: {(page.summonerSpellIds ?? []).map(spellName).join(" + ")}</span>
+              <button class="button" onclick={() => applyRunePage(i)} disabled={runeApplying}>
+                {$t("league.runes_apply")}
+              </button>
+            </div>
+          </div>
         {/each}
       </div>
+    {:else}
+      <p class="empty-hint">{$t("league.runes_empty")}</p>
     {/if}
-    {#each [["starterItems", "items_starter"], ["coreItems", "items_core"], ["boots", "items_boots"], ["lastItems", "items_last"]] as [key, label] (key)}
-      {#if metaInfo[key]?.ids?.length}
-        <div class="build-phase">
-          <span class="list-label">{$t(`league.${label}`)}</span>
-          <div class="build-items">
-            {#each metaInfo[key].ids as id (id)}
-              <span class="build-item">
-                <img class="item-icon" src={itemIcon(id)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
-              </span>
-            {/each}
-            {#if metaInfo[key].winrate !== null && metaInfo[key].winrate !== undefined}
-              <span class="dim">{metaInfo[key].winrate}%</span>
-            {/if}
-          </div>
-        </div>
-      {/if}
-    {/each}
-    {#if metaInfo.counters?.length}
-      <div class="build-phase">
-        <span class="list-label">{$t("league.counters")}</span>
-        <div class="build-items">
-          {#each metaInfo.counters.slice(0, 6) as c (c.championId)}
-            <span class="build-item">
-              <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${c.championId}.png`} alt="" title={championById.get(c.championId)?.name ?? ""} loading="lazy" />
-              <span class="dim">{c.winrate}%</span>
-            </span>
-          {/each}
-        </div>
-      </div>
-    {/if}
-    <p class="win-disclaimer">{$t("league.meta_source")}</p>
-  {/if}
-</section>
+  </section>
 
-<section class="card">
-  <div class="card-head">
-    <h3>{$t("league.tiers_title")}</h3>
-    <div class="tier-controls">
-      <select class="select-role" bind:value={tierPosition} aria-label={$t("league.tiers_position") as string}>
-        {#each TIER_POSITIONS as pos (pos)}
-          <option value={pos}>{$t(`league.role_${pos.toLowerCase()}`)}</option>
+  <section class="card">
+    <div class="card-head">
+      <h3>{$t("league.build_title")}</h3>
+      <button
+        class="button"
+        onclick={() => loadBuild(champSelectChampionId || (buildChampionId ?? 0))}
+        disabled={buildLoading || (!champSelectChampionId && !buildChampionId)}
+      >{$t("league.refresh")}</button>
+    </div>
+    <p class="win-disclaimer">{$t("league.build_desc")}</p>
+    <div class="build-picker">
+      <select class="select-role" bind:value={buildChampionId} aria-label={$t("league.build_champion") as string}>
+        <option value={0}>{$t("league.build_champion")}</option>
+        {#each champions as ch (ch.id)}
+          <option value={ch.id}>{ch.name}</option>
         {/each}
       </select>
-      <button class="button" onclick={loadTiers} disabled={tiersLoading}>{$t("league.refresh")}</button>
     </div>
-  </div>
-  <p class="win-disclaimer">{$t("league.tiers_desc")}</p>
-  {#if tiersError}
-    <p class="action-error" role="alert">{tiersError}</p>
-  {:else if tierRows.length > 0}
-    <div class="champ-table">
-      {#each tierRows as row (row.championId)}
-        <div class="champ-row">
-          <span class={`tier-badge tier-${row.tier}`}>{tierLabel(row.tier)}</span>
-          <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${row.championId}.png`} alt="" loading="lazy" />
-          <span class="champ-row-name">{championById.get(row.championId)?.name ?? row.championId}</span>
-          <span class="champ-row-wr" class:good={row.winRate >= 52} class:bad={row.winRate <= 48}>{row.winRate}%</span>
-          <span class="champ-row-games dim">{$t("league.tiers_pick")} {row.pickRate}%</span>
-          <span class="champ-row-kda dim">{$t("league.tiers_ban")} {row.banRate}%</span>
+    {#if buildInfo && buildInfo.gamesSeen > 0}
+      <p class="win-note">
+        {buildInfo.gamesSeen} {$t("league.build_samples")} · {buildInfo.winrate}% {$t("league.stat_winrate")}
+      </p>
+      <div class="build-items">
+        {#each buildInfo.items as it (it.itemId)}
+          <span class="build-item">
+            <img class="item-icon" src={`${CDRAGON}/../../game/assets/items/icons2d/${it.itemId}.png`} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
+            <span class="dim">{it.pickRate}%</span>
+          </span>
+        {/each}
+      </div>
+      {#if buildInfo.spells?.length}
+        <p class="win-note">{$t("league.runes_spells")}: {buildInfo.spells.map((s: any) => s.spellIds.map(spellName).join(" + ")).join(" / ")}</p>
+      {/if}
+    {:else if buildInfo}
+      <p class="empty-hint">{$t("league.build_empty")}</p>
+    {/if}
+    <div class="divider"></div>
+    <div class="card-head">
+      <h4 class="section-title">
+        {$t("league.meta_reference")}
+        {#if buildFeature && needsBadge(buildFeature)}
+          <span class="feature-badge">{$t(`league.badge_${buildFeature.state}`)}</span>
+        {/if}
+      </h4>
+      <h4 class="section-title">{$t("league.meta_reference")}</h4>
+      <button
+        class="button"
+        onclick={() => loadMeta(champSelectChampionId || (buildChampionId ?? 0))}
+        disabled={metaLoading || (!champSelectChampionId && !buildChampionId)}
+      >{$t("league.refresh")}</button>
+    </div>
+    {#if metaError}
+      <p class="action-error" role="alert">{metaError}</p>
+    {:else if metaLoading}
+      <p class="empty-hint">…</p>
+    {:else if metaInfo}
+      {#if metaInfo.skillPriority?.length}
+        <p class="win-note">
+          {$t("league.skill_priority")}: <strong>{metaInfo.skillPriority.join(" › ")}</strong>
+        </p>
+        <div class="skill-order">
+          {#each metaInfo.skillOrder as skill, i (`${i}-${skill}`)}
+            <span class="skill-step" class:ult={skill === "R"}>{skill}</span>
+          {/each}
         </div>
+      {/if}
+      {#each [["starterItems", "items_starter"], ["coreItems", "items_core"], ["boots", "items_boots"], ["lastItems", "items_last"]] as [key, label] (key)}
+        {#if metaInfo[key]?.ids?.length}
+          <div class="build-phase">
+            <span class="list-label">{$t(`league.${label}`)}</span>
+            <div class="build-items">
+              {#each metaInfo[key].ids as id (id)}
+                <span class="build-item">
+                  <img class="item-icon" src={itemIcon(id)} alt="" loading="lazy" onerror={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }} />
+                </span>
+              {/each}
+              {#if metaInfo[key].winrate !== null && metaInfo[key].winrate !== undefined}
+                <span class="dim">{metaInfo[key].winrate}%</span>
+              {/if}
+            </div>
+          </div>
+        {/if}
       {/each}
+      {#if metaInfo.counters?.length}
+        <div class="build-phase">
+          <span class="list-label">{$t("league.counters")}</span>
+          <div class="build-items">
+            {#each metaInfo.counters.slice(0, 6) as c (c.championId)}
+              <span class="build-item">
+                <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${c.championId}.png`} alt="" title={championById.get(c.championId)?.name ?? ""} loading="lazy" />
+                <span class="dim">{c.winrate}%</span>
+              </span>
+            {/each}
+          </div>
+        </div>
+      {/if}
+      <p class="win-disclaimer">{$t("league.meta_source")}</p>
+    {/if}
+  </section>
+
+  <section class="card">
+    <div class="card-head">
+      <h3>{$t("league.tiers_title")}</h3>
+      <div class="tier-controls">
+        <select class="select-role" bind:value={tierPosition} aria-label={$t("league.tiers_position") as string}>
+          {#each TIER_POSITIONS as pos (pos)}
+            <option value={pos}>{$t(`league.role_${pos.toLowerCase()}`)}</option>
+          {/each}
+        </select>
+        <button class="button" onclick={loadTiers} disabled={tiersLoading}>{$t("league.refresh")}</button>
+      </div>
     </div>
-  {:else}
-    <p class="empty-hint">{tiersLoading ? $t("league.searching_player") : $t("league.tiers_empty")}</p>
-  {/if}
-</section>
+    <p class="win-disclaimer">{$t("league.tiers_desc")}</p>
+    {#if tiersError}
+      <p class="action-error" role="alert">{tiersError}</p>
+    {:else if tierRows.length > 0}
+      <div class="champ-table">
+        {#each tierRows as row (row.championId)}
+          <div class="champ-row">
+            <span class={`tier-badge tier-${row.tier}`}>{tierLabel(row.tier)}</span>
+            <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${row.championId}.png`} alt="" loading="lazy" />
+            <span class="champ-row-name">{championById.get(row.championId)?.name ?? row.championId}</span>
+            <span class="champ-row-wr" class:good={row.winRate >= 52} class:bad={row.winRate <= 48}>{row.winRate}%</span>
+            <span class="champ-row-games dim">{$t("league.tiers_pick")} {row.pickRate}%</span>
+            <span class="champ-row-kda dim">{$t("league.tiers_ban")} {row.banRate}%</span>
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <p class="empty-hint">{tiersLoading ? $t("league.searching_player") : $t("league.tiers_empty")}</p>
+    {/if}
+  </section>
+{/if}

--- a/src/components/league/OverviewTab.svelte
+++ b/src/components/league/OverviewTab.svelte
@@ -16,6 +16,7 @@
     championById,
     championByAlias,
     onAction,
+    active,
   }: {
     summoner: any;
     ranked: Record<string, RankedEntry>;
@@ -29,6 +30,7 @@
     championById: Map<number, Champion>;
     championByAlias: Map<string, Champion>;
     onAction: (cmd: string, args?: Record<string, unknown>) => void;
+    active?: boolean;
   } = $props();
 
   const PHASE_KEYS: Record<string, string> = {
@@ -153,247 +155,249 @@
   }
 </script>
 
-{#if summoner}
-  <section class="profile-card">
-    <img
-      class="profile-icon"
-      src={`${CDRAGON}/profile-icons/${summoner.profileIconId}.jpg`}
-      alt=""
-      loading="lazy"
-    />
-    <div class="profile-info">
-      <span class="profile-name">
-        {summoner.gameName ?? summoner.displayName}{#if summoner.tagLine}<span class="tag">#{summoner.tagLine}</span>{/if}
-      </span>
-      <span class="profile-level">{$t("league.level")} {summoner.summonerLevel}</span>
-    </div>
-    <div class="ranked-chips">
-      <div class="ranked-chip">
-        <span class="ranked-queue">{$t("league.ranked_solo")}</span>
-        <span class="ranked-value">{rankLabel(ranked?.RANKED_SOLO_5x5)}</span>
+{#if active !== false}
+  {#if summoner}
+    <section class="profile-card">
+      <img
+        class="profile-icon"
+        src={`${CDRAGON}/profile-icons/${summoner.profileIconId}.jpg`}
+        alt=""
+        loading="lazy"
+      />
+      <div class="profile-info">
+        <span class="profile-name">
+          {summoner.gameName ?? summoner.displayName}{#if summoner.tagLine}<span class="tag">#{summoner.tagLine}</span>{/if}
+        </span>
+        <span class="profile-level">{$t("league.level")} {summoner.summonerLevel}</span>
       </div>
-      <div class="ranked-chip">
-        <span class="ranked-queue">{$t("league.ranked_flex")}</span>
-        <span class="ranked-value">{rankLabel(ranked?.RANKED_FLEX_SR)}</span>
-      </div>
-    </div>
-  </section>
-{/if}
-{#if actionError}
-  <div class="action-error" role="alert">{actionError}</div>
-{/if}
-{#if restartError}
-  <div class="action-error" role="alert">{restartError}</div>
-{/if}
-{#if summoner}
-  <details class="profile-tools" bind:open={profileOpen}>
-    <summary>{$t("league.profile_tools")}</summary>
-    {#if profileError}
-      <p class="action-error" role="alert">{profileError}</p>
-    {/if}
-    {#if profileSaved}
-      <p class="profile-saved">{profileSaved}</p>
-    {/if}
-    <div class="profile-tool-row">
-      <span class="list-label">{$t("league.profile_icon")}</span>
-      <input class="input-text tiny-input" type="number" min="0" bind:value={iconInput} aria-label={$t("league.profile_icon") as string} />
-      <button
-        class="button"
-        disabled={iconInput === null}
-        onclick={() => runProfileAction(() => invoke("league_set_icon", { iconId: iconInput }), $t("league.profile_icon_saved") as string)}
-      >{$t("league.apply")}</button>
-    </div>
-    <div class="profile-tool-row">
-      <span class="list-label">{$t("league.profile_status")}</span>
-      <div class="seg-group" role="radiogroup" aria-label={$t("league.profile_status") as string}>
-        {#each ["chat", "away", "dnd"] as value (value)}
-          <button
-            class="seg"
-            role="radio"
-            aria-checked={false}
-            onclick={() => runProfileAction(() => invoke("league_set_status", { availability: value }), $t("league.profile_status_saved") as string)}
-          >{$t(`league.status_${value}`)}</button>
-        {/each}
-      </div>
-    </div>
-    <div class="profile-tool-row">
-      <span class="list-label">{$t("league.profile_message")}</span>
-      <input class="input-text" maxlength="140" bind:value={statusMessage} placeholder={$t("league.profile_message") as string} />
-      <button
-        class="button"
-        onclick={() => runProfileAction(() => invoke("league_set_status", { message: statusMessage }), $t("league.profile_message_saved") as string)}
-      >{$t("league.apply")}</button>
-    </div>
-    <div class="profile-tool-row">
-      <span class="list-label">{$t("league.profile_background")}</span>
-      <select
-        class="select-role"
-        bind:value={bgChampion}
-        onchange={() => loadOwnedSkins(bgChampion)}
-        aria-label={$t("league.profile_background") as string}
-      >
-        <option value={0}>{$t("league.build_champion")}</option>
-        {#each champions as ch (ch.id)}
-          <option value={ch.id}>{ch.name}</option>
-        {/each}
-      </select>
-      {#if ownedSkins.length > 0}
-        <div class="skin-options">
-          {#each ownedSkins as skin (skin.id)}
-            <button
-              class="button subtle"
-              onclick={() => runProfileAction(() => invoke("league_set_profile_background", { skinId: skin.id }), $t("league.profile_background_saved") as string)}
-            >{skin.name}</button>
-          {/each}
+      <div class="ranked-chips">
+        <div class="ranked-chip">
+          <span class="ranked-queue">{$t("league.ranked_solo")}</span>
+          <span class="ranked-value">{rankLabel(ranked?.RANKED_SOLO_5x5)}</span>
         </div>
-      {:else if bgChampion > 0}
-        <span class="dim">{$t("league.profile_no_skins")}</span>
-      {/if}
-    </div>
-  </details>
-{/if}
-<div class="repair-row">
-  {#if restartConfirming}
-    <span class="repair-note">{$t("league.restart_ux_warning")}</span>
-    <button class="button" onclick={() => (restartConfirming = false)}>{$t("league.dodge_cancel")}</button>
-    <button class="button" onclick={restartClientUx} disabled={restartLoading}>{$t("league.restart_ux_confirm")}</button>
-  {:else}
-    <button class="button subtle" onclick={() => (restartConfirming = true)}>{$t("league.restart_ux")}</button>
+        <div class="ranked-chip">
+          <span class="ranked-queue">{$t("league.ranked_flex")}</span>
+          <span class="ranked-value">{rankLabel(ranked?.RANKED_FLEX_SR)}</span>
+        </div>
+      </div>
+    </section>
   {/if}
-</div>
-{#if phase === "ChampSelect" && champSelect}
-  <section class="card">
-    <div class="card-head">
-      <h3>{$t("league.champ_select_title")}</h3>
-      <span class="phase-tag">{phaseLabel(phase)}</span>
-    </div>
-    <div class="team-picks">
-      {#each myTeamPicks(champSelect) as pick (pick.cellId)}
-        {#if pick.championId > 0}
-          <img class="champ-icon" src={`${CDRAGON}/champion-icons/${pick.championId}.png`} alt={championById.get(pick.championId)?.name ?? ""} title={championById.get(pick.championId)?.name ?? ""} loading="lazy" />
-        {:else}
-          <div class="champ-icon champ-empty" aria-hidden="true"></div>
-        {/if}
-      {/each}
-    </div>
-    {#if champSelect.benchEnabled}
-      <div class="bench-row">
-        <span class="bench-label">{$t("league.bench_title")}</span>
-        <div class="bench-champs">
-          {#each champSelect.benchChampions ?? [] as bc (bc.championId)}
-            <button
-              class="bench-swap"
-              onclick={() => onAction("league_bench_swap", { championId: bc.championId })}
-              title={championById.get(bc.championId)?.name ?? ""}
-              aria-label={`${$t("league.swap")} ${championById.get(bc.championId)?.name ?? bc.championId}`}
-            >
-              <img class="champ-icon" src={`${CDRAGON}/champion-icons/${bc.championId}.png`} alt="" loading="lazy" />
-            </button>
-          {/each}
-        </div>
-        <div class="reroll-actions">
-          <button class="button" onclick={() => onAction("league_reroll")}>{$t("league.reroll")}</button>
-          <button class="button" onclick={() => onAction("league_reroll_keeping_champion")} title={$t("league.reroll_keep_hint") as string}>
-            {$t("league.reroll_keep")}
-          </button>
-        </div>
-      </div>
-    {/if}
-    {#if dodgeError}
-      <p class="action-error" role="alert">{dodgeError}</p>
-    {/if}
-    <div class="dodge-row">
-      {#if dodgeConfirming}
-        <span class="dodge-warning">{$t("league.dodge_warning")}</span>
-        <button class="button" onclick={() => (dodgeConfirming = false)}>{$t("league.dodge_cancel")}</button>
-        <button class="button danger" onclick={dodgeChampSelect} disabled={dodgeLoading}>{$t("league.dodge_confirm")}</button>
-      {:else}
-        <button class="button subtle-danger" onclick={() => (dodgeConfirming = true)}>{$t("league.dodge")}</button>
+  {#if actionError}
+    <div class="action-error" role="alert">{actionError}</div>
+  {/if}
+  {#if restartError}
+    <div class="action-error" role="alert">{restartError}</div>
+  {/if}
+  {#if summoner}
+    <details class="profile-tools" bind:open={profileOpen}>
+      <summary>{$t("league.profile_tools")}</summary>
+      {#if profileError}
+        <p class="action-error" role="alert">{profileError}</p>
       {/if}
-    </div>
-  </section>
-{:else if phase === "InProgress" && liveGame?.stats}
-  <section class="card">
-    <div class="card-head">
-      <h3>{$t("league.live_title")}</h3>
-      <span class="phase-tag">{formatGameTime(liveGame.stats.gameTime ?? 0)}</span>
-    </div>
-    {#if Array.isArray(liveGame.players)}
-      {@const teams = liveTeams(liveGame.players)}
-      <div class="live-teams">
-        {#each [teams.order, teams.chaos] as team, ti (ti)}
-          <div class="live-team">
-            {#each team as p (p.riotId ?? p.summonerName ?? p.championName)}
-              {@const cid = liveChampionId(p)}
-              <div class="live-row" class:me={(p.riotId ?? p.summonerName) === liveGame.activePlayer}>
-                {#if cid}
-                  <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${cid}.png`} alt="" loading="lazy" />
-                {:else}
-                  <div class="champ-icon small champ-empty" aria-hidden="true"></div>
-                {/if}
-                <span class="live-name">{p.championName}</span>
-                <span class="live-kda">{p.scores?.kills ?? 0}/{p.scores?.deaths ?? 0}/{p.scores?.assists ?? 0}</span>
-                {#if p.isDead && p.respawnTimer > 0}
-                  <span class="live-respawn">{$t("league.respawn_in")} {Math.ceil(p.respawnTimer)}s</span>
-                {/if}
-              </div>
-            {/each}
-          </div>
-        {/each}
-      </div>
-    {/if}
-  </section>
-{:else}
-  <section class="card">
-    <div class="card-head">
-      <h3>{$t("league.lobby_title")}</h3>
-      {#if phase && phase !== "None"}
-        <span class="phase-tag">{phaseLabel(phase)}</span>
-      {/if}
-    </div>
-    {#if phase === "ReadyCheck"}
-      <div class="lobby-actions">
-        <button class="button primary" onclick={() => onAction("league_accept_ready_check")}>{$t("league.accept_now")}</button>
-      </div>
-    {:else if phase === "Matchmaking"}
-      <div class="lobby-actions">
-        <span class="searching-hint">{$t("league.searching")}</span>
-        <button class="button" onclick={() => onAction("league_stop_matchmaking")}>{$t("league.stop_queue")}</button>
-      </div>
-    {:else if phase === "Lobby" && lobby}
-      <div class="lobby-actions">
-        <button class="button primary" onclick={() => onAction("league_start_matchmaking")}>{$t("league.start_queue")}</button>
-        <button class="button" onclick={() => onAction("league_leave_lobby")}>{$t("league.leave_lobby")}</button>
-      </div>
-      {#if roleError}
-        <p class="action-error" role="alert">{roleError}</p>
+      {#if profileSaved}
+        <p class="profile-saved">{profileSaved}</p>
       {/if}
       <div class="profile-tool-row">
-        <span class="list-label">{$t("league.role_preference")}</span>
-        <select class="select-role" bind:value={firstRole} aria-label={$t("league.role_first") as string}>
-          {#each LOBBY_ROLES as role (role)}
-            <option value={role}>{$t(`league.role_${role.toLowerCase()}`)}</option>
+        <span class="list-label">{$t("league.profile_icon")}</span>
+        <input class="input-text tiny-input" type="number" min="0" bind:value={iconInput} aria-label={$t("league.profile_icon") as string} />
+        <button
+          class="button"
+          disabled={iconInput === null}
+          onclick={() => runProfileAction(() => invoke("league_set_icon", { iconId: iconInput }), $t("league.profile_icon_saved") as string)}
+        >{$t("league.apply")}</button>
+      </div>
+      <div class="profile-tool-row">
+        <span class="list-label">{$t("league.profile_status")}</span>
+        <div class="seg-group" role="radiogroup" aria-label={$t("league.profile_status") as string}>
+          {#each ["chat", "away", "dnd"] as value (value)}
+            <button
+              class="seg"
+              role="radio"
+              aria-checked={false}
+              onclick={() => runProfileAction(() => invoke("league_set_status", { availability: value }), $t("league.profile_status_saved") as string)}
+            >{$t(`league.status_${value}`)}</button>
+          {/each}
+        </div>
+      </div>
+      <div class="profile-tool-row">
+        <span class="list-label">{$t("league.profile_message")}</span>
+        <input class="input-text" maxlength="140" bind:value={statusMessage} placeholder={$t("league.profile_message") as string} />
+        <button
+          class="button"
+          onclick={() => runProfileAction(() => invoke("league_set_status", { message: statusMessage }), $t("league.profile_message_saved") as string)}
+        >{$t("league.apply")}</button>
+      </div>
+      <div class="profile-tool-row">
+        <span class="list-label">{$t("league.profile_background")}</span>
+        <select
+          class="select-role"
+          bind:value={bgChampion}
+          onchange={() => loadOwnedSkins(bgChampion)}
+          aria-label={$t("league.profile_background") as string}
+        >
+          <option value={0}>{$t("league.build_champion")}</option>
+          {#each champions as ch (ch.id)}
+            <option value={ch.id}>{ch.name}</option>
           {/each}
         </select>
-        <select class="select-role" bind:value={secondRole} aria-label={$t("league.role_second") as string}>
-          {#each LOBBY_ROLES as role (role)}
-            <option value={role}>{$t(`league.role_${role.toLowerCase()}`)}</option>
-          {/each}
-        </select>
-        <button class="button" onclick={saveRoles}>{$t("league.apply")}</button>
+        {#if ownedSkins.length > 0}
+          <div class="skin-options">
+            {#each ownedSkins as skin (skin.id)}
+              <button
+                class="button subtle"
+                onclick={() => runProfileAction(() => invoke("league_set_profile_background", { skinId: skin.id }), $t("league.profile_background_saved") as string)}
+              >{skin.name}</button>
+            {/each}
+          </div>
+        {:else if bgChampion > 0}
+          <span class="dim">{$t("league.profile_no_skins")}</span>
+        {/if}
       </div>
-    {:else if phase === "EndOfGame" || phase === "PreEndOfGame" || phase === "WaitingForStats"}
-      <div class="lobby-actions">
-        <button class="button primary" onclick={() => onAction("league_play_again")}>{$t("league.play_again")}</button>
+    </details>
+  {/if}
+  <div class="repair-row">
+    {#if restartConfirming}
+      <span class="repair-note">{$t("league.restart_ux_warning")}</span>
+      <button class="button" onclick={() => (restartConfirming = false)}>{$t("league.dodge_cancel")}</button>
+      <button class="button" onclick={restartClientUx} disabled={restartLoading}>{$t("league.restart_ux_confirm")}</button>
+    {:else}
+      <button class="button subtle" onclick={() => (restartConfirming = true)}>{$t("league.restart_ux")}</button>
+    {/if}
+  </div>
+  {#if phase === "ChampSelect" && champSelect}
+    <section class="card">
+      <div class="card-head">
+        <h3>{$t("league.champ_select_title")}</h3>
+        <span class="phase-tag">{phaseLabel(phase)}</span>
       </div>
-    {:else if queues.length > 0}
-      <div class="queue-grid">
-        {#each queues as q (q.id)}
-          <button class="button" onclick={() => onAction("league_create_lobby", { queueId: q.id })}>{q.shortName || q.name}</button>
+      <div class="team-picks">
+        {#each myTeamPicks(champSelect) as pick (pick.cellId)}
+          {#if pick.championId > 0}
+            <img class="champ-icon" src={`${CDRAGON}/champion-icons/${pick.championId}.png`} alt={championById.get(pick.championId)?.name ?? ""} title={championById.get(pick.championId)?.name ?? ""} loading="lazy" />
+          {:else}
+            <div class="champ-icon champ-empty" aria-hidden="true"></div>
+          {/if}
         {/each}
       </div>
-    {:else}
-      <p class="empty-hint">{$t("league.lobby_hint")}</p>
-    {/if}
-  </section>
+      {#if champSelect.benchEnabled}
+        <div class="bench-row">
+          <span class="bench-label">{$t("league.bench_title")}</span>
+          <div class="bench-champs">
+            {#each champSelect.benchChampions ?? [] as bc (bc.championId)}
+              <button
+                class="bench-swap"
+                onclick={() => onAction("league_bench_swap", { championId: bc.championId })}
+                title={championById.get(bc.championId)?.name ?? ""}
+                aria-label={`${$t("league.swap")} ${championById.get(bc.championId)?.name ?? bc.championId}`}
+              >
+                <img class="champ-icon" src={`${CDRAGON}/champion-icons/${bc.championId}.png`} alt="" loading="lazy" />
+              </button>
+            {/each}
+          </div>
+          <div class="reroll-actions">
+            <button class="button" onclick={() => onAction("league_reroll")}>{$t("league.reroll")}</button>
+            <button class="button" onclick={() => onAction("league_reroll_keeping_champion")} title={$t("league.reroll_keep_hint") as string}>
+              {$t("league.reroll_keep")}
+            </button>
+          </div>
+        </div>
+      {/if}
+      {#if dodgeError}
+        <p class="action-error" role="alert">{dodgeError}</p>
+      {/if}
+      <div class="dodge-row">
+        {#if dodgeConfirming}
+          <span class="dodge-warning">{$t("league.dodge_warning")}</span>
+          <button class="button" onclick={() => (dodgeConfirming = false)}>{$t("league.dodge_cancel")}</button>
+          <button class="button danger" onclick={dodgeChampSelect} disabled={dodgeLoading}>{$t("league.dodge_confirm")}</button>
+        {:else}
+          <button class="button subtle-danger" onclick={() => (dodgeConfirming = true)}>{$t("league.dodge")}</button>
+        {/if}
+      </div>
+    </section>
+  {:else if phase === "InProgress" && liveGame?.stats}
+    <section class="card">
+      <div class="card-head">
+        <h3>{$t("league.live_title")}</h3>
+        <span class="phase-tag">{formatGameTime(liveGame.stats.gameTime ?? 0)}</span>
+      </div>
+      {#if Array.isArray(liveGame.players)}
+        {@const teams = liveTeams(liveGame.players)}
+        <div class="live-teams">
+          {#each [teams.order, teams.chaos] as team, ti (ti)}
+            <div class="live-team">
+              {#each team as p (p.riotId ?? p.summonerName ?? p.championName)}
+                {@const cid = liveChampionId(p)}
+                <div class="live-row" class:me={(p.riotId ?? p.summonerName) === liveGame.activePlayer}>
+                  {#if cid}
+                    <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${cid}.png`} alt="" loading="lazy" />
+                  {:else}
+                    <div class="champ-icon small champ-empty" aria-hidden="true"></div>
+                  {/if}
+                  <span class="live-name">{p.championName}</span>
+                  <span class="live-kda">{p.scores?.kills ?? 0}/{p.scores?.deaths ?? 0}/{p.scores?.assists ?? 0}</span>
+                  {#if p.isDead && p.respawnTimer > 0}
+                    <span class="live-respawn">{$t("league.respawn_in")} {Math.ceil(p.respawnTimer)}s</span>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {:else}
+    <section class="card">
+      <div class="card-head">
+        <h3>{$t("league.lobby_title")}</h3>
+        {#if phase && phase !== "None"}
+          <span class="phase-tag">{phaseLabel(phase)}</span>
+        {/if}
+      </div>
+      {#if phase === "ReadyCheck"}
+        <div class="lobby-actions">
+          <button class="button primary" onclick={() => onAction("league_accept_ready_check")}>{$t("league.accept_now")}</button>
+        </div>
+      {:else if phase === "Matchmaking"}
+        <div class="lobby-actions">
+          <span class="searching-hint">{$t("league.searching")}</span>
+          <button class="button" onclick={() => onAction("league_stop_matchmaking")}>{$t("league.stop_queue")}</button>
+        </div>
+      {:else if phase === "Lobby" && lobby}
+        <div class="lobby-actions">
+          <button class="button primary" onclick={() => onAction("league_start_matchmaking")}>{$t("league.start_queue")}</button>
+          <button class="button" onclick={() => onAction("league_leave_lobby")}>{$t("league.leave_lobby")}</button>
+        </div>
+        {#if roleError}
+          <p class="action-error" role="alert">{roleError}</p>
+        {/if}
+        <div class="profile-tool-row">
+          <span class="list-label">{$t("league.role_preference")}</span>
+          <select class="select-role" bind:value={firstRole} aria-label={$t("league.role_first") as string}>
+            {#each LOBBY_ROLES as role (role)}
+              <option value={role}>{$t(`league.role_${role.toLowerCase()}`)}</option>
+            {/each}
+          </select>
+          <select class="select-role" bind:value={secondRole} aria-label={$t("league.role_second") as string}>
+            {#each LOBBY_ROLES as role (role)}
+              <option value={role}>{$t(`league.role_${role.toLowerCase()}`)}</option>
+            {/each}
+          </select>
+          <button class="button" onclick={saveRoles}>{$t("league.apply")}</button>
+        </div>
+      {:else if phase === "EndOfGame" || phase === "PreEndOfGame" || phase === "WaitingForStats"}
+        <div class="lobby-actions">
+          <button class="button primary" onclick={() => onAction("league_play_again")}>{$t("league.play_again")}</button>
+        </div>
+      {:else if queues.length > 0}
+        <div class="queue-grid">
+          {#each queues as q (q.id)}
+            <button class="button" onclick={() => onAction("league_create_lobby", { queueId: q.id })}>{q.shortName || q.name}</button>
+          {/each}
+        </div>
+      {:else}
+        <p class="empty-hint">{$t("league.lobby_hint")}</p>
+      {/if}
+    </section>
+  {/if}
 {/if}

--- a/src/components/league/SearchTab.svelte
+++ b/src/components/league/SearchTab.svelte
@@ -5,8 +5,10 @@
 
   let {
     championById,
+    active,
   }: {
     championById: Map<number, Champion>;
+    active?: boolean;
   } = $props();
 
   let searchQuery = $state("");
@@ -85,178 +87,180 @@
   }
 </script>
 
-<section class="card">
-  <div class="card-head">
-    <h3>{$t("league.search_title")}</h3>
-  </div>
-  <form class="search-form" onsubmit={(e) => { e.preventDefault(); runSearch(); }}>
-    <input
-      class="input-text"
-      placeholder={$t("league.search_placeholder") as string}
-      bind:value={searchQuery}
-      spellcheck="false"
-    />
-    <button class="button primary" type="submit" disabled={searchLoading}>
-      {searchLoading ? $t("league.searching_player") : $t("league.search_button")}
-    </button>
-  </form>
-  {#if searchError}
-    <p class="action-error" role="alert">{searchError}</p>
-  {:else}
-    <p class="win-disclaimer">{$t("league.search_hint")}</p>
-  {/if}
-</section>
-
-{#if searchResult}
-  {@const s = searchResult.summoner}
-  {@const r = searchResult.report}
-  <section class="profile-card">
-    <img class="profile-icon" src={`${CDRAGON}/profile-icons/${s.profileIconId}.jpg`} alt="" loading="lazy" />
-    <div class="profile-info">
-      <span class="profile-name">{s.gameName}<span class="tag">#{s.tagLine}</span></span>
-      <span class="profile-level">{$t("league.level")} {s.summonerLevel ?? "—"}</span>
+{#if active !== false}
+  <section class="card">
+    <div class="card-head">
+      <h3>{$t("league.search_title")}</h3>
     </div>
-    <div class="ranked-chips">
-      <div class="ranked-chip">
-        <span class="ranked-queue">{$t("league.ranked_solo")}</span>
-        <span class="ranked-value">{rankLabel(r?.solo)}</span>
-      </div>
-      <div class="ranked-chip">
-        <span class="ranked-queue">{$t("league.ranked_flex")}</span>
-        <span class="ranked-value">{rankLabel(r?.flex)}</span>
-      </div>
-    </div>
-    <button class="button" onclick={spectateSearched} disabled={spectateLoading}>
-      {spectateLoading ? $t("league.spectate_loading") : $t("league.spectate")}
-    </button>
+    <form class="search-form" onsubmit={(e) => { e.preventDefault(); runSearch(); }}>
+      <input
+        class="input-text"
+        placeholder={$t("league.search_placeholder") as string}
+        bind:value={searchQuery}
+        spellcheck="false"
+      />
+      <button class="button primary" type="submit" disabled={searchLoading}>
+        {searchLoading ? $t("league.searching_player") : $t("league.search_button")}
+      </button>
+    </form>
+    {#if searchError}
+      <p class="action-error" role="alert">{searchError}</p>
+    {:else}
+      <p class="win-disclaimer">{$t("league.search_hint")}</p>
+    {/if}
   </section>
-  {#if spectateError}
-    <p class="action-error">{spectateError}</p>
-  {/if}
 
-  {#if r?.stats?.games > 0}
-    <section class="card">
-      <div class="card-head"><h3>{$t("league.search_recent")}</h3></div>
-      <div class="stat-grid">
-        <div class="stat-cell">
-          <span class="stat-value" class:good={r.stats.winrate >= 55} class:bad={r.stats.winrate <= 45}>{r.stats.winrate}%</span>
-          <span class="stat-label">{$t("league.stat_winrate")} ({r.stats.games})</span>
+  {#if searchResult}
+    {@const s = searchResult.summoner}
+    {@const r = searchResult.report}
+    <section class="profile-card">
+      <img class="profile-icon" src={`${CDRAGON}/profile-icons/${s.profileIconId}.jpg`} alt="" loading="lazy" />
+      <div class="profile-info">
+        <span class="profile-name">{s.gameName}<span class="tag">#{s.tagLine}</span></span>
+        <span class="profile-level">{$t("league.level")} {s.summonerLevel ?? "—"}</span>
+      </div>
+      <div class="ranked-chips">
+        <div class="ranked-chip">
+          <span class="ranked-queue">{$t("league.ranked_solo")}</span>
+          <span class="ranked-value">{rankLabel(r?.solo)}</span>
         </div>
-        <div class="stat-cell">
-          <span class="stat-value">{r.stats.kda}</span>
-          <span class="stat-label">KDA</span>
+        <div class="ranked-chip">
+          <span class="ranked-queue">{$t("league.ranked_flex")}</span>
+          <span class="ranked-value">{rankLabel(r?.flex)}</span>
         </div>
-        <div class="stat-cell">
-          <span class="stat-value">{r.stats.streak?.length ?? 0}</span>
-          <span class="stat-label">{r.stats.streak?.win ? $t("league.tag_hot_streak") : $t("league.tag_cold_streak")}</span>
-        </div>
-        {#if r.impact !== null && r.impact !== undefined}
+      </div>
+      <button class="button" onclick={spectateSearched} disabled={spectateLoading}>
+        {spectateLoading ? $t("league.spectate_loading") : $t("league.spectate")}
+      </button>
+    </section>
+    {#if spectateError}
+      <p class="action-error">{spectateError}</p>
+    {/if}
+
+    {#if r?.stats?.games > 0}
+      <section class="card">
+        <div class="card-head"><h3>{$t("league.search_recent")}</h3></div>
+        <div class="stat-grid">
           <div class="stat-cell">
-            <span class="stat-value">{r.impact}<span class="dim">/10</span></span>
-            <span class="stat-label">{$t("league.impact_label")} ({r.impactGames})</span>
+            <span class="stat-value" class:good={r.stats.winrate >= 55} class:bad={r.stats.winrate <= 45}>{r.stats.winrate}%</span>
+            <span class="stat-label">{$t("league.stat_winrate")} ({r.stats.games})</span>
+          </div>
+          <div class="stat-cell">
+            <span class="stat-value">{r.stats.kda}</span>
+            <span class="stat-label">KDA</span>
+          </div>
+          <div class="stat-cell">
+            <span class="stat-value">{r.stats.streak?.length ?? 0}</span>
+            <span class="stat-label">{r.stats.streak?.win ? $t("league.tag_hot_streak") : $t("league.tag_cold_streak")}</span>
+          </div>
+          {#if r.impact !== null && r.impact !== undefined}
+            <div class="stat-cell">
+              <span class="stat-value">{r.impact}<span class="dim">/10</span></span>
+              <span class="stat-label">{$t("league.impact_label")} ({r.impactGames})</span>
+            </div>
+          {/if}
+          {#if searchResult.deep}
+            <div class="stat-cell">
+              <span class="stat-value">{searchResult.deep.soloKillsPerGame}</span>
+              <span class="stat-label">{$t("league.solo_kills_label")} ({searchResult.deep.analysedGames})</span>
+            </div>
+            <div class="stat-cell">
+              <span class="stat-value">{searchResult.deep.earlyDeathsPerGame}</span>
+              <span class="stat-label">{$t("league.early_deaths_label")} ({searchResult.deep.analysedGames})</span>
+            </div>
+          {/if}
+        </div>
+        {#if r.stats.insights?.length}
+          <div class="scout-champs">
+            {#each r.stats.insights as tagId (tagId)}
+              <span class="scout-tag">{$t(TAG_KEYS[tagId] ?? tagId)}</span>
+            {/each}
           </div>
         {/if}
-        {#if searchResult.deep}
-          <div class="stat-cell">
-            <span class="stat-value">{searchResult.deep.soloKillsPerGame}</span>
-            <span class="stat-label">{$t("league.solo_kills_label")} ({searchResult.deep.analysedGames})</span>
-          </div>
-          <div class="stat-cell">
-            <span class="stat-value">{searchResult.deep.earlyDeathsPerGame}</span>
-            <span class="stat-label">{$t("league.early_deaths_label")} ({searchResult.deep.analysedGames})</span>
-          </div>
-        {/if}
-      </div>
-      {#if r.stats.insights?.length}
-        <div class="scout-champs">
-          {#each r.stats.insights as tagId (tagId)}
-            <span class="scout-tag">{$t(TAG_KEYS[tagId] ?? tagId)}</span>
-          {/each}
+      </section>
+    {/if}
+
+    {#if searchResult.champions?.length}
+      <section class="card">
+        <div class="card-head">
+          <h3>{$t("league.search_champions")}</h3>
+          <span class="phase-tag">{$t("league.search_champions_hint")}</span>
         </div>
-      {/if}
-    </section>
-  {/if}
-
-  {#if searchResult.champions?.length}
-    <section class="card">
-      <div class="card-head">
-        <h3>{$t("league.search_champions")}</h3>
-        <span class="phase-tag">{$t("league.search_champions_hint")}</span>
-      </div>
-      <div class="champ-table">
-        {#each searchResult.champions as ch (ch.championId)}
-          <div class="champ-row">
-            <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${ch.championId}.png`} alt="" loading="lazy" />
-            <span class="champ-row-name">{championById.get(ch.championId)?.name ?? ch.championId}</span>
-            <span class="champ-row-games">{ch.games} {$t("league.games_short")}</span>
-            <span class="champ-row-wr" class:good={ch.winrate >= 55} class:bad={ch.winrate <= 45}>{ch.winrate}%</span>
-            <span class="champ-row-kda">{ch.kda} KDA</span>
-            <span class="champ-row-cs dim">{ch.csPerMin}/m</span>
-          </div>
-        {/each}
-      </div>
-    </section>
-  {/if}
-
-  {#if r?.mastery?.length}
-    <section class="card">
-      <div class="card-head"><h3>{$t("league.search_mastery")}</h3></div>
-      <div class="scout-champs">
-        {#each r.mastery as m (m.championId)}
-          <span class="champ-chip">
-            <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${m.championId}.png`} alt="" loading="lazy" />
-            {championById.get(m.championId)?.name ?? m.championId}
-            <span class="dim">M{m.championLevel} · {Math.round((m.championPoints ?? 0) / 1000)}k</span>
-          </span>
-        {/each}
-      </div>
-    </section>
-  {/if}
-
-  {#if jungleReport}
-    <section class="card">
-      <div class="card-head">
-        <h3>{$t("league.jungle_title")}</h3>
-        <span class="phase-tag">{jungleReport.analysedGames} {$t("league.games_short")}</span>
-      </div>
-      {#if jungleReport.analysedGames > 0}
-        <div class="zone-bars">
-          {#each [["top", jungleReport.zones.top], ["mid", jungleReport.zones.mid], ["bot", jungleReport.zones.bot]] as [zone, pct] (zone)}
-            <div class="zone-row">
-              <span class="zone-name">{$t(`league.zone_${zone}`)}</span>
-              <div class="goal-bar"><div class="goal-fill" style={`width:${pct}%`}></div></div>
-              <span class="goal-value">{pct}%</span>
+        <div class="champ-table">
+          {#each searchResult.champions as ch (ch.championId)}
+            <div class="champ-row">
+              <img class="champ-icon small" src={`${CDRAGON}/champion-icons/${ch.championId}.png`} alt="" loading="lazy" />
+              <span class="champ-row-name">{championById.get(ch.championId)?.name ?? ch.championId}</span>
+              <span class="champ-row-games">{ch.games} {$t("league.games_short")}</span>
+              <span class="champ-row-wr" class:good={ch.winrate >= 55} class:bad={ch.winrate <= 45}>{ch.winrate}%</span>
+              <span class="champ-row-kda">{ch.kda} KDA</span>
+              <span class="champ-row-cs dim">{ch.csPerMin}/m</span>
             </div>
           {/each}
         </div>
-        <p class="win-note">
-          {$t(`league.pref_${jungleReport.preference}`)} · {$t("league.jungle_invade")} {jungleReport.invadeRate}% · {$t("league.jungle_gank3")} {jungleReport.level3GankRate}%
-        </p>
-      {:else}
-        <p class="empty-hint">{$t("league.jungle_empty")}</p>
-      {/if}
-    </section>
-  {/if}
-{/if}
+      </section>
+    {/if}
 
-<section class="card">
-  <div class="card-head">
-    <h3>{$t("league.duos_title")}</h3>
-    <button class="button" onclick={loadDuos} disabled={duosLoading}>{$t("league.refresh")}</button>
-  </div>
-  <p class="win-disclaimer">{$t("league.duos_desc")}</p>
-  {#if duos?.duos?.length}
-    <div class="champ-table">
-      {#each duos.duos as d (d.puuid)}
-        <div class="champ-row">
-          <span class="champ-row-name">{d.gameName ?? "—"}{#if d.tagLine}<span class="dim">#{d.tagLine}</span>{/if}</span>
-          <span class="champ-row-games">{d.games} {$t("league.games_short")}</span>
-          <span class="champ-row-wr" class:good={d.winrate >= 55} class:bad={d.winrate <= 45}>{d.winrate}%</span>
-          <span class="champ-row-kda dim">{$t("league.duos_score")} {d.score}%</span>
+    {#if r?.mastery?.length}
+      <section class="card">
+        <div class="card-head"><h3>{$t("league.search_mastery")}</h3></div>
+        <div class="scout-champs">
+          {#each r.mastery as m (m.championId)}
+            <span class="champ-chip">
+              <img class="champ-icon tiny" src={`${CDRAGON}/champion-icons/${m.championId}.png`} alt="" loading="lazy" />
+              {championById.get(m.championId)?.name ?? m.championId}
+              <span class="dim">M{m.championLevel} · {Math.round((m.championPoints ?? 0) / 1000)}k</span>
+            </span>
+          {/each}
         </div>
-      {/each}
-    </div>
-  {:else if duos}
-    <p class="empty-hint">{$t("league.duos_empty")}</p>
+      </section>
+    {/if}
+
+    {#if jungleReport}
+      <section class="card">
+        <div class="card-head">
+          <h3>{$t("league.jungle_title")}</h3>
+          <span class="phase-tag">{jungleReport.analysedGames} {$t("league.games_short")}</span>
+        </div>
+        {#if jungleReport.analysedGames > 0}
+          <div class="zone-bars">
+            {#each [["top", jungleReport.zones.top], ["mid", jungleReport.zones.mid], ["bot", jungleReport.zones.bot]] as [zone, pct] (zone)}
+              <div class="zone-row">
+                <span class="zone-name">{$t(`league.zone_${zone}`)}</span>
+                <div class="goal-bar"><div class="goal-fill" style={`width:${pct}%`}></div></div>
+                <span class="goal-value">{pct}%</span>
+              </div>
+            {/each}
+          </div>
+          <p class="win-note">
+            {$t(`league.pref_${jungleReport.preference}`)} · {$t("league.jungle_invade")} {jungleReport.invadeRate}% · {$t("league.jungle_gank3")} {jungleReport.level3GankRate}%
+          </p>
+        {:else}
+          <p class="empty-hint">{$t("league.jungle_empty")}</p>
+        {/if}
+      </section>
+    {/if}
   {/if}
-</section>
+
+  <section class="card">
+    <div class="card-head">
+      <h3>{$t("league.duos_title")}</h3>
+      <button class="button" onclick={loadDuos} disabled={duosLoading}>{$t("league.refresh")}</button>
+    </div>
+    <p class="win-disclaimer">{$t("league.duos_desc")}</p>
+    {#if duos?.duos?.length}
+      <div class="champ-table">
+        {#each duos.duos as d (d.puuid)}
+          <div class="champ-row">
+            <span class="champ-row-name">{d.gameName ?? "—"}{#if d.tagLine}<span class="dim">#{d.tagLine}</span>{/if}</span>
+            <span class="champ-row-games">{d.games} {$t("league.games_short")}</span>
+            <span class="champ-row-wr" class:good={d.winrate >= 55} class:bad={d.winrate <= 45}>{d.winrate}%</span>
+            <span class="champ-row-kda dim">{$t("league.duos_score")} {d.score}%</span>
+          </div>
+        {/each}
+      </div>
+    {:else if duos}
+      <p class="empty-hint">{$t("league.duos_empty")}</p>
+    {/if}
+  </section>
+{/if}

--- a/src/routes/league/+page.svelte
+++ b/src/routes/league/+page.svelte
@@ -438,7 +438,12 @@
       }
     }).then((u) => unlisteners.push(u));
     listen<string>("league-phase", (e) => {
-      phase = e.payload ?? "";
+      const next = e.payload ?? "";
+      // The client repeats the current phase on reconnects and on its own
+      // heartbeat; refreshing again for the same phase re-fetches everything for
+      // nothing.
+      if (next === phase) return;
+      phase = next;
       refreshPhaseData();
     }).then((u) => unlisteners.push(u));
     listen<any>("league-champ-select", (e) => {
@@ -492,29 +497,28 @@
            timers, expanded games) survives switching, and the meta tab's
            auto-rune effect keeps working from any tab. -->
       <div class="tab-panel" class:active={tab === "overview"}>
-        <OverviewTab {summoner} {ranked} {phase} {champSelect} {liveGame} {lobby} {queues} {actionError} {champions} {championById} {championByAlias} onAction={action} />
+        <OverviewTab {summoner} {ranked} {phase} {champSelect} {liveGame} {lobby} {queues} {actionError} {champions} {championById} {championByAlias} onAction={action} active={tab === "overview"} />
       </div>
       <div class="tab-panel" class:active={tab === "analysis"}>
-        <AnalysisTab {analysis} {analysisLoading} onRefreshAnalysis={loadAnalysis} {phase} {scoutPlayers} {scoutReports} {scoutLoading} onRefreshScouting={loadScouting} {championById} {notes} onSaveNote={saveNote} {timesSeenBefore} {platform} clientConnected={status.connected} />
+        <AnalysisTab {analysis} {analysisLoading} onRefreshAnalysis={loadAnalysis} {phase} {scoutPlayers} {scoutReports} {scoutLoading} onRefreshScouting={loadScouting} {championById} {notes} onSaveNote={saveNote} {timesSeenBefore} {platform} clientConnected={status.connected} active={tab === "analysis"} />
       </div>
       <div class="tab-panel" class:active={tab === "meta"}>
-        <MetaTab {champSelectChampionId} {myAssignedPosition} {championById} {champions} region={status.region} />
+        <MetaTab {champSelectChampionId} {myAssignedPosition} {championById} {champions} region={status.region} active={tab === "meta"} />
       </div>
       <div class="tab-panel" class:active={tab === "search"}>
-        <SearchTab {championById} />
+        <SearchTab {championById} active={tab === "search"} />
       </div>
       <div class="tab-panel" class:active={tab === "live"}>
-        <LiveTab {liveMetrics} {cooldowns} {liveEvents} {goalValue} {platform} clientConnected={status.connected} />
-        <LiveTab {liveMetrics} {cooldowns} {liveEvents} {goalValue} />
+        <LiveTab {liveMetrics} {cooldowns} {liveEvents} {goalValue} {platform} clientConnected={status.connected} active={tab === "live"} />
       </div>
       <div class="tab-panel" class:active={tab === "goals"}>
-        <GoalsTab {goalValue} {setGoal} {resetGoals} />
+        <GoalsTab {goalValue} {setGoal} {resetGoals} active={tab === "goals"} />
       </div>
       <div class="tab-panel" class:active={tab === "automation"}>
-        <AutomationTab {champions} {championById} />
+        <AutomationTab {champions} {championById} active={tab === "automation"} />
       </div>
       <div class="tab-panel" class:active={tab === "history"}>
-        <HistoryTab {games} loading={loadingHistory} onRefresh={loadHistory} {championById} />
+        <HistoryTab {games} loading={loadingHistory} onRefresh={loadHistory} {championById} active={tab === "history"} />
       </div>
     {/if}
   {/if}


### PR DESCRIPTION
## O que

Segunda rodada do travamento. A primeira (#268) atacou **um** evento; a causa é estrutural e tem cinco fontes, corrigidas aqui.

## Por que a primeira correção não bastou

A página monta os **oito painéis ao mesmo tempo** e os mantém montados de propósito, para preservar estado entre abas. Isso significa que qualquer mudança de estado — não só o champ select — faz os oito reavaliarem derivados e redesenharem. A webview que desenha esses painéis é a mesma que desenha a navegação do app: saturá-la congela a janela inteira, e é por isso que não dá para clicar em nada nem trocar de menu.

Throttlar só o champ select reduziu uma das fontes. Sobraram: lobby (republica a cada tique da estimativa de fila), ready check (a cada tique do contador), e o próprio volume de trabalho por evento.

## As cinco correções

1. **Painel inativo não renderiza.** Mantém instância, estado e efeitos — o auto-runas continua funcionando de qualquer aba, e os timers de feitiço não se perdem — mas o custo de desenho cai de oito painéis para um. É a correção estrutural; as outras quatro reduzem a frequência com que ela é exercitada.
2. **`LiveTab` estava montado duas vezes.** Duplicata introduzida na resolução manual de conflito do #262: duas instâncias completas, cada uma com seus `setInterval` e efeitos.
3. **Coalescing para lobby e ready check**, com a mesma impressão digital do champ select — o lobby ignora a estimativa de fila, o ready check ignora o contador.
4. **Filtro por uri antes do parse.** A assinatura do WebSocket é `OnJsonApiEvent`, ou seja, o firehose de **todos** os plugins do cliente; cada mensagem era parseada por inteiro para depois ser descartada. Agora um `contains` sobre o texto cru decide antes de alocar.
5. **Settings em cache por 2s.** `league_settings()` era chamado a cada evento e cada chamada relia e parseava o arquivo de settings do disco.

Bônus: `get_client()` deixou de segurar o mutex do cliente cacheado durante a checagem de rede, o que punha todos os comandos do league em fila atrás de uma ida e volta de até 10s.

## Como testar

1. `cd src-tauri && cargo test -p omniget league` — 3 testes novos (80 no total): o filtro por uri aceita as nossas e rejeita hovercard/loot; a impressão digital do lobby ignora a estimativa e reage a entrada/saída e troca de rota; a do ready check ignora o relógio e reage à resposta.
2. Abrir a página do League e ficar na fila, entrar em champ select e jogar uma partida: a janela deve continuar respondendo, e trocar de menu deve funcionar a qualquer momento.
3. Trocar de aba e voltar: busca, timers de feitiço e partidas expandidas continuam onde estavam (a instância não é destruída).
4. Ligar auto-runas e ficar em outra aba durante o champ select: as runas continuam sendo aplicadas.

## Plataformas

- [x] Windows: as correções são de backend e de render, sem código específico de SO
- [x] macOS testado (`cargo test` 80, `pnpm test` 58, `pnpm check` 0 erros)

## Estado

`stable` — sem flag.

## Risco & rollback

Risco ToS: nenhum (o app faz menos trabalho e menos requisições). Rollback: reverter o commit único.

## O que ainda não sei

Continuo **sem conseguir reproduzir** o travamento — não há cliente de LoL nesta máquina. As cinco fontes acima são reais e mensuráveis por leitura do código, mas não posso afirmar que cobrem o caso do usuário. Se voltar a travar, o próximo passo não é adivinhar de novo: é instrumentar. O caminho seria registrar, em memória e sob o painel de debug, a contagem de eventos emitidos por segundo e a duração dos comandos — o que transformaria o próximo relato em dado em vez de hipótese.
