### PR TITLE
fix(downloads): prevent removed items from returning

### DIFF
--- a/src-tauri/src/core/queue.rs
+++ b/src-tauri/src/core/queue.rs
@@ -228,6 +228,10 @@ pub struct DownloadQueue {
     pub default_max_retries: u32,
 }
 
+fn can_finish_active_item(status: &QueueStatus) -> bool {
+    *status == QueueStatus::Active
+}
+
 impl DownloadQueue {
     pub fn new(max_concurrent: u32) -> Self {
         Self {
@@ -445,6 +449,9 @@ impl DownloadQueue {
         file_size_bytes: Option<u64>,
     ) {
         if let Some(item) = self.items.iter_mut().find(|i| i.id == id) {
+            if !can_finish_active_item(&item.status) {
+                return;
+            }
             let error_for_history = error.clone();
             if success {
                 item.status = QueueStatus::Complete { success: true };
@@ -495,6 +502,9 @@ impl DownloadQueue {
         torrent_id: Option<usize>,
     ) {
         if let Some(item) = self.items.iter_mut().find(|i| i.id == id) {
+            if !can_finish_active_item(&item.status) {
+                return;
+            }
             item.status = QueueStatus::Seeding;
             item.percent = 100.0;
             item.file_path = file_path;
@@ -2010,7 +2020,18 @@ fn is_generic_title(title: &str) -> bool {
 
 #[cfg(test)]
 mod kind_tests {
-    use super::{kind_from_platform, QueueKind};
+    use super::{can_finish_active_item, kind_from_platform, QueueKind, QueueStatus};
+
+    #[test]
+    fn only_active_items_can_finish() {
+        assert!(can_finish_active_item(&QueueStatus::Active));
+        assert!(!can_finish_active_item(&QueueStatus::Queued));
+        assert!(!can_finish_active_item(&QueueStatus::Paused));
+        assert!(!can_finish_active_item(&QueueStatus::Error {
+            message: "Cancelled".to_string(),
+            retryable: false,
+        }));
+    }
 
     #[test]
     fn youtube_and_video_platforms_map_to_video() {

--- a/src/lib/stores/download-store.svelte.ts
+++ b/src/lib/stores/download-store.svelte.ts
@@ -59,6 +59,7 @@ const SPEED_HISTORY_MAX = 60;
 
 let downloads = $state(new Map<number, DownloadItem>());
 const speedHistory = new Map<number, SpeedPoint[]>();
+const suppressedGenericIds = new Set<number>();
 let flushScheduled = false;
 
 function pushSpeedPoint(id: number, bps: number) {
@@ -282,10 +283,12 @@ export function syncQueueState(items: QueueItemInfo[]) {
     if (item.kind === "generic" && !queueIds.has(id)) {
       downloads.delete(id);
       clearSpeedHistory(id);
+      suppressedGenericIds.add(id);
     }
   }
 
   for (const qi of items) {
+    suppressedGenericIds.delete(qi.id);
     const existing = downloads.get(qi.id);
     const dlStatus = queueStatusToDownloadStatus(qi.status);
 
@@ -331,9 +334,13 @@ export function syncQueueState(items: QueueItemInfo[]) {
 }
 
 export function removeDownload(id: number) {
-  if (downloads.has(id)) {
+  const item = downloads.get(id);
+  if (item) {
     downloads.delete(id);
     clearSpeedHistory(id);
+    if (item.kind === "generic") {
+      suppressedGenericIds.add(id);
+    }
     flushNow();
   }
 }
@@ -369,6 +376,7 @@ export function upsertGenericProgress(
   etaSeconds?: number | null,
 ) {
   const now = Date.now();
+  if (suppressedGenericIds.has(id)) return;
   const existing = downloads.get(id);
 
   let speed = speedBytesPerSec;
@@ -410,4 +418,3 @@ export function upsertGenericProgress(
 }
 
 export { formatBytes, formatSpeed, formatEta } from "../download-format";
-

--- a/src/lib/stores/download-store.test.ts
+++ b/src/lib/stores/download-store.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+type DownloadStore = typeof import("./download-store.svelte");
+
+let store: DownloadStore;
+
+const queueItem = (id: number) => ({
+  id,
+  url: "https://example.com/video",
+  platform: "youtube",
+  title: "Example video",
+  status: { type: "Active" as const },
+  percent: 0,
+  speed_bytes_per_sec: 0,
+  downloaded_bytes: 0,
+  total_bytes: 100,
+  file_path: null,
+  file_size_bytes: null,
+  file_count: null,
+  thumbnail_url: null,
+});
+
+beforeAll(async () => {
+  vi.stubGlobal("$state", <T>(value: T) => value);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  });
+  store = await import("./download-store.svelte");
+});
+
+afterEach(() => {
+  store.syncQueueState([]);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("generic download progress", () => {
+  it("does not recreate an item removed by an authoritative queue update", () => {
+    const id = 901;
+    store.syncQueueState([queueItem(id)]);
+    store.syncQueueState([]);
+
+    store.upsertGenericProgress(id, "Example video", "youtube", 50, 10, 50, 100, "downloading");
+
+    expect(store.getDownloads().has(id)).toBe(false);
+  });
+
+  it("accepts progress again after the queue restores the same item", () => {
+    const id = 902;
+    store.syncQueueState([queueItem(id)]);
+    store.syncQueueState([]);
+    store.syncQueueState([queueItem(id)]);
+
+    store.upsertGenericProgress(id, "Example video", "youtube", 50, 10, 50, 100, "downloading");
+
+    expect(store.getDownloads().get(id)).toMatchObject({
+      kind: "generic",
+      percent: 50,
+      downloadedBytes: 50,
+      status: "downloading",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- prevent late progress events from recreating a download that was removed from the authoritative queue
- preserve a cancelled queue item when a worker reports completion concurrently
- cover removal and re-queue state transitions

Fixes #274.

## Checks

- `pnpm test` — 71 passed
- `pnpm check` — 0 errors
- `cargo fmt --all -- --check`
- `cargo test --workspace` — 702 passed

`cargo clippy --workspace --all-targets -- -D warnings` remains blocked by 37 pre-existing findings outside this change.
