### PR TITLE
fix(instagram): download Reel video instead of cover image

### DIFF
--- a/src-tauri/omniget-core/src/platforms/instagram.rs
+++ b/src-tauri/omniget-core/src/platforms/instagram.rs
@@ -111,6 +111,14 @@ impl InstagramDownloader {
         false
     }
 
+    fn is_reel_url(url: &str) -> bool {
+        if let Ok(parsed) = url::Url::parse(url) {
+            let path = parsed.path().to_lowercase();
+            return path.starts_with("/reel/") || path.starts_with("/reels/");
+        }
+        false
+    }
+
     async fn resolve_share_link(&self, share_id: &str) -> anyhow::Result<String> {
         let url = format!("https://www.instagram.com/share/{}/", share_id);
 
@@ -697,6 +705,24 @@ impl PlatformDownloader for InstagramDownloader {
             }
         };
 
+        // Instagram embed metadata can expose only a Reel's display_url,
+        // which is the cover image rather than the video. In that case,
+        // use yt-dlp to resolve and download the actual video streams.
+        if Self::is_reel_url(url)
+            && matches!(
+                &media,
+                InstagramMedia::Single {
+                    is_video: false,
+                    ..
+                }
+            )
+        {
+            tracing::debug!(
+                "[instagram] Reel embed returned only a display image; falling back to yt-dlp"
+            );
+            return self.fallback_ytdlp(url, &post_id).await;
+        }
+
         match media {
             InstagramMedia::Single { url, is_video } => {
                 let (media_type, format) = if is_video {
@@ -914,6 +940,30 @@ mod tests {
             media_type: MediaType::Video,
             file_size_bytes: None,
         }
+    }
+
+    #[test]
+    fn is_reel_url_accepts_reel_paths() {
+        assert!(InstagramDownloader::is_reel_url(
+            "https://www.instagram.com/reel/Dbi_MeVOphM/"
+        ));
+        assert!(InstagramDownloader::is_reel_url(
+            "https://www.instagram.com/reels/Dbi_MeVOphM/"
+        ));
+    }
+
+    #[test]
+    fn is_reel_url_rejects_regular_posts() {
+        assert!(!InstagramDownloader::is_reel_url(
+            "https://www.instagram.com/p/Dbi_MeVOphM/"
+        ));
+    }
+
+    #[test]
+    fn is_reel_url_handles_case_insensitive_paths() {
+        assert!(InstagramDownloader::is_reel_url(
+            "https://www.instagram.com/REEL/Dbi_MeVOphM/"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Instagram Reel embed metadata can expose only `display_url`, which is the Reel cover image rather than the video. OmniGet previously treated that URL as a photo and reported a successful video download while saving a JPG.

This change detects `/reel/` and `/reels/` URLs and falls back to yt-dlp when embed extraction returns a single non-video item.

## Reproduction

Test URL:

https://www.instagram.com/reel/Dbi_MeVOphM/

Before this change, OmniGet saved:

```text
instagram_Dbi_MeVOphM.jpg
```

The history database recorded:

```text
success = 1
error = NULL
kind = "video"
```

Running OmniGet's bundled yt-dlp directly downloaded the actual 1080x1920 video successfully.

## Result

After this change, OmniGet logs:

```text
[instagram] Reel embed returned only a display image; falling back to yt-dlp
```

OmniGet then downloads the actual Reel as an MP4 instead of saving the cover image as a JPG.

For the tested Reel, yt-dlp selected Instagram's highest available video stream:

```text
Video: VP9, 1080x1920, 23.98 fps
Audio: AAC, 44.1 kHz, stereo
Duration: 10.93 seconds
```

The resulting MP4 contains VP9 video and AAC audio. QuickTime may not support VP9 playback on every Mac, but codec compatibility is separate from this pull request. This change fixes the original issue where OmniGet downloaded only the JPG cover image.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
  - Passed with existing project warnings
- `cargo test --workspace`
  - 350 tests passed
  - 0 failed
- `pnpm check`
  - 0 errors
  - 107 existing warnings
- End-to-end macOS test with the public Instagram Reel above
  - Before: saved the cover image as a JPG
  - After: downloaded the actual 1080x1920 MP4
  - Video codec: VP9
  - Audio codec: AAC
  - Duration: 10.93 seconds

## Scope

Regular `/p/` Instagram posts are unaffected. The fallback applies only to `/reel/` and `/reels/` URLs when embed extraction returns a single non-video item.