### PR TITLE
fix(omnibox): restore download mode selector for batch downloads (regression from #197)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1062,7 +1062,10 @@
     {/if}
 
     {#if omniState.kind === "batch"}
-      <BatchDownload count={omniState.urls.length} onDownload={handleBatchDownload} />
+      <div class="batch-options">
+        <DownloadModeSelector bind:downloadMode />
+        <BatchDownload count={omniState.urls.length} onDownload={handleBatchDownload} />
+      </div>
 
     {:else if omniState.kind === "searching"}
       <div class="feedback feedback-enter">
@@ -1415,6 +1418,12 @@
       opacity: 0.7;
       transform: scale(0.95);
     }
+  }
+
+  .batch-options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
   }
 
   .feedback {


### PR DESCRIPTION
## Problem

#182 added the `DownloadModeSelector` above "Download all" in the batch state, so pasting multiple URLs let you force **Audio only** / **No sound** (notably for `music.youtube.com` links, detected as regular YouTube videos). It's gone again as of 0.8.5.

It was not reverted on purpose — it was lost in a merge race:

- #182 merged 2026-07-28 23:07 UTC (`e8cbf1b9`)
- #197 was opened 2026-07-28 09:59 UTC, i.e. its branch predates #182, and merged 2026-07-29 08:15 UTC (`9a6abc8e`). Its squash merge touched 71 files and rewrote `src/routes/+page.svelte` wholesale, dropping the `batch-options` block.

`git log -S"batch-options" -- src/routes/+page.svelte` returns exactly two commits: `e8cbf1b9` (added) and `9a6abc8e` (removed). No revert, no discussion.

## Fix

Re-apply the removed markup and the `.batch-options` style. That's all that's needed — the rest of #182 survived:

- `handleBatchDownload` still forwards `downloadMode` to the backend
- `DownloadModeSelector`'s `onChange` prop is still optional

## Notes

- No backend changes, no Rust files touched.
- `pnpm check` passes: 0 errors (107 pre-existing warnings, none new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)