### PR TITLE
fix(build): allow building from source without the updater signing key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # `createUpdaterArtifacts` is `false` in the committed tauri.conf.json so
+          # that anyone building from source does not need the release signing key;
+          # re-enable it here, only for tagged releases.
+          TAURI_CONFIG: '{"bundle":{"createUpdaterArtifacts":true}}'
           LDAI_UPDATE_INFORMATION: ${{ contains(matrix.platform, 'ubuntu') && 'gh-releases-zsync|tonhowtf|omniget|latest|*AppImage.zsync' || '' }}
           NODE_OPTIONS: --max-old-space-size=6144
         with:

--- a/package.json
+++ b/package.json
@@ -86,5 +86,11 @@
     "vite-plugin-top-level-await": "^1.5.0",
     "vite-plugin-wasm": "^3.4.1",
     "vitest": "^4.1.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "esbuild"
+    ]
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,7 +56,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "resources": {
       "../browser-extension/chrome/": "browser-extension/chrome/",
       "../browser-extension/firefox/": "browser-extension/firefox/"


### PR DESCRIPTION
## 🐛 Problem

Anyone following the README's *Build from source* steps hits a hard failure
at the bundling step:

```
Error: A public key has been found, but no private key.
Make sure to set `TAURI_SIGNING_PRIVATE_KEY` environment variable.
```

`src-tauri/tauri.conf.json` sets `bundle.createUpdaterArtifacts: true`,
which forces every build to sign updater artifacts. The signing key exists
only in the maintainers' GitHub secrets, so external contributors cannot
build from source without generating a throwaway key first.

## 🔧 Fix

- Set `createUpdaterArtifacts: false` in the committed `tauri.conf.json`
  so a plain `pnpm tauri build` works for everyone.
- Re-enable it **only for tagged releases** in `.github/workflows/release.yml`
  via `TAURI_CONFIG`, where `TAURI_SIGNING_PRIVATE_KEY` is already provided
  as a secret.
- The runtime updater pubkey stays in the config, so installed apps still
  verify updates normally.

✅ Verified locally: `pnpm tauri build --bundles deb` now succeeds with no
signing environment variables set.

## 📦 Also included

`pnpm.onlyBuiltDependencies: ["@swc/core", "esbuild"]` — pnpm 10 blocks
dependency postinstall scripts by default (`Ignored build scripts:
@swc/core, esbuild`). This approves them so `pnpm install` is clean and the
binaries are validated on install instead of silently skipped.