### PR TITLE
fix(build): move onlyBuiltDependencies where pnpm 10 reads it

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,11 +86,5 @@
     "vite-plugin-top-level-await": "^1.5.0",
     "vite-plugin-wasm": "^3.4.1",
     "vitest": "^4.1.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm 10 no longer reads the `pnpm` field from package.json. These build
+# scripts are approved here so `pnpm install` compiles the native binaries
+# instead of silently skipping them.
+onlyBuiltDependencies:
+  - "@swc/core"
+  - esbuild


### PR DESCRIPTION
Follow-up to #290, which added the block to `package.json`. pnpm 10 parses that field and throws it away:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
       The following keys were ignored: "pnpm.onlyBuiltDependencies".
       See https://pnpm.io/settings for the new home of each setting.
```

So `@swc/core` and `esbuild` build scripts stayed blocked — the opposite of the intent. Moved to `pnpm-workspace.yaml`, where pnpm 10 keeps its settings.

Verified with a forced full reinstall (`pnpm install --force`, pnpm 10.29.3): no `Ignored build scripts: @swc/core, esbuild` line and no warning, where both appeared before.