### PR TITLE
docs: the CLI ships in releases now

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,9 +377,9 @@ sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file lib
 
 Production build: `pnpm tauri build`.
 
-### Command line interface (build it yourself)
+### Command line interface
 
-The repository also contains `omniget-cli`, a small Rust binary that makes OmniGet scriptable. **It is not included in the release downloads yet** — you build it from this repository:
+The repository also contains `omniget-cli`, a small Rust binary that makes OmniGet scriptable. It ships with every release — grab `omniget-cli-<version>-<target>` from the [latest release](https://github.com/tonhowtf/omniget/releases/latest) for Windows, macOS (Intel and Apple Silicon) or Linux. To build it from this repository instead:
 
 ```bash
 cargo build --release -p omniget-cli

--- a/README.ru.md
+++ b/README.ru.md
@@ -365,7 +365,7 @@ sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file lib
 
 ### Интерфейс командной строки (собирается вручную)
 
-В репозитории также есть `omniget-cli` — небольшая программа на Rust, которая делает OmniGet пригодным для скриптов. **В готовые сборки она пока не входит**, её нужно собрать из этого репозитория:
+В репозитории также есть `omniget-cli` — небольшая программа на Rust, которая делает OmniGet пригодным для скриптов. Она входит в каждый релиз: скачайте `omniget-cli-<версия>-<платформа>` из [последнего релиза](https://github.com/tonhowtf/omniget/releases/latest) для Windows, macOS (Intel и Apple Silicon) или Linux. Чтобы собрать её из этого репозитория:
 
 ```bash
 cargo build --release -p omniget-cli

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -379,7 +379,7 @@ Build de produção: `pnpm tauri build`.
 
 ### Interface de linha de comando (compile você mesmo)
 
-O repositório também contém o `omniget-cli`, um binário Rust pequeno que torna o OmniGet scriptável. **Ele ainda não vem incluído nos downloads das releases** — você compila a partir deste repositório:
+O repositório também contém o `omniget-cli`, um binário Rust pequeno que torna o OmniGet scriptável. Ele sai junto com cada release — baixe `omniget-cli-<versão>-<alvo>` na [release mais recente](https://github.com/tonhowtf/omniget/releases/latest), para Windows, macOS (Intel e Apple Silicon) ou Linux. Para compilar a partir deste repositório:
 
 ```bash
 cargo build --release -p omniget-cli

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -365,7 +365,7 @@ sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file lib
 
 ### 命令行工具（需自行构建）
 
-仓库中还包含 `omniget-cli`，一个让 OmniGet 可被脚本调用的小型 Rust 程序。**它目前尚未随 Release 一起发布**，需要你从本仓库自行构建：
+仓库中还包含 `omniget-cli`，一个让 OmniGet 可被脚本调用的小型 Rust 程序。它随每个 Release 一起发布——请在[最新 Release](https://github.com/tonhowtf/omniget/releases/latest) 中下载 `omniget-cli-<版本>-<目标平台>`，支持 Windows、macOS（Intel 与 Apple Silicon）和 Linux。若要从本仓库自行构建：
 
 ```bash
 cargo build --release -p omniget-cli

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ It is not only a downloader. OmniGet includes a course player that resumes to th
 - Can OmniGet download paid content? OmniGet downloads what the user's own logged-in session can already open, such as a course they bought. It does not bypass DRM or paywalls.
 - Is OmniGet a yt-dlp GUI? OmniGet uses yt-dlp for generic sites and adds native extractors for major platforms, a download queue, a library and built-in players. It is more than a front end.
 - Does OmniGet resume interrupted downloads? Yes. The queue keeps partial files and continues from where it stopped, retrying with backoff.
-- Is there a command line interface? `omniget-cli` exists in the repository with `info`, `download`, `batch` and `import-cookies` commands, but it is not included in release downloads and must be built from source.
+- Is there a command line interface? Yes. `omniget-cli` ships with every release for Windows, macOS (Intel and Apple Silicon) and Linux, with `info`, `download`, `batch` and `import-cookies` commands. It can also be built from source.
 
 ## Links
 


### PR DESCRIPTION
The `build-cli` job has been publishing `omniget-cli` for all four targets for several releases — v0.8.5 carries:

```
omniget-cli-0.8.5-aarch64-apple-darwin.tar.gz
omniget-cli-0.8.5-x86_64-apple-darwin.tar.gz
omniget-cli-0.8.5-x86_64-pc-windows-msvc.zip
omniget-cli-0.8.5-x86_64-unknown-linux-gnu.tar.gz
```

The docs still said **"It is not included in the release downloads yet"** and told people to compile it themselves. That caveat was correct when it was written and was deliberately left in place until a release actually carried the binaries (#202) — that condition has been met, so it now sends people to build something they could have downloaded.

Corrected in all four READMEs and `llms.txt`, since the claim was translated into each. Each one now links the latest release and keeps the build-from-source instructions as the alternative rather than the only route.

Closes #202