### PR TITLE
fix(deps): report the PDFium the user pointed at

### DIFF
--- a/src-tauri/omniget-core/src/core/pdfium.rs
+++ b/src-tauri/omniget-core/src/core/pdfium.rs
@@ -114,8 +114,33 @@ pub fn pdfium_version_marker_path() -> Option<PathBuf> {
     pdfium_target_dir().map(|d| d.join("pdfium.version"))
 }
 
+/// The PDFium library actually in use, and where it came from: `"custom"` for
+/// a file the user pointed at, `"managed"` for the one OmniGet downloaded.
+///
+/// Issue #222: yt-dlp and FFmpeg have honoured the user's own binary since
+/// the feature shipped, through `find_tool_with_source`. PDFium never did —
+/// only the managed folder was ever checked — so a linked library was
+/// recorded and displayed while the status stayed "missing".
+pub fn resolve_with_source() -> Option<(PathBuf, &'static str)> {
+    if let Some(custom) = crate::core::binary_overrides::get("PDFium") {
+        if custom.is_file() {
+            return Some((custom, "custom"));
+        }
+    }
+    let managed = pdfium_target_path()?;
+    if managed.is_file() {
+        return Some((managed, "managed"));
+    }
+    None
+}
+
+/// Path to the PDFium library to load, honouring a custom override.
+pub fn resolve_path() -> Option<PathBuf> {
+    resolve_with_source().map(|(p, _)| p)
+}
+
 pub fn is_installed() -> bool {
-    pdfium_target_path().map(|p| p.is_file()).unwrap_or(false)
+    resolve_with_source().is_some()
 }
 
 pub fn read_version_marker() -> Option<String> {

--- a/src-tauri/src/commands/dependencies.rs
+++ b/src-tauri/src/commands/dependencies.rs
@@ -48,7 +48,8 @@ pub async fn check_dependencies() -> Result<Vec<DependencyStatus>, String> {
         },
     );
 
-    let pdfium_installed = pdfium::is_installed();
+    let pdfium_resolved = pdfium::resolve_with_source();
+    let pdfium_installed = pdfium_resolved.is_some();
     let pdfium_version = if pdfium_installed {
         Some(pdfium::read_version_marker().unwrap_or_else(|| "installed".to_string()))
     } else {
@@ -94,14 +95,16 @@ pub async fn check_dependencies() -> Result<Vec<DependencyStatus>, String> {
             name: "PDFium".into(),
             installed: pdfium_installed,
             version: pdfium_version,
-            source: if pdfium_installed {
-                "managed".into()
-            } else {
-                "missing".into()
-            },
-            path: pdfium::pdfium_target_dir()
-                .filter(|_| pdfium_installed)
-                .map(|p| p.to_string_lossy().to_string()),
+            source: pdfium_resolved
+                .as_ref()
+                .map(|(_, s)| (*s).to_string())
+                .unwrap_or_else(|| "missing".to_string()),
+            // The resolved library, not the managed folder: with a custom
+            // path those are different places, and naming the folder there
+            // would point at something the app is not using.
+            path: pdfium_resolved
+                .as_ref()
+                .map(|(p, _)| p.to_string_lossy().to_string()),
             outdated: false,
         },
     ])


### PR DESCRIPTION
Issue #222, reported by @PaduaPlay: after linking a local PDFium the Settings row still read **missing**, while yt-dlp and FFmpeg correctly flipped to installed.

The reason is that PDFium was never wired into the custom-binary feature at all. yt-dlp and FFmpeg resolve through `find_tool_with_source`, which checks `binary_overrides` first and returns `"custom"`. PDFium had its own path:

```rust
pub fn is_installed() -> bool {
    pdfium_target_path().map(|p| p.is_file()).unwrap_or(false)   // managed folder only
}
```

and the status was assembled with the source hardcoded:

```rust
source: if pdfium_installed { "managed".into() } else { "missing".into() },
path: pdfium::pdfium_target_dir()...
```

So it was not a refresh problem — the UI re-fetched correctly and the backend answered wrong. The `path` column was wrong too, naming the managed folder rather than the file in use.

`resolve_with_source()` now checks the override first, falls back to the managed copy, and reports `"custom"` or `"managed"` like the other two. An override whose file has since been deleted is ignored rather than reported as installed, matching how `binary_overrides::get` already treats a vanished binary.

**The other half of #222 is fixed in the study plugin, not here.** The reader resolved PDFium only from its own data folder, so a linked library was recorded and displayed and never actually loaded. That is fixed in study v0.3.6 with tests, and it also explains why blaming a linked `.dll` for the stutter in that thread never added up — it was not in the process.

### Checks
- `cargo test --workspace` — 359 + 350 + 3 passed
- `cargo fmt --all --check` — clean

Not clicked through: the resolution logic reads global state (the overrides file and the app data dir), so it is not unit-testable without injection. The study-side half is covered by tests.

Refs #222