### PR TITLE
fix(release): restore the updater signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # `createUpdaterArtifacts` is `false` in the committed tauri.conf.json so
-          # that anyone building from source does not need the release signing key;
-          # re-enable it here, only for tagged releases.
-          TAURI_CONFIG: '{"bundle":{"createUpdaterArtifacts":true}}'
           LDAI_UPDATE_INFORMATION: ${{ contains(matrix.platform, 'ubuntu') && 'gh-releases-zsync|tonhowtf|omniget|latest|*AppImage.zsync' || '' }}
           NODE_OPTIONS: --max-old-space-size=6144
         with:

--- a/README.md
+++ b/README.md
@@ -375,7 +375,13 @@ sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file lib
 
 </details>
 
-Production build: `pnpm tauri build`.
+Production build:
+
+```bash
+pnpm tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}'
+```
+
+Releases sign their updater artifacts with a private key only the maintainers hold, so a plain `pnpm tauri build` stops at the bundling step with *"A public key has been found, but no private key"*. The flag above turns those artifacts off for your local build — everything else is identical. It is passed on the command line rather than committed to `tauri.conf.json` on purpose: a config that disables them by default would silently ship a release with no signatures and break the auto-updater for everyone.
 
 ### Command line interface
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,7 +56,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": false,
+    "createUpdaterArtifacts": true,
     "resources": {
       "../browser-extension/chrome/": "browser-extension/chrome/",
       "../browser-extension/firefox/": "browser-extension/firefox/"


### PR DESCRIPTION
Caught while verifying the v0.8.6 draft before publishing it. **The build produced no `.sig` files at all** — normalising the version out of both asset lists:

```
$ diff <(v0.8.5 assets) <(v0.8.6 assets)
< omniget-VER-1.aarch64.rpm.sig
< omniget-VER-1.x86_64.rpm.sig
< omniget_VER_aarch64.AppImage.sig
< omniget_VER_amd64.AppImage.sig
< omniget_VER_amd64.deb.sig
< omniget_VER_arm64.deb.sig
< omniget_VER_x64-setup.exe.sig
< omniget_VER_x64_en-US.msi.sig
< omniget_aarch64.app.tar.gz.sig
< omniget_x64.app.tar.gz.sig
```

All ten signatures, gone. `latest.json` was still generated, so the release would have looked complete and the updater would have failed on every platform. The draft has been deleted and the tag removed; nothing shipped.

### Cause

#290 set `createUpdaterArtifacts: false` in the committed config so contributors could build without the release signing key, and re-enabled it for tagged releases via `TAURI_CONFIG`. The variable **did** reach the runner:

```
publish-tauri (ubuntu-22.04)  Run tauri-apps/tauri-action@v0
  TAURI_CONFIG: {"bundle":{"createUpdaterArtifacts":true}}
```

and had no effect through `tauri-action`. `TAURI_CONFIG` is a real env var the CLI knows, which is why it survived review — I checked the variable existed and was a merge patch, and did not check that it survives `tauri-action`. It does not.

### Fix

`createUpdaterArtifacts: true` goes back in the committed config, restoring exactly what shipped in 0.8.5.

The direction matters more than the mechanism: a contributor hitting a build error is a far better failure than every user silently losing updates, so the setting that **cannot** break a release is the one that belongs in the repo. The dead `TAURI_CONFIG` is removed rather than left looking load-bearing.

#290 was solving a real problem, so the escape hatch moves to the README as a documented flag, where its blast radius is one local build:

```bash
pnpm tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}'
```

Verified locally that this flag actually suppresses the artifacts: with `createUpdaterArtifacts: true` committed and no signing key in the environment, the build completes instead of stopping at *"A public key has been found, but no private key"*.

Once this lands, v0.8.6 gets re-tagged and the release re-run, and the signatures get checked against 0.8.5 before anything is published.