### PR TITLE
feat(skill): OmniGet Claude Code plugin (fetch, caption, transcript)

### DIFF
--- a/claude-plugin/.claude-plugin/marketplace.json
+++ b/claude-plugin/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "omniget",
+  "description": "Claude Code plugin for OmniGet: fetch media, captions and transcripts from a pasted URL",
+  "owner": {
+    "name": "Theodore Imonigie"
+  },
+  "plugins": [
+    {
+      "name": "omniget",
+      "description": "Paste a video or post URL: download it, pull the caption, transcribe the audio locally or in the cloud, and research it. Reuses OmniGet's managed yt-dlp, ffmpeg, cookies and models when the app is installed.",
+      "source": "./omniget",
+      "category": "productivity",
+      "keywords": ["omniget", "yt-dlp", "video", "transcript", "whisper", "download"]
+    }
+  ]
+}

--- a/claude-plugin/.gitignore
+++ b/claude-plugin/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.DS_Store

--- a/claude-plugin/omniget/.claude-plugin/plugin.json
+++ b/claude-plugin/omniget/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "omniget",
+  "version": "0.1.0",
+  "description": "Fetch media, captions and transcripts from a pasted URL with OmniGet's tooling: yt-dlp, ffmpeg, whisper.cpp or cloud speech APIs.",
+  "author": {
+    "name": "Theodore Imonigie"
+  },
+  "repository": "https://github.com/tonhowtf/omniget",
+  "license": "GPL-3.0",
+  "keywords": ["omniget", "yt-dlp", "download", "transcript", "whisper", "youtube", "instagram"]
+}

--- a/claude-plugin/omniget/.claude-plugin/plugin.json
+++ b/claude-plugin/omniget/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omniget",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Fetch media, captions and transcripts from a pasted URL with OmniGet's tooling: yt-dlp, ffmpeg, whisper.cpp or cloud speech APIs.",
   "author": {
     "name": "Theodore Imonigie"

--- a/claude-plugin/omniget/.claude-plugin/plugin.json
+++ b/claude-plugin/omniget/.claude-plugin/plugin.json
@@ -1,11 +1,19 @@
 {
   "name": "omniget",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Fetch media, captions and transcripts from a pasted URL with OmniGet's tooling: yt-dlp, ffmpeg, whisper.cpp or cloud speech APIs.",
   "author": {
     "name": "Theodore Imonigie"
   },
   "repository": "https://github.com/tonhowtf/omniget",
   "license": "GPL-3.0",
-  "keywords": ["omniget", "yt-dlp", "download", "transcript", "whisper", "youtube", "instagram"]
+  "keywords": [
+    "omniget",
+    "yt-dlp",
+    "download",
+    "transcript",
+    "whisper",
+    "youtube",
+    "instagram"
+  ]
 }

--- a/claude-plugin/omniget/.claude-plugin/plugin.json
+++ b/claude-plugin/omniget/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omniget",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Fetch media, captions and transcripts from a pasted URL with OmniGet's tooling: yt-dlp, ffmpeg, whisper.cpp or cloud speech APIs.",
   "author": {
     "name": "Theodore Imonigie"

--- a/claude-plugin/omniget/INSTALL.md
+++ b/claude-plugin/omniget/INSTALL.md
@@ -96,10 +96,11 @@ behind login, and even OmniGet depends on a signed-in session for much of it. If
 returns *"empty media response"* or *HTTP 400/429*:
 
 - It's usually a **temporary rate-limit** — wait a few minutes and retry.
-- If the post is **private or login-gated**, provide a session: log into the site in the
-  OmniGet app (its cookies are reused automatically), or set
-  `OMNIGET_COOKIES_FROM_BROWSER=chrome` (or `firefox`/`safari`/`edge`) and retry. If your
-  browser has multiple profiles, point at the right one, e.g. `chrome:Default`.
+- If the post is **private or login-gated**, the skill **retries automatically** using the
+  browser you're logged into (auto-detected). On macOS the first such read raises a one-time
+  Keychain prompt — allow it. If your browser has several profiles and the default isn't the
+  logged-in one, pin it: `OMNIGET_COOKIES_FROM_BROWSER=chrome:"Profile 3"`. Logging into the
+  site in the OmniGet app also works — those cookies are reused first, before any browser.
 
 Public content on YouTube, TikTok, Reddit, Vimeo, Twitch, and the ~1,800 yt-dlp sites is
 reliable and needs none of this.

--- a/claude-plugin/omniget/INSTALL.md
+++ b/claude-plugin/omniget/INSTALL.md
@@ -1,0 +1,122 @@
+# Installing the OmniGet skill
+
+A Claude Code plugin that downloads media, captions, and transcripts from a pasted URL.
+It reuses OmniGet's own tools when present and installs what's missing.
+
+## What it needs
+
+| Purpose | Tool | Required? |
+|---|---|---|
+| Download / metadata / captions | `yt-dlp` + `ffmpeg` | yes |
+| Reliable Instagram / X / Bilibili / Threads | `omniget-cli` (prebuilt) | recommended |
+| Local, offline transcription | `whisper-cli` (whisper.cpp) or `mlx_whisper` + a model | optional |
+| Cloud transcription | OpenAI **or** Gemini API key | optional |
+
+You do not need all of these. Captions alone need only `yt-dlp` + `ffmpeg`. Any one
+transcription option (captions, local model, or a cloud key) is enough.
+
+## 1. Install the plugin
+
+In a Claude Code session:
+
+```
+/plugin marketplace add /path/to/omniget/claude-plugin
+/plugin install omniget
+```
+
+## 2. Install the tools — one step
+
+```
+/omniget:setup
+```
+
+`/omniget:setup` detects your OS and:
+- installs `yt-dlp` and `ffmpeg` if missing (after one confirmation),
+- downloads the prebuilt `omniget-cli` for your OS/arch (native extractors for
+  Instagram/X/Bilibili/Threads),
+- reports which API keys work and how to add one.
+
+Flags: `--yes` (no prompt), `--local` (also set up on-device Whisper + a model),
+`--no-cli` (skip omniget-cli), `--update` (refresh yt-dlp + omniget-cli).
+
+You can also run it straight from a terminal:
+
+```bash
+bash claude-plugin/omniget/scripts/setup.sh --yes
+```
+
+If the OmniGet **desktop app** is installed, `yt-dlp` and `ffmpeg` are already managed by
+it and setup will find them.
+
+### Per-OS
+
+- **macOS** — needs [Homebrew](https://brew.sh). Installs `yt-dlp`, `ffmpeg`, and (with
+  `--local`) `whisper-cpp` via brew. `omniget-cli` is downloaded for Apple Silicon or Intel.
+- **Windows** — needs winget (App Installer from the Microsoft Store) or scoop. Installs
+  `yt-dlp` and `ffmpeg`; `omniget-cli` (x64) is downloaded. For local Whisper, prefer a
+  cloud key.
+- **Linux** — setup runs `apt`/`dnf`/`pacman`/`zypper` (needs `sudo`, so run it in a
+  terminal) or prints the commands. `omniget-cli` is downloaded for x86_64 (no prebuilt
+  arm64 CLI — those machines use `yt-dlp` for every site). Distro `yt-dlp` is often stale;
+  `pipx install yt-dlp` (what setup uses on apt) stays current.
+
+## 3. Add a transcription key (optional)
+
+Captions and local Whisper need no key. For cloud transcription, add an OpenAI or Gemini
+key **in your own terminal** — the input is hidden and the key never passes through Claude:
+
+```bash
+bash claude-plugin/omniget/scripts/keys.sh set
+```
+
+Confirm what works:
+
+```bash
+bash claude-plugin/omniget/scripts/keys.sh check
+```
+
+> Only OpenAI and Gemini transcribe. OpenRouter has no speech-to-text endpoint and is not
+> supported here.
+
+## Keeping it working
+
+Sites change and extractors break — this is normal for every downloader. When something
+that used to work stops:
+
+```bash
+bash claude-plugin/omniget/scripts/setup.sh --update
+```
+
+That upgrades `yt-dlp` and re-downloads the latest `omniget-cli`.
+
+## Private and rate-limited content (Instagram, X)
+
+No downloader "always works" for Instagram/X. They rate-limit by IP and gate content
+behind login, and even OmniGet depends on a signed-in session for much of it. If a fetch
+returns *"empty media response"* or *HTTP 400/429*:
+
+- It's usually a **temporary rate-limit** — wait a few minutes and retry.
+- If the post is **private or login-gated**, provide a session: log into the site in the
+  OmniGet app (its cookies are reused automatically), or set
+  `OMNIGET_COOKIES_FROM_BROWSER=chrome` (or `firefox`/`safari`/`edge`) and retry. If your
+  browser has multiple profiles, point at the right one, e.g. `chrome:Default`.
+
+Public content on YouTube, TikTok, Reddit, Vimeo, Twitch, and the ~1,800 yt-dlp sites is
+reliable and needs none of this.
+
+## Troubleshooting
+
+- `/omniget:doctor` — full status: tools, models, and (with the command) live key checks.
+- `yt-dlp not found` → run `/omniget:setup`.
+- A site suddenly fails → `setup.sh --update`.
+- Everything green but one URL fails → check the hint the script prints; it distinguishes
+  rate-limits, login-required, and DRM.
+
+## Uninstall
+
+```
+/plugin uninstall omniget
+```
+
+Downloaded tools/models live in `~/.cache/omniget-skill/` (and, if you used brew/winget,
+in the usual system locations); remove them by hand if you want the space back.

--- a/claude-plugin/omniget/README.md
+++ b/claude-plugin/omniget/README.md
@@ -8,14 +8,60 @@ desktop app's own resolver: `omniget-cli` on `PATH` → the binaries OmniGet
 manages in its app-data folder → the system `PATH`. Nothing here requires the
 desktop app; with `yt-dlp` and `ffmpeg` on `PATH` it works on its own.
 
-## Install
+## Setup
+
+Three steps. The first is the only one that's always required.
+
+**1. Install the plugin** (in a Claude Code session):
 
 ```
 /plugin marketplace add /path/to/omniget/claude-plugin
 /plugin install omniget
 ```
 
-Then run `/omniget:doctor` to see what is available and what to add.
+**2. Install the tools** — one step, on any OS:
+
+```
+/omniget:setup
+```
+
+It checks for `yt-dlp` and `ffmpeg`, and installs whatever is missing after a single
+confirmation (Mac via Homebrew, Windows via winget/scoop). Add `--local` to also set up
+an on-device Whisper engine and model. You can also run it straight from a terminal:
+`bash claude-plugin/omniget/scripts/setup.sh` (add `--yes` to skip the prompt).
+
+If the OmniGet desktop app is installed, `yt-dlp` and `ffmpeg` are already managed by it,
+so this step finds them and installs nothing.
+
+**3. Add a transcription key (optional).** Captions and local Whisper need no key. For
+cloud transcription (more accurate, no model download), add an OpenAI or Gemini key **in
+your own terminal** — the input is hidden and the key never passes through Claude:
+
+```bash
+bash claude-plugin/omniget/scripts/keys.sh set
+```
+
+Then confirm what works:
+
+```bash
+bash claude-plugin/omniget/scripts/keys.sh check
+```
+
+> Only OpenAI and Gemini are supported for transcription. OpenRouter has no
+> speech-to-text endpoint, so it is not offered here.
+
+### Per-OS notes
+
+- **macOS** — needs [Homebrew](https://brew.sh). `/omniget:setup` then installs
+  `yt-dlp`, `ffmpeg`, and (with `--local`) `whisper-cpp` automatically.
+- **Windows** — needs winget (App Installer, from the Microsoft Store) or scoop.
+  `/omniget:setup` installs `yt-dlp` and `ffmpeg`. For local transcription, prefer a
+  cloud key or install whisper.cpp manually; captions and cloud both work out of the box.
+- **Linux** — `/omniget:setup` detects `apt`/`dnf`/`pacman`/`zypper` and runs it (with
+  `sudo`, so it needs a terminal), or prints the exact commands if it can't. Distro
+  `yt-dlp` is often outdated — `pipx install yt-dlp` (what setup uses on apt) stays current.
+  For local Whisper, install `whisper.cpp` from your distro or the upstream release and
+  fetch a model with `scripts/get-model.sh`.
 
 ## Commands
 
@@ -24,6 +70,7 @@ Then run `/omniget:doctor` to see what is available and what to add.
 | `/omniget:fetch <url> [--audio] [--quality N]` | Download the media to `~/Downloads/omniget` |
 | `/omniget:transcribe <url\|file> [--backend B] [--lang xx] [--summarize]` | Transcribe and optionally summarize |
 | `/omniget:research <url> [--backend B]` | Caption + transcript distilled into a Markdown note with `[mm:ss]` references |
+| `/omniget:setup` | Install missing tools for your OS (confirm once) and check your API keys |
 | `/omniget:doctor` | Report available tools, models, and keys, plus how to add the missing ones |
 
 The two skills (`omniget-fetch`, `omniget-transcribe`) trigger on their own when a
@@ -42,15 +89,6 @@ media URL is pasted with a request, so the slash commands are optional.
 Force one with `--backend local|mlx|gemini|openai|captions`. API keys are read from
 the environment or `~/.config/ai-keys.env` and never printed.
 
-## Getting the pieces
-
-Nothing is installed for you; `/omniget:doctor` prints the commands and you decide.
-
-- **yt-dlp + ffmpeg**: `brew install yt-dlp ffmpeg` (macOS), `winget install yt-dlp.yt-dlp Gyan.FFmpeg` (Windows), your distro's packages (Linux).
-- **local Whisper**: `brew install whisper-cpp`, or the release bundle from `ggml-org/whisper.cpp`. On Apple Silicon `uv tool install mlx-whisper` is faster.
-- **a model**: `scripts/get-model.sh large-v3-turbo-q5_0` (547 MB, SHA-256 verified from `ggerganov/whisper.cpp`). Smaller: `base` (141 MB), `small` (465 MB).
-- **cloud keys**: `export GEMINI_API_KEY=...` / `export OPENAI_API_KEY=...`, or put them in `~/.config/ai-keys.env`.
-
 ## Environment variables
 
 | Variable | Meaning |
@@ -65,10 +103,11 @@ Nothing is installed for you; `/omniget:doctor` prints the commands and you deci
 ## Scripts
 
 The skills call `scripts/`; each prints one JSON line on success, progress on stderr:
-`doctor.sh`, `resolve-tools.sh` (shared lookup, sourced by the rest), `fetch.sh`,
-`research.sh`, `transcribe.sh`, `get-model.sh`, plus `srt_tools.py`,
-`gemini_transcribe.py`, `openai_transcribe.sh`. Run the tests with
-`python3 -m unittest discover -s tests`.
+`setup.sh` (cross-OS installer), `keys.sh` (add/test keys), `doctor.sh`,
+`resolve-tools.sh` (shared lookup, sourced by the rest), `fetch.sh`, `research.sh`,
+`transcribe.sh`, `get-model.sh`, plus `srt_tools.py`, `gemini_transcribe.py`,
+`openai_transcribe.sh`. Run the tests with `python3 -m unittest discover -s tests`
+and `bash tests/test_keys.sh`.
 
 ## Scope
 

--- a/claude-plugin/omniget/README.md
+++ b/claude-plugin/omniget/README.md
@@ -1,0 +1,77 @@
+# OmniGet — Claude Code plugin
+
+Paste a video, audio, or social-post URL into Claude Code and get the media file,
+its caption, and a transcript, ready to summarize, quote, or research.
+
+It reuses whatever OmniGet already installed. Tool lookup order, mirroring the
+desktop app's own resolver: `omniget-cli` on `PATH` → the binaries OmniGet
+manages in its app-data folder → the system `PATH`. Nothing here requires the
+desktop app; with `yt-dlp` and `ffmpeg` on `PATH` it works on its own.
+
+## Install
+
+```
+/plugin marketplace add /path/to/omniget/claude-plugin
+/plugin install omniget
+```
+
+Then run `/omniget:doctor` to see what is available and what to add.
+
+## Commands
+
+| Command | Does |
+|---|---|
+| `/omniget:fetch <url> [--audio] [--quality N]` | Download the media to `~/Downloads/omniget` |
+| `/omniget:transcribe <url\|file> [--backend B] [--lang xx] [--summarize]` | Transcribe and optionally summarize |
+| `/omniget:research <url> [--backend B]` | Caption + transcript distilled into a Markdown note with `[mm:ss]` references |
+| `/omniget:doctor` | Report available tools, models, and keys, plus how to add the missing ones |
+
+The two skills (`omniget-fetch`, `omniget-transcribe`) trigger on their own when a
+media URL is pasted with a request, so the slash commands are optional.
+
+## Transcription backends
+
+`--backend auto` (the default) walks this ladder and uses the first that works:
+
+1. **captions** — platform subtitles via `yt-dlp`. Free, instant.
+2. **local** — `whisper-cli` (whisper.cpp) with a ggml model. Free, offline, private.
+3. **mlx** — `mlx_whisper` on Apple Silicon. Free, offline, faster than whisper-cli.
+4. **gemini** — Gemini 2.5 Flash, needs `GEMINI_API_KEY`. Cents per hour, audio-native.
+5. **openai** — needs `OPENAI_API_KEY`. `whisper-1` returns timestamps; `--model gpt-4o-transcribe` is more accurate but text-only.
+
+Force one with `--backend local|mlx|gemini|openai|captions`. API keys are read from
+the environment or `~/.config/ai-keys.env` and never printed.
+
+## Getting the pieces
+
+Nothing is installed for you; `/omniget:doctor` prints the commands and you decide.
+
+- **yt-dlp + ffmpeg**: `brew install yt-dlp ffmpeg` (macOS), `winget install yt-dlp.yt-dlp Gyan.FFmpeg` (Windows), your distro's packages (Linux).
+- **local Whisper**: `brew install whisper-cpp`, or the release bundle from `ggml-org/whisper.cpp`. On Apple Silicon `uv tool install mlx-whisper` is faster.
+- **a model**: `scripts/get-model.sh large-v3-turbo-q5_0` (547 MB, SHA-256 verified from `ggerganov/whisper.cpp`). Smaller: `base` (141 MB), `small` (465 MB).
+- **cloud keys**: `export GEMINI_API_KEY=...` / `export OPENAI_API_KEY=...`, or put them in `~/.config/ai-keys.env`.
+
+## Environment variables
+
+| Variable | Meaning |
+|---|---|
+| `OMNIGET_DIR` | Output directory (default `~/Downloads/omniget`) |
+| `OMNIGET_DATA_DIR` | OmniGet app-data dir (auto-detected per OS) |
+| `OMNIGET_TOOL_YT_DLP`, `OMNIGET_TOOL_FFMPEG`, ... | Explicit binary paths |
+| `OMNIGET_WHISPER_MODEL` | Explicit ggml model file for the local backend |
+| `OMNIGET_COOKIES_FROM_BROWSER` | `chrome` / `firefox` / `safari` / `edge` for login-gated media |
+| `OMNIGET_KEYS_FILE` | Alternative to `~/.config/ai-keys.env` |
+
+## Scripts
+
+The skills call `scripts/`; each prints one JSON line on success, progress on stderr:
+`doctor.sh`, `resolve-tools.sh` (shared lookup, sourced by the rest), `fetch.sh`,
+`research.sh`, `transcribe.sh`, `get-model.sh`, plus `srt_tools.py`,
+`gemini_transcribe.py`, `openai_transcribe.sh`. Run the tests with
+`python3 -m unittest discover -s tests`.
+
+## Scope
+
+Downloads only what the user asks for. Never bypasses DRM or paywalls; it uses the
+session the user already has (via OmniGet cookie accounts or `--cookies-from-browser`).
+Captions cover the post description; comments are out of scope.

--- a/claude-plugin/omniget/README.md
+++ b/claude-plugin/omniget/README.md
@@ -8,6 +8,8 @@ desktop app's own resolver: `omniget-cli` on `PATH` → the binaries OmniGet
 manages in its app-data folder → the system `PATH`. Nothing here requires the
 desktop app; with `yt-dlp` and `ffmpeg` on `PATH` it works on its own.
 
+> Full install guide, per-OS notes, updating, and private-content handling: **[INSTALL.md](INSTALL.md)**.
+
 ## Setup
 
 Three steps. The first is the only one that's always required.
@@ -25,9 +27,12 @@ Three steps. The first is the only one that's always required.
 /omniget:setup
 ```
 
-It checks for `yt-dlp` and `ffmpeg`, and installs whatever is missing after a single
-confirmation (Mac via Homebrew, Windows via winget/scoop). Add `--local` to also set up
-an on-device Whisper engine and model. You can also run it straight from a terminal:
+It checks for `yt-dlp` and `ffmpeg`, installs whatever is missing after a single
+confirmation (Mac via Homebrew, Windows via winget/scoop), and downloads the prebuilt
+`omniget-cli` for your OS/arch — OmniGet's native extractors for Instagram/X/Bilibili/Threads,
+which are more reliable than raw yt-dlp for those sites. Add `--local` to also set up an
+on-device Whisper engine and model, `--no-cli` to skip omniget-cli, or `--update` to refresh
+`yt-dlp` and `omniget-cli` when a site breaks. You can also run it from a terminal:
 `bash claude-plugin/omniget/scripts/setup.sh` (add `--yes` to skip the prompt).
 
 If the OmniGet desktop app is installed, `yt-dlp` and `ffmpeg` are already managed by it,
@@ -70,7 +75,7 @@ bash claude-plugin/omniget/scripts/keys.sh check
 | `/omniget:fetch <url> [--audio] [--quality N]` | Download the media to `~/Downloads/omniget` |
 | `/omniget:transcribe <url\|file> [--backend B] [--lang xx] [--summarize]` | Transcribe and optionally summarize |
 | `/omniget:research <url> [--backend B]` | Caption + transcript distilled into a Markdown note with `[mm:ss]` references |
-| `/omniget:setup` | Install missing tools for your OS (confirm once) and check your API keys |
+| `/omniget:setup` | Install missing tools + `omniget-cli` (confirm once), check API keys; `--update` refreshes them |
 | `/omniget:doctor` | Report available tools, models, and keys, plus how to add the missing ones |
 
 The two skills (`omniget-fetch`, `omniget-transcribe`) trigger on their own when a

--- a/claude-plugin/omniget/commands/doctor.md
+++ b/claude-plugin/omniget/commands/doctor.md
@@ -3,7 +3,9 @@ description: Check which OmniGet tools, Whisper models and speech API keys this 
 allowed-tools: ["Bash"]
 ---
 
-Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh"` and explain the result in plain words:
+Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh" --check-keys` and explain the result in plain words:
 what works today (captions, local Whisper, Gemini, OpenAI), what is missing, and the exact
 command that would add each missing piece. Do not run any install command unless the user
 answers yes.
+
+If tools or keys are missing, tell the user they can fix it in one step with `/omniget:setup` (or, for a key, by running `keys.sh set` in their own terminal).

--- a/claude-plugin/omniget/commands/doctor.md
+++ b/claude-plugin/omniget/commands/doctor.md
@@ -1,0 +1,9 @@
+---
+description: Check which OmniGet tools, Whisper models and speech API keys this machine has, and how to add missing ones
+allowed-tools: ["Bash"]
+---
+
+Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh"` and explain the result in plain words:
+what works today (captions, local Whisper, Gemini, OpenAI), what is missing, and the exact
+command that would add each missing piece. Do not run any install command unless the user
+answers yes.

--- a/claude-plugin/omniget/commands/fetch.md
+++ b/claude-plugin/omniget/commands/fetch.md
@@ -1,0 +1,16 @@
+---
+description: Download the media at a URL with OmniGet's tooling (yt-dlp, ffmpeg, omniget-cli)
+argument-hint: <url> [--audio] [--quality N] [--out DIR]
+allowed-tools: ["Bash", "Read"]
+---
+
+Download the media for the arguments below using the `omniget-fetch` skill.
+
+Run:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/fetch.sh" $ARGUMENTS
+```
+
+Then report the saved file path, size and duration in one or two sentences. If the script
+fails, run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh"`, apply the error table from the
+`omniget-fetch` skill, and ask before installing anything.

--- a/claude-plugin/omniget/commands/research.md
+++ b/claude-plugin/omniget/commands/research.md
@@ -1,0 +1,14 @@
+---
+description: "Research a video or post URL: caption plus transcript, distilled into a Markdown note with timestamps"
+argument-hint: <url> [--backend auto|local|mlx|gemini|openai] [--lang xx]
+allowed-tools: ["Bash", "Read", "Write"]
+---
+
+Build a research note for the URL in the arguments using the `omniget-transcribe` skill.
+
+1. `bash "${CLAUDE_PLUGIN_ROOT}/scripts/research.sh" "<url>"` for title, uploader, duration and caption.
+2. `bash "${CLAUDE_PLUGIN_ROOT}/scripts/transcribe.sh" <arguments>` for the transcript.
+3. Read the transcript file. Write `<transcript path without .md>.notes.md` containing:
+   title and source link; the caption verbatim when present; a five-line summary; key points
+   with `[mm:ss]` references; notable quotes with timestamps; open questions worth checking.
+4. Reply with the note's path and the summary. Mention which backend produced the transcript.

--- a/claude-plugin/omniget/commands/setup.md
+++ b/claude-plugin/omniget/commands/setup.md
@@ -10,9 +10,10 @@ Set up everything the skill needs, using the `omniget-fetch` / `omniget-transcri
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" $ARGUMENTS
    ```
-   - It checks for `yt-dlp` and `ffmpeg`, lists anything missing, and (on Mac/Windows)
-     installs it after one confirmation. `--yes` skips the prompt; `--local` also sets up
-     a local Whisper engine + model.
+   - It checks for `yt-dlp` and `ffmpeg`, lists anything missing, installs it after one
+     confirmation (Mac/Windows), and downloads `omniget-cli` (native Instagram/X/Bilibili
+     extractors). `--yes` skips the prompt; `--local` adds a local Whisper engine + model;
+     `--no-cli` skips omniget-cli; `--update` refreshes yt-dlp and omniget-cli.
    - It cannot type the user's API keys, and neither can you. It reports which keys work
      and prints the exact command for the user to run in their own terminal to add one.
 2. Read the output and tell the user, in plain words: what is now installed, which

--- a/claude-plugin/omniget/commands/setup.md
+++ b/claude-plugin/omniget/commands/setup.md
@@ -1,0 +1,24 @@
+---
+description: "Set up the omniget skill: install missing tools for this OS (confirm once) and check API keys"
+argument-hint: "[--yes] [--local]"
+allowed-tools: ["Bash"]
+---
+
+Set up everything the skill needs, using the `omniget-fetch` / `omniget-transcribe` skills' scripts.
+
+1. Run the setup script with any arguments the user passed:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" $ARGUMENTS
+   ```
+   - It checks for `yt-dlp` and `ffmpeg`, lists anything missing, and (on Mac/Windows)
+     installs it after one confirmation. `--yes` skips the prompt; `--local` also sets up
+     a local Whisper engine + model.
+   - It cannot type the user's API keys, and neither can you. It reports which keys work
+     and prints the exact command for the user to run in their own terminal to add one.
+2. Read the output and tell the user, in plain words: what is now installed, which
+   transcription options are available to them (captions always; local if a model is
+   present; Gemini/OpenAI if a key tested "working"), and — only if they have no working
+   key and no local model — that to add a key they should run, in their own terminal:
+   `bash "${CLAUDE_PLUGIN_ROOT}/scripts/keys.sh" set`
+3. Do not ask the user to paste a key to you, and never run `keys.sh set` yourself — it
+   needs their terminal and their keys must not pass through this conversation.

--- a/claude-plugin/omniget/commands/transcribe.md
+++ b/claude-plugin/omniget/commands/transcribe.md
@@ -1,0 +1,15 @@
+---
+description: Transcribe a video/audio URL or local file (captions, local Whisper, Gemini or OpenAI) and summarize on request
+argument-hint: <url|file> [--backend auto|local|mlx|gemini|openai] [--lang xx] [--summarize]
+allowed-tools: ["Bash", "Read", "Write"]
+---
+
+Transcribe the media in the arguments below using the `omniget-transcribe` skill.
+
+1. If `--summarize` is present, remove it from the arguments and remember to summarize.
+2. For a URL, first run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/research.sh" "<url>"` to get the
+   title and caption.
+3. Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/transcribe.sh" <remaining arguments>`.
+4. Read the transcript file named in the JSON output.
+5. Reply with the transcript path, the backend used, and, when asked, a summary with
+   `[mm:ss]` references. Otherwise give a two-sentence description of the content.

--- a/claude-plugin/omniget/scripts/doctor.sh
+++ b/claude-plugin/omniget/scripts/doctor.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Report which tools, models and keys the omniget skill can use, and how to get the missing ones.
+# Usage: doctor.sh [--json]
+set -u
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=resolve-tools.sh
+. "$here/resolve-tools.sh"
+
+json=false
+[ "${1:-}" = "--json" ] && json=true
+
+rows=""
+add_row() { rows="$rows$1	$2	$3
+"; }
+
+for t in omniget-cli yt-dlp ffmpeg ffprobe whisper-cli mlx_whisper; do
+  if found="$(og_find_tool "$t")"; then
+    add_row "$t" "$(printf '%s' "$found" | cut -f2)" "$(printf '%s' "$found" | cut -f1)"
+  else
+    add_row "$t" missing -
+  fi
+done
+
+if model="$(og_whisper_model)"; then
+  add_row whisper-model present "$model"
+else
+  add_row whisper-model missing -
+fi
+
+for k in GEMINI_API_KEY OPENAI_API_KEY; do
+  if og_has_key "$k"; then add_row "$k" present "(set)"; else add_row "$k" missing -; fi
+done
+
+data="$(og_data_dir)"
+if [ -d "$data" ]; then add_row omniget-app installed "$data"; else add_row omniget-app missing "$data"; fi
+add_row output-dir configured "$(og_output_dir)"
+
+if $json; then
+  printf '{'
+  first=true
+  printf '%s' "$rows" | while IFS='	' read -r name status where; do
+    [ -n "$name" ] || continue
+    $first || printf ','
+    first=false
+    printf '"%s":{"status":"%s","path":"%s"}' "$name" "$status" "$(printf '%s' "$where" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  done
+  printf '}\n'
+  exit 0
+fi
+
+printf '%-16s %-10s %s\n' TOOL STATUS WHERE
+printf '%s' "$rows" | while IFS='	' read -r name status where; do
+  [ -n "$name" ] || continue
+  printf '%-16s %-10s %s\n' "$name" "$status" "$where"
+done
+
+echo
+echo "How to fill gaps (ask the user before running any of these):"
+case "$(og_os)" in
+  mac)
+    echo "  OmniGet app:     https://github.com/tonhowtf/omniget/releases/latest  (.dmg; then: xattr -cr /Applications/omniget.app)"
+    echo "  yt-dlp + ffmpeg: brew install yt-dlp ffmpeg"
+    echo "  local whisper:   brew install whisper-cpp        (whisper.cpp CLI, CPU/Metal)"
+    echo "                   uv tool install mlx-whisper     (faster on Apple Silicon)"
+    ;;
+  linux)
+    echo "  OmniGet app:     https://github.com/tonhowtf/omniget/releases/latest  (.deb/.rpm/.AppImage)"
+    echo "  yt-dlp + ffmpeg: sudo apt install ffmpeg && pip install -U yt-dlp   (or your distro's packages)"
+    echo "  local whisper:   whisper-bin-ubuntu-x64.tar.gz from https://github.com/ggml-org/whisper.cpp/releases"
+    ;;
+  windows)
+    echo "  OmniGet app:     winget install -e --id tonhowtf.OmniGet"
+    echo "  yt-dlp + ffmpeg: winget install yt-dlp.yt-dlp Gyan.FFmpeg"
+    echo "  local whisper:   whisper-bin-x64.zip from https://github.com/ggml-org/whisper.cpp/releases"
+    ;;
+esac
+echo "  whisper model:   $here/get-model.sh large-v3-turbo-q5_0    (547 MB, from ggerganov/whisper.cpp on Hugging Face)"
+echo "  cloud keys:      export GEMINI_API_KEY=... or OPENAI_API_KEY=..., or put them in ~/.config/ai-keys.env"

--- a/claude-plugin/omniget/scripts/doctor.sh
+++ b/claude-plugin/omniget/scripts/doctor.sh
@@ -7,7 +7,13 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$here/resolve-tools.sh"
 
 json=false
-[ "${1:-}" = "--json" ] && json=true
+check_keys=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) json=true ;;
+    --check-keys) check_keys=true ;;
+  esac
+done
 
 rows=""
 add_row() { rows="$rows$1	$2	$3
@@ -76,3 +82,8 @@ case "$(og_os)" in
 esac
 echo "  whisper model:   $here/get-model.sh large-v3-turbo-q5_0    (547 MB, from ggerganov/whisper.cpp on Hugging Face)"
 echo "  cloud keys:      export GEMINI_API_KEY=... or OPENAI_API_KEY=..., or put them in ~/.config/ai-keys.env"
+
+if $check_keys && ! $json; then
+  echo
+  bash "$here/keys.sh" check
+fi

--- a/claude-plugin/omniget/scripts/fetch.sh
+++ b/claude-plugin/omniget/scripts/fetch.sh
@@ -60,10 +60,9 @@ elif [ -n "$quality" ]; then
 else
   args+=(-f "bv*+ba/b" --merge-output-format mp4)
 fi
-while IFS= read -r line; do args+=("$line"); done < <(og_cookie_args "$url")
-
+# og_run_ytdlp adds cookies and does one browser-login retry if the site blocks us.
 err="$(mktemp "${TMPDIR:-/tmp}/omniget-fetch.XXXXXX")"
-if ! output="$("$ytdlp" "${args[@]}" "$url" 2>"$err")"; then
+if ! output="$(og_run_ytdlp "$url" "$err" "${args[@]}")"; then
   cat "$err" >&2
   hint="$(og_explain_error "$(cat "$err" 2>/dev/null)")"
   [ -n "$hint" ] && echo "-> $hint" >&2

--- a/claude-plugin/omniget/scripts/fetch.sh
+++ b/claude-plugin/omniget/scripts/fetch.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Download media from a URL. Prints one JSON line: {file,title,duration,size,platform,engine,id}.
+# Usage: fetch.sh <url> [--audio] [--quality 720] [--out DIR]
+set -eu
+set -o pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$here/resolve-tools.sh"
+
+url=""; audio=false; quality=""; out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --audio) audio=true ;;
+    --quality) quality="$2"; shift ;;
+    --out) out="$2"; shift ;;
+    -*) echo "fetch: unknown flag $1" >&2; exit 2 ;;
+    *) url="$1" ;;
+  esac
+  shift
+done
+[ -n "$url" ] || { echo "usage: fetch.sh <url> [--audio] [--quality N] [--out DIR]" >&2; exit 2; }
+[ -n "$out" ] || out="$(og_output_dir)"
+mkdir -p "$out"
+
+file_size() {
+  if stat -f%z "$1" >/dev/null 2>&1; then stat -f%z "$1"; else stat -c%s "$1"; fi
+}
+
+# omniget-cli path: native extractors and OmniGet cookie accounts for the hosts that need them.
+if og_prefers_cli "$url" && cli="$(og_tool_path omniget-cli)"; then
+  info="$("$cli" --json info "$url")"
+  args=(--json download "$url" -o "$out")
+  $audio && args+=(--audio-only)
+  [ -n "$quality" ] && args+=(-q "$quality")
+  result="$("$cli" "${args[@]}" | tail -n 1)"
+  printf '%s\n%s\n' "$info" "$result" | python3 -c '
+import json, sys
+info, result = [json.loads(l) for l in sys.stdin.read().splitlines() if l.strip()][:2]
+if not result.get("success"):
+    sys.exit("fetch: omniget-cli failed: %s" % result.get("error"))
+print(json.dumps({
+    "file": result["file_path"], "title": info.get("title"), "duration": info.get("duration"),
+    "size": result.get("size"), "platform": result.get("platform"), "engine": "omniget-cli",
+}, ensure_ascii=False))'
+  exit 0
+fi
+
+ytdlp="$(og_tool_path yt-dlp)" || { echo "fetch: yt-dlp not found; run doctor.sh" >&2; exit 1; }
+ffmpeg_dir=""
+if ffmpeg="$(og_tool_path ffmpeg)"; then ffmpeg_dir="$(dirname "$ffmpeg")"; fi
+
+args=(--no-warnings --no-playlist --no-simulate --quiet
+      --print "%(id)s ||| %(extractor_key)s ||| %(duration)s ||| %(title)s"
+      --print "after_move:filepath"
+      -o "$out/%(title).120B [%(id)s].%(ext)s")
+[ -n "$ffmpeg_dir" ] && args+=(--ffmpeg-location "$ffmpeg_dir")
+if $audio; then
+  args+=(-f "bestaudio/best" -x --audio-format m4a)
+elif [ -n "$quality" ]; then
+  args+=(-f "bv*[height<=$quality]+ba/b[height<=$quality]/b" --merge-output-format mp4)
+else
+  args+=(-f "bv*+ba/b" --merge-output-format mp4)
+fi
+while IFS= read -r line; do args+=("$line"); done < <(og_cookie_args "$url")
+
+output="$("$ytdlp" "${args[@]}" "$url")"
+meta="$(printf '%s\n' "$output" | head -n 1)"
+path="$(printf '%s\n' "$output" | tail -n 1)"
+[ -f "$path" ] || { echo "fetch: download finished but file not found: $path" >&2; exit 1; }
+
+id="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $1}')"
+platform="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $2}')"
+duration="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $3}')"
+title="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $4}')"
+[ "$duration" = "NA" ] && duration=""
+og_json file="$path" title="$title" duration:n="$duration" size:n="$(file_size "$path")" platform="$platform" engine="yt-dlp" id="$id"

--- a/claude-plugin/omniget/scripts/fetch.sh
+++ b/claude-plugin/omniget/scripts/fetch.sh
@@ -62,7 +62,15 @@ else
 fi
 while IFS= read -r line; do args+=("$line"); done < <(og_cookie_args "$url")
 
-output="$("$ytdlp" "${args[@]}" "$url")"
+err="$(mktemp "${TMPDIR:-/tmp}/omniget-fetch.XXXXXX")"
+if ! output="$("$ytdlp" "${args[@]}" "$url" 2>"$err")"; then
+  cat "$err" >&2
+  hint="$(og_explain_error "$(cat "$err" 2>/dev/null)")"
+  [ -n "$hint" ] && echo "-> $hint" >&2
+  rm -f "$err"
+  exit 1
+fi
+rm -f "$err"
 meta="$(printf '%s\n' "$output" | head -n 1)"
 path="$(printf '%s\n' "$output" | tail -n 1)"
 [ -f "$path" ] || { echo "fetch: download finished but file not found: $path" >&2; exit 1; }

--- a/claude-plugin/omniget/scripts/gemini_transcribe.py
+++ b/claude-plugin/omniget/scripts/gemini_transcribe.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Transcribe an audio file with Gemini and write SubRip (SRT) output.
+
+Usage: gemini_transcribe.py AUDIO --out OUT.srt [--model gemini-2.5-flash] [--lang xx]
+
+Reads GEMINI_API_KEY from the environment. Standard library only: files up to
+19 MB are sent inline, larger ones go through the Gemini Files API. If the
+model does not return parseable SRT, the raw text is written to OUT with a
+.txt extension and that path is printed instead.
+"""
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import srt_tools  # noqa: E402
+
+API = "https://generativelanguage.googleapis.com"
+INLINE_LIMIT = 19 * 1024 * 1024
+
+PROMPT = (
+    "Transcribe this audio verbatim into SubRip (SRT) subtitle format. "
+    "Number every cue, use `HH:MM:SS,mmm --> HH:MM:SS,mmm` timestamps that match "
+    "when the words are spoken, keep each cue under about 10 seconds, and write "
+    "exactly what is said with no commentary, no speaker guesses and no markdown fences. {lang}"
+)
+
+
+def normalize_srt_timestamps(text):
+    """Rewrite the timestamp lines Gemini emits into strict SRT `HH:MM:SS,mmm`.
+
+    Gemini is inconsistent: it produces `MM:SS:mmm`, `HH:MM:SS.mmm`, bare
+    `HH:MM:SS`, and the correct comma form interchangeably. Normalize every
+    `-->` line so srt_tools.parse_cues can read it.
+    """
+    def one(token):
+        parts = [p for p in re.split(r"[:.,]", token.strip()) if p != ""]
+        if not parts:
+            return None
+        ms = 0
+        if len(parts) > 1 and len(parts[-1]) == 3 and parts[-1].isdigit():
+            ms = int(parts[-1])
+            parts = parts[:-1]
+        try:
+            nums = [int(p) for p in parts]
+        except ValueError:
+            return None
+        s = nums[-1] if len(nums) >= 1 else 0
+        m = nums[-2] if len(nums) >= 2 else 0
+        h = nums[-3] if len(nums) >= 3 else 0
+        return "%02d:%02d:%02d,%03d" % (h, m, s, ms)
+
+    out = []
+    for line in text.splitlines():
+        if "-->" in line:
+            m = re.match(r"\s*([0-9:.,]+)\s*-->\s*([0-9:.,]+)(.*)$", line)
+            if m:
+                a, b = one(m.group(1)), one(m.group(2))
+                if a and b:
+                    line = "%s --> %s" % (a, b)
+        out.append(line)
+    return "\n".join(out)
+
+
+
+def request(method, url, body=None, headers=None, raw=False, timeout=900):
+    data = body if raw else (json.dumps(body).encode() if body is not None else None)
+    hdrs = {"Content-Type": "application/json"}
+    hdrs.update(headers or {})
+    req = urllib.request.Request(url, data=data, method=method, headers=hdrs)
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.headers, resp.read()
+        except urllib.error.HTTPError as err:
+            detail = err.read().decode(errors="replace")[:500]
+            if err.code in (429, 500, 502, 503, 504) and attempt < 3:
+                time.sleep(5 * (attempt + 1))
+                continue
+            sys.exit("gemini: HTTP %s: %s" % (err.code, detail))
+        except urllib.error.URLError as err:
+            if attempt < 3:
+                time.sleep(5 * (attempt + 1))
+                continue
+            sys.exit("gemini: %s" % err)
+
+
+def upload_file(path, mime, key):
+    size = os.path.getsize(path)
+    headers, _ = request(
+        "POST",
+        "%s/upload/v1beta/files?key=%s" % (API, key),
+        {"file": {"display_name": os.path.basename(path)}},
+        {
+            "X-Goog-Upload-Protocol": "resumable",
+            "X-Goog-Upload-Command": "start",
+            "X-Goog-Upload-Header-Content-Length": str(size),
+            "X-Goog-Upload-Header-Content-Type": mime,
+        },
+    )
+    upload_url = headers.get("X-Goog-Upload-URL")
+    if not upload_url:
+        sys.exit("gemini: upload session did not return an upload URL")
+    with open(path, "rb") as fh:
+        payload = fh.read()
+    _, body = request(
+        "POST",
+        upload_url,
+        payload,
+        {
+            "Content-Type": mime,
+            "X-Goog-Upload-Offset": "0",
+            "X-Goog-Upload-Command": "upload, finalize",
+        },
+        raw=True,
+    )
+    info = json.loads(body)["file"]
+    name, uri = info["name"], info["uri"]
+    while info.get("state") == "PROCESSING":
+        time.sleep(3)
+        _, body = request("GET", "%s/v1beta/%s?key=%s" % (API, name, key))
+        info = json.loads(body)
+    if info.get("state") == "FAILED":
+        sys.exit("gemini: file processing failed")
+    return uri
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("audio")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--model", default="gemini-2.5-flash")
+    ap.add_argument("--lang", default="")
+    args = ap.parse_args()
+
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not key:
+        sys.exit("gemini: GEMINI_API_KEY is not set")
+
+    mime = mimetypes.guess_type(args.audio)[0] or "audio/mpeg"
+    if os.path.getsize(args.audio) <= INLINE_LIMIT:
+        with open(args.audio, "rb") as fh:
+            media = {"inline_data": {"mime_type": mime, "data": base64.b64encode(fh.read()).decode()}}
+    else:
+        media = {"file_data": {"mime_type": mime, "file_uri": upload_file(args.audio, mime, key)}}
+
+    lang_hint = ("The audio is in %s." % args.lang) if args.lang else "Keep the spoken language."
+    body = {
+        "contents": [{"parts": [{"text": PROMPT.format(lang=lang_hint)}, media]}],
+        "generationConfig": {"temperature": 0, "maxOutputTokens": 65536},
+    }
+    _, raw = request("POST", "%s/v1beta/models/%s:generateContent?key=%s" % (API, args.model, key), body)
+    reply = json.loads(raw)
+    candidates = reply.get("candidates") or []
+    if not candidates:
+        sys.exit("gemini: empty response: %s" % json.dumps(reply)[:300])
+    text = "".join(p.get("text", "") for p in candidates[0].get("content", {}).get("parts", []))
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        text = text.split("\n", 1)[1] if "\n" in text else text
+
+    cues = srt_tools.parse_cues(normalize_srt_timestamps(text))
+    if cues:
+        out = args.out
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(srt_tools.render_srt(cues))
+    else:
+        out = os.path.splitext(args.out)[0] + ".txt"
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-plugin/omniget/scripts/get-model.sh
+++ b/claude-plugin/omniget/scripts/get-model.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Download a whisper.cpp ggml model from Hugging Face (ggerganov/whisper.cpp) and verify its SHA-256.
+# Usage: get-model.sh <name>      e.g. large-v3-turbo-q5_0 (547 MB), base (141 MB), small (465 MB)
+# Destination: OmniGet's models/whisper dir when it exists, else ~/.cache/omniget-skill/models.
+set -eu
+set -o pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$here/resolve-tools.sh"
+
+name="${1:?usage: get-model.sh <model-name>}"
+name="${name#ggml-}"; name="${name%.bin}"
+file="ggml-$name.bin"
+
+dest_dir="$(og_data_dir)/models/whisper"
+[ -d "$dest_dir" ] || dest_dir="$(og_skill_cache_dir)/models"
+mkdir -p "$dest_dir"
+dest="$dest_dir/$file"
+if [ -f "$dest" ]; then
+  echo "$dest"
+  exit 0
+fi
+
+expected="$(curl -sSf -m 30 "https://huggingface.co/api/models/ggerganov/whisper.cpp/tree/main" \
+  | python3 -c 'import json,sys; want=sys.argv[1]
+for e in json.load(sys.stdin):
+    if e.get("path")==want: print((e.get("lfs") or {}).get("oid","")); break' "$file")"
+[ -n "$expected" ] || { echo "get-model: $file is not in ggerganov/whisper.cpp" >&2; exit 1; }
+
+tmp="$dest.part"
+echo "Downloading $file to $dest_dir ..." >&2
+curl -L --fail --progress-bar -o "$tmp" "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$file"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp" | cut -d' ' -f1)"
+else
+  actual="$(shasum -a 256 "$tmp" | cut -d' ' -f1)"
+fi
+if [ "$actual" != "$expected" ]; then
+  rm -f "$tmp"
+  echo "get-model: SHA-256 mismatch for $file (expected $expected, got $actual)" >&2
+  exit 1
+fi
+mv "$tmp" "$dest"
+echo "$dest"

--- a/claude-plugin/omniget/scripts/keys.sh
+++ b/claude-plugin/omniget/scripts/keys.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Manage and test the transcription API keys the skill uses (OpenAI, Gemini).
+#
+#   keys.sh set     Interactively add/replace keys in ~/.config/ai-keys.env (hidden
+#                   input, file chmod 600). Run this in YOUR OWN terminal — it needs
+#                   a prompt and Claude must never type your keys.
+#   keys.sh check   Test each configured key against its provider and report
+#                   working / bad / not-set. Safe for anyone (Claude included) to run;
+#                   never prints key values.
+#
+# Keys live in ~/.config/ai-keys.env (override with OMNIGET_KEYS_FILE). OpenRouter is
+# not supported: it has no speech-to-text endpoint, so it can't transcribe.
+set -u
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=resolve-tools.sh
+. "$here/resolve-tools.sh"
+
+KEYS_FILE="${OMNIGET_KEYS_FILE:-$HOME/.config/ai-keys.env}"
+
+# _upsert_env NAME  (value read from stdin) — set NAME in KEYS_FILE, preserving every
+# other line. Kept value-on-stdin (never argv) so it stays out of ps and shell history.
+_upsert_env() {
+  local name="$1" value file tmp
+  value="$(cat)"
+  file="$KEYS_FILE"
+  mkdir -p "$(dirname "$file")"
+  [ -f "$file" ] || { : > "$file"; chmod 600 "$file"; }
+  tmp="$(mktemp "${TMPDIR:-/tmp}/omniget-keys.XXXXXX")"
+  awk -v n="$name" 'BEGIN{FS="="} $1!=n && $1!="export "n {print}' "$file" > "$tmp"
+  printf '%s=%s\n' "$name" "$value" >> "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$file"
+  chmod 600 "$file"
+}
+
+cmd_set() {
+  if [ ! -t 0 ]; then
+    echo "keys.sh set needs an interactive terminal (it hides what you type)." >&2
+    echo "Open your own terminal and run:  bash \"$here/keys.sh\" set" >&2
+    return 2
+  fi
+  echo "Add transcription API keys. Leave a field blank to keep the current value."
+  echo "Keys are written to $KEYS_FILE (permissions 600) and never printed."
+  echo
+  og_load_keys
+  local existing
+  for spec in "OpenAI:OPENAI_API_KEY:https://platform.openai.com/api-keys" \
+              "Gemini:GEMINI_API_KEY:https://aistudio.google.com/apikey"; do
+    local label var url
+    label="${spec%%:*}"; var="$(printf '%s' "$spec" | cut -d: -f2)"; url="${spec#*:*:}"
+    existing="$(eval "printf '%s' \"\${$var:-}\"")"
+    if [ -n "$existing" ]; then
+      printf '%s key [already set, press Enter to keep] (%s): ' "$label" "$url"
+    else
+      printf '%s key [%s]: ' "$label" "$url"
+    fi
+    local value=""
+    read -r -s value
+    echo
+    if [ -n "$value" ]; then
+      printf '%s' "$value" | _upsert_env "$var"
+      echo "  saved $var"
+    fi
+  done
+  echo
+  cmd_check
+}
+
+# http_status URL [header] — GET, print the numeric HTTP status (000 on network failure).
+_http_status() {
+  local url="$1" header="${2:-}"
+  if [ -n "$header" ]; then
+    curl -s -o /dev/null -w '%{http_code}' -m 20 -H "$header" "$url" 2>/dev/null || echo 000
+  else
+    curl -s -o /dev/null -w '%{http_code}' -m 20 "$url" 2>/dev/null || echo 000
+  fi
+}
+
+_report() { printf '  %-14s %s\n' "$1" "$2"; }
+
+cmd_check() {
+  og_load_keys
+  echo "Transcription API keys ($KEYS_FILE):"
+  local any=false
+
+  if [ -n "${OPENAI_API_KEY:-}" ]; then
+    any=true
+    case "$(_http_status https://api.openai.com/v1/models "Authorization: Bearer $OPENAI_API_KEY")" in
+      200) _report OpenAI "working" ;;
+      401|403) _report OpenAI "BAD KEY (rejected)" ;;
+      000) _report OpenAI "no network / timeout" ;;
+      *) _report OpenAI "unexpected response" ;;
+    esac
+  else
+    _report OpenAI "not set"
+  fi
+
+  if [ -n "${GEMINI_API_KEY:-}" ]; then
+    any=true
+    case "$(_http_status "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY")" in
+      200) _report Gemini "working" ;;
+      400|401|403) _report Gemini "BAD KEY (rejected)" ;;
+      000) _report Gemini "no network / timeout" ;;
+      *) _report Gemini "unexpected response" ;;
+    esac
+  else
+    _report Gemini "not set"
+  fi
+
+  echo
+  if $any; then
+    echo "A 'working' key lets you use --backend openai / --backend gemini for accurate transcription."
+  else
+    echo "No cloud keys set. You can still use platform captions or a local Whisper model,"
+    echo "or add a key with:  bash \"$here/keys.sh\" set"
+  fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  case "${1:-}" in
+    set) cmd_set ;;
+    check|"") cmd_check ;;
+    *) echo "usage: keys.sh set|check" >&2; exit 2 ;;
+  esac
+fi

--- a/claude-plugin/omniget/scripts/openai_transcribe.sh
+++ b/claude-plugin/omniget/scripts/openai_transcribe.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Transcribe an audio file with OpenAI's /v1/audio/transcriptions and write SRT (whisper-1)
+# or plain text (gpt-4o-transcribe, gpt-4o-mini-transcribe). Files over 24 MB are split into
+# 20-minute parts and stitched back with time offsets. Prints the output path.
+# Usage: openai_transcribe.sh AUDIO --out OUT.srt [--model whisper-1] [--lang xx]
+set -eu
+set -o pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$here/resolve-tools.sh"
+
+audio=""; out=""; model="whisper-1"; lang=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out) out="$2"; shift ;;
+    --model) model="$2"; shift ;;
+    --lang) lang="$2"; shift ;;
+    -*) echo "openai_transcribe: unknown flag $1" >&2; exit 2 ;;
+    *) audio="$1" ;;
+  esac
+  shift
+done
+[ -n "$audio" ] && [ -n "$out" ] || { echo "usage: openai_transcribe.sh AUDIO --out OUT.srt [--model M] [--lang xx]" >&2; exit 2; }
+og_load_keys
+[ -n "${OPENAI_API_KEY:-}" ] || { echo "openai_transcribe: OPENAI_API_KEY is not set" >&2; exit 1; }
+
+case "$model" in
+  whisper-1) fmt=srt; ext=srt ;;
+  *) fmt=text; ext=txt ;;
+esac
+[ "$ext" = txt ] && out="${out%.*}.txt"
+
+file_size() { if stat -f%z "$1" >/dev/null 2>&1; then stat -f%z "$1"; else stat -c%s "$1"; fi; }
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/omniget-openai.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+transcribe_one() {
+  local part="$1" dest="$2" attempt
+  for attempt in 1 2 3; do
+    if curl -sS --fail --max-time 900 https://api.openai.com/v1/audio/transcriptions \
+        -H "Authorization: Bearer $OPENAI_API_KEY" \
+        -F "file=@$part" -F "model=$model" -F "response_format=$fmt" \
+        ${lang:+-F "language=$lang"} -o "$dest"; then
+      return 0
+    fi
+    echo "openai_transcribe: attempt $attempt failed, retrying" >&2
+    sleep $((attempt * 5))
+  done
+  return 1
+}
+
+if [ "$(file_size "$audio")" -le $((24 * 1024 * 1024)) ]; then
+  transcribe_one "$audio" "$out"
+  echo "$out"
+  exit 0
+fi
+
+ffmpeg="$(og_tool_path ffmpeg)" || { echo "openai_transcribe: ffmpeg needed to split large audio" >&2; exit 1; }
+ffprobe="$(og_tool_path ffprobe)" || ffprobe="$(dirname "$ffmpeg")/ffprobe"
+"$ffmpeg" -v error -y -i "$audio" -f segment -segment_time 1200 -c copy "$tmp/part%03d.${audio##*.}"
+
+offset=0
+parts=()
+for part in "$tmp"/part*; do
+  dest="$tmp/$(basename "${part%.*}").$ext"
+  transcribe_one "$part" "$dest"
+  parts+=("$dest:$offset")
+  dur="$("$ffprobe" -v error -show_entries format=duration -of csv=p=0 "$part")"
+  offset="$(python3 -c "print($offset + $dur)")"
+done
+
+if [ "$ext" = srt ]; then
+  python3 "$here/srt_tools.py" concat --out "$out" "${parts[@]}"
+else
+  : > "$out"
+  for spec in "${parts[@]}"; do cat "${spec%:*}" >> "$out"; printf '\n' >> "$out"; done
+fi
+echo "$out"

--- a/claude-plugin/omniget/scripts/research.sh
+++ b/claude-plugin/omniget/scripts/research.sh
@@ -11,9 +11,16 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 url="${1:?usage: research.sh <url>}"
 ytdlp="$(og_tool_path yt-dlp)" || { echo "research: yt-dlp not found; run doctor.sh" >&2; exit 1; }
 args=(-J --no-warnings --no-playlist)
-while IFS= read -r line; do args+=("$line"); done < <(og_cookie_args "$url")
 
-"$ytdlp" "${args[@]}" "$url" | python3 -c '
+err="$(mktemp "${TMPDIR:-/tmp}/omniget-research.XXXXXX")"
+if ! json="$(og_run_ytdlp "$url" "$err" "${args[@]}")"; then
+  cat "$err" >&2
+  hint="$(og_explain_error "$(cat "$err" 2>/dev/null)")"; [ -n "$hint" ] && echo "-> $hint" >&2
+  rm -f "$err"; exit 1
+fi
+rm -f "$err"
+
+printf '%s' "$json" | python3 -c '
 import json, sys
 info = json.load(sys.stdin)
 if info.get("_type") == "playlist":

--- a/claude-plugin/omniget/scripts/research.sh
+++ b/claude-plugin/omniget/scripts/research.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Describe a media URL without downloading it. Prints one JSON line:
+# {title, platform, uploader, duration, url, caption?, has_captions, thumbnail?, upload_date?}
+# `caption` is the post text / description and is omitted when the platform provides none.
+# Usage: research.sh <url>
+set -eu
+set -o pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$here/resolve-tools.sh"
+
+url="${1:?usage: research.sh <url>}"
+ytdlp="$(og_tool_path yt-dlp)" || { echo "research: yt-dlp not found; run doctor.sh" >&2; exit 1; }
+args=(-J --no-warnings --no-playlist)
+while IFS= read -r line; do args+=("$line"); done < <(og_cookie_args "$url")
+
+"$ytdlp" "${args[@]}" "$url" | python3 -c '
+import json, sys
+info = json.load(sys.stdin)
+if info.get("_type") == "playlist":
+    entries = info.get("entries") or []
+    info = entries[0] if entries else info
+caption = (info.get("description") or "").strip()
+out = {
+    "title": info.get("title"),
+    "platform": info.get("extractor_key"),
+    "uploader": info.get("uploader") or info.get("channel") or info.get("uploader_id"),
+    "duration": info.get("duration"),
+    "url": info.get("webpage_url") or sys.argv[1],
+    "has_captions": bool(info.get("subtitles")) or bool(info.get("automatic_captions")),
+    "thumbnail": info.get("thumbnail"),
+    "upload_date": info.get("upload_date"),
+}
+if caption:
+    out["caption"] = caption
+print(json.dumps({k: v for k, v in out.items() if v not in (None, "")}, ensure_ascii=False))' "$url"

--- a/claude-plugin/omniget/scripts/resolve-tools.sh
+++ b/claude-plugin/omniget/scripts/resolve-tools.sh
@@ -238,6 +238,64 @@ og_explain_error() {
   esac
 }
 
+# og_detect_browser -> a browser name yt-dlp's --cookies-from-browser accepts, chosen from
+# what's installed (chrome, brave, edge, firefox, safari, chromium). Empty if none found.
+# Order favours the most commonly logged-in browser.
+og_detect_browser() {
+  case "$(og_os)" in
+    mac)
+      [ -d "/Applications/Google Chrome.app" ] && { echo chrome; return; }
+      [ -d "/Applications/Brave Browser.app" ] && { echo brave; return; }
+      [ -d "/Applications/Microsoft Edge.app" ] && { echo edge; return; }
+      [ -d "/Applications/Firefox.app" ] && { echo firefox; return; }
+      [ -d "/Applications/Safari.app" ] && { echo safari; return; }
+      ;;
+    linux)
+      for c in google-chrome google-chrome-stable brave-browser microsoft-edge firefox chromium chromium-browser; do
+        if command -v "$c" >/dev/null 2>&1; then
+          case "$c" in google-chrome*) echo chrome ;; brave*) echo brave ;; microsoft-edge) echo edge ;; firefox) echo firefox ;; chromium*) echo chromium ;; esac
+          return
+        fi
+      done
+      ;;
+    windows) echo chrome; return ;;
+  esac
+  return 1
+}
+
+# og_should_retry_with_cookies <stderr text> -> true when the failure is the login /
+# rate-limit class, i.e. a logged-in session is worth trying. Reuses og_explain_error's
+# categories without duplicating the patterns.
+og_should_retry_with_cookies() {
+  case "$(og_explain_error "$1")" in
+    "This platform is rate-limiting"*|"This content needs a logged-in session"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# og_run_ytdlp URL ERRFILE ARG... -> run yt-dlp ARG... URL, with ONE automatic cookie
+# retry if the first attempt is blocked and no cookies were used yet. Prints yt-dlp's
+# stdout on success; returns its exit code; stderr is captured to ERRFILE. When the retry
+# runs it prints a one-line notice to fd 2 (a browser-cookie read can raise a one-time
+# macOS Keychain prompt).
+og_run_ytdlp() {
+  local url="$1" errfile="$2"; shift 2
+  local ytdlp; ytdlp="$(og_tool_path yt-dlp)" || { echo "yt-dlp not found; run setup.sh" >"$errfile"; return 127; }
+  local cookie=() line had=false out br
+  while IFS= read -r line; do cookie+=("$line"); done < <(og_cookie_args "$url")
+  [ ${#cookie[@]} -gt 0 ] && had=true
+  if out="$("$ytdlp" "$@" ${cookie[@]+"${cookie[@]}"} "$url" 2>"$errfile")"; then
+    printf '%s' "$out"; return 0
+  fi
+  if ! $had && og_should_retry_with_cookies "$(cat "$errfile" 2>/dev/null)" && br="$(og_detect_browser)"; then
+    echo "omniget: request blocked — retrying with your $br login (a one-time Keychain prompt may appear)…" >&2
+    if out="$("$ytdlp" "$@" --cookies-from-browser "$br" "$url" 2>"$errfile")"; then
+      printf '%s' "$out"; return 0
+    fi
+  fi
+  return 1
+}
+
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   tools="$*"
   [ -n "$tools" ] || tools="omniget-cli yt-dlp ffmpeg ffprobe whisper-cli mlx_whisper"

--- a/claude-plugin/omniget/scripts/resolve-tools.sh
+++ b/claude-plugin/omniget/scripts/resolve-tools.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Locate the tools the omniget skill relies on, preferring OmniGet's own copies.
+#
+# Lookup order mirrors OmniGet's find_tool_with_source:
+#   1. explicit override   OMNIGET_TOOL_<NAME>=/path   (e.g. OMNIGET_TOOL_YT_DLP)
+#   2. OmniGet managed dir <data dir>/bin              (source "omniget")
+#   3. PATH                                            (source "system")
+#
+# Usage:  resolve-tools.sh [tool ...]      prints "name<TAB>path<TAB>source" per tool
+#         . resolve-tools.sh               then call og_find_tool / og_whisper_model / og_load_keys
+#
+# Bash 3.2 compatible (macOS default shell).
+
+og_os() {
+  case "$(uname -s)" in
+    Darwin) echo mac ;;
+    Linux) echo linux ;;
+    MINGW*|MSYS*|CYGWIN*) echo windows ;;
+    *) echo other ;;
+  esac
+}
+
+# OmniGet's app data directory (see omniget-core/src/core/paths.rs).
+og_data_dir() {
+  if [ -n "${OMNIGET_DATA_DIR:-}" ]; then
+    echo "$OMNIGET_DATA_DIR"
+    return
+  fi
+  case "$(og_os)" in
+    mac) echo "$HOME/Library/Application Support/wtf.tonho.omniget" ;;
+    linux) echo "${XDG_DATA_HOME:-$HOME/.local/share}/wtf.tonho.omniget" ;;
+    windows) echo "${APPDATA:-$HOME/AppData/Roaming}/wtf.tonho.omniget" ;;
+    *) echo "$HOME/.omniget" ;;
+  esac
+}
+
+# Where the skill keeps its own downloads (models) when OmniGet has none.
+og_skill_cache_dir() {
+  echo "${OMNIGET_SKILL_CACHE:-$HOME/.cache/omniget-skill}"
+}
+
+# Output directory for media and transcripts.
+og_output_dir() {
+  echo "${OMNIGET_DIR:-$HOME/Downloads/omniget}"
+}
+
+og_exe() {
+  if [ "$(og_os)" = windows ]; then echo "$1.exe"; else echo "$1"; fi
+}
+
+# og_find_tool NAME -> prints "path<TAB>source", exit 1 when missing.
+og_find_tool() {
+  local name="$1" var path alt
+  var="OMNIGET_TOOL_$(printf '%s' "$name" | tr 'a-z-' 'A-Z_')"
+  path="$(eval "printf '%s' \"\${$var:-}\"")"
+  if [ -n "$path" ] && [ -x "$path" ]; then
+    printf '%s\tcustom\n' "$path"
+    return 0
+  fi
+  path="$(og_data_dir)/bin/$(og_exe "$name")"
+  if [ -x "$path" ]; then
+    printf '%s\tomniget\n' "$path"
+    return 0
+  fi
+  if path="$(command -v "$name" 2>/dev/null)"; then
+    printf '%s\tsystem\n' "$path"
+    return 0
+  fi
+  # Homebrew's older formula installed the whisper.cpp CLI as whisper-cpp.
+  if [ "$name" = whisper-cli ] && alt="$(command -v whisper-cpp 2>/dev/null)"; then
+    printf '%s\tsystem\n' "$alt"
+    return 0
+  fi
+  return 1
+}
+
+og_tool_path() {
+  og_find_tool "$1" | cut -f1
+}
+
+# Best available ggml model for whisper-cli. Preference: large-v3-turbo (quantised first),
+# then medium, small, base, tiny. Looks in OmniGet's models dir, then the skill cache.
+og_whisper_model() {
+  local dir candidate
+  if [ -n "${OMNIGET_WHISPER_MODEL:-}" ] && [ -f "$OMNIGET_WHISPER_MODEL" ]; then
+    echo "$OMNIGET_WHISPER_MODEL"
+    return 0
+  fi
+  for dir in "$(og_data_dir)/models/whisper" "$(og_skill_cache_dir)/models"; do
+    [ -d "$dir" ] || continue
+    for candidate in \
+      ggml-large-v3-turbo-q5_0.bin ggml-large-v3-turbo-q8_0.bin ggml-large-v3-turbo.bin \
+      ggml-large-v3-q5_0.bin ggml-large-v3.bin \
+      ggml-medium-q5_0.bin ggml-medium-q8_0.bin ggml-medium.bin \
+      ggml-small-q5_1.bin ggml-small-q8_0.bin ggml-small.bin \
+      ggml-base-q5_1.bin ggml-base-q8_0.bin ggml-base.bin \
+      ggml-tiny-q5_1.bin ggml-tiny-q8_0.bin ggml-tiny.bin; do
+      if [ -f "$dir/$candidate" ]; then
+        echo "$dir/$candidate"
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
+# Newest cookies.txt OmniGet holds for a domain (e.g. instagram.com), if any.
+og_cookie_file() {
+  local domain="$1" root dir
+  root="$(og_data_dir)/cookies"
+  [ -d "$root" ] || return 1
+  for dir in "$root"/*"$domain"*; do
+    [ -d "$dir" ] || continue
+    ls -t "$dir"/*.txt 2>/dev/null | head -n 1
+    return 0
+  done
+  return 1
+}
+
+# Load API keys from the environment or ~/.config/ai-keys.env. Never prints values.
+og_load_keys() {
+  local file="${OMNIGET_KEYS_FILE:-$HOME/.config/ai-keys.env}"
+  if [ -f "$file" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$file"
+    set +a
+  fi
+}
+
+og_has_key() {
+  og_load_keys
+  [ -n "$(eval "printf '%s' \"\${$1:-}\"")" ]
+}
+
+# og_json key=value key:n=number key:b=bool ... -> one JSON object on stdout. Empty values are omitted.
+og_json() {
+  python3 - "$@" <<'PY'
+import json, sys
+out = {}
+for kv in sys.argv[1:]:
+    key, _, value = kv.partition("=")
+    if value == "":
+        continue
+    name, _, kind = key.partition(":")
+    if kind == "n":
+        try:
+            out[name] = int(value)
+        except ValueError:
+            out[name] = float(value)
+    elif kind == "b":
+        out[name] = value.lower() in ("1", "true", "yes")
+    else:
+        out[name] = value
+print(json.dumps(out, ensure_ascii=False))
+PY
+}
+
+# og_slug TEXT -> filesystem-safe ASCII slug, max 80 chars.
+og_slug() {
+  python3 - "$1" <<'PY'
+import re, sys, unicodedata
+text = unicodedata.normalize("NFKD", sys.argv[1]).encode("ascii", "ignore").decode()
+text = re.sub(r"[^A-Za-z0-9]+", "_", text).strip("_")
+print((text or "untitled")[:80].rstrip("_"))
+PY
+}
+
+# og_url_host URL -> bare host without www./m. prefixes.
+og_url_host() {
+  printf '%s\n' "$1" | sed -E 's#^[A-Za-z]+://##; s#[/?].*##; s#^(www|m|mobile)\.##'
+}
+
+# og_cookie_args URL -> yt-dlp cookie flags for that host, if OmniGet or the user provides any.
+og_cookie_args() {
+  local host file
+  host="$(og_url_host "$1")"
+  case "$host" in
+    x.com) host=twitter.com ;;
+  esac
+  if file="$(og_cookie_file "$host")" && [ -n "$file" ]; then
+    printf -- '--cookies\n%s\n' "$file"
+  elif [ -n "${OMNIGET_COOKIES_FROM_BROWSER:-}" ]; then
+    printf -- '--cookies-from-browser\n%s\n' "$OMNIGET_COOKIES_FROM_BROWSER"
+  fi
+}
+
+og_is_url() {
+  case "$1" in
+    http://*|https://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Hosts where omniget-cli's native extractors beat plain yt-dlp.
+og_prefers_cli() {
+  case "$(og_url_host "$1")" in
+    instagram.com|threads.net|threads.com|twitter.com|x.com|bilibili.com|b23.tv) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  tools="$*"
+  [ -n "$tools" ] || tools="omniget-cli yt-dlp ffmpeg ffprobe whisper-cli mlx_whisper"
+  for t in $tools; do
+    if found="$(og_find_tool "$t")"; then
+      printf '%s\t%s\n' "$t" "$found"
+    else
+      printf '%s\t-\tmissing\n' "$t"
+    fi
+  done
+fi

--- a/claude-plugin/omniget/scripts/resolve-tools.sh
+++ b/claude-plugin/omniget/scripts/resolve-tools.sh
@@ -39,6 +39,11 @@ og_skill_cache_dir() {
   echo "${OMNIGET_SKILL_CACHE:-$HOME/.cache/omniget-skill}"
 }
 
+# Where the skill installs its own binaries (e.g. a downloaded omniget-cli).
+og_skill_bin_dir() {
+  echo "$(og_skill_cache_dir)/bin"
+}
+
 # Output directory for media and transcripts.
 og_output_dir() {
   echo "${OMNIGET_DIR:-$HOME/Downloads/omniget}"
@@ -60,6 +65,11 @@ og_find_tool() {
   path="$(og_data_dir)/bin/$(og_exe "$name")"
   if [ -x "$path" ]; then
     printf '%s\tomniget\n' "$path"
+    return 0
+  fi
+  path="$(og_skill_bin_dir)/$(og_exe "$name")"
+  if [ -x "$path" ]; then
+    printf '%s\tskill\n' "$path"
     return 0
   fi
   if path="$(command -v "$name" 2>/dev/null)"; then
@@ -197,6 +207,34 @@ og_prefers_cli() {
   case "$(og_url_host "$1")" in
     instagram.com|threads.net|threads.com|twitter.com|x.com|bilibili.com|b23.tv) return 0 ;;
     *) return 1 ;;
+  esac
+}
+
+# og_arch -> normalized CPU arch: aarch64 or x86_64 (matches release asset triples).
+og_arch() {
+  case "$(uname -m)" in
+    arm64|aarch64) echo aarch64 ;;
+    x86_64|amd64) echo x86_64 ;;
+    *) uname -m ;;
+  esac
+}
+
+# og_explain_error <text> -> print one plain-language hint for a known download failure,
+# or nothing. Turns raw yt-dlp/omniget-cli stderr into advice the user can act on.
+og_explain_error() {
+  local t="$1"
+  case "$t" in
+    *"empty media response"*|*"HTTP Error 400"*|*"HTTP Error 429"*|*"Too Many Requests"*|*"rate-limit"*|*"rate limit"*)
+      echo "This platform is rate-limiting or temporarily blocking this request (common on Instagram/X). Wait a few minutes and retry; if it's private, sign in (see cookies below)." ;;
+    *"Sign in to confirm"*|*"login required"*|*"Requested content is not available"*|*"Private video"*|*"This video is private"*|*"HTTP Error 401"*|*"HTTP Error 403"*|*"login_required"*|*"require_login"*)
+      echo "This content needs a logged-in session. Use OmniGet's cookies for the site, or set OMNIGET_COOKIES_FROM_BROWSER=chrome (or firefox/safari/edge), then retry." ;;
+    *"DRM"*|*"SAMPLE-AES"*|*"FairPlay"*|*"Widevine"*)
+      echo "This stream is DRM-protected and cannot be downloaded. OmniGet does not bypass DRM." ;;
+    *"Unsupported URL"*|*"no suitable extractor"*|*"extractor is broken"*)
+      echo "No working extractor for this URL right now. Try updating the tools (setup.sh --update); some sites break until yt-dlp/omniget-cli is refreshed." ;;
+    *"Requested format is not available"*|*"requested format not available"*)
+      echo "The requested quality wasn't available. Retry without --quality." ;;
+    *) : ;;
   esac
 }
 

--- a/claude-plugin/omniget/scripts/setup.sh
+++ b/claude-plugin/omniget/scripts/setup.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# One-step setup for the omniget skill. Detects the OS, checks for the tools the
+# skill needs, and installs the missing ones after a single confirmation.
+#
+#   setup.sh              interactive: check, confirm, install, then key setup + check
+#   setup.sh --yes        install missing tools without the confirmation prompt
+#   setup.sh --local      also install a local Whisper engine + default model
+#   setup.sh --check-only  report status and exit; install nothing (safe for Claude)
+#
+# Core tools (needed for everything): yt-dlp, ffmpeg. Cloud transcription then needs
+# only an OpenAI or Gemini key (see keys.sh). Local transcription (--local) additionally
+# wants whisper-cli + a ggml model. Mac (brew) and Windows (winget/scoop) install
+# automatically; Linux runs the distro manager when it can, else prints the commands.
+set -u
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=resolve-tools.sh
+. "$here/resolve-tools.sh"
+
+ASSUME_YES=false; WANT_LOCAL=false; CHECK_ONLY=false
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) ASSUME_YES=true ;;
+    --local) WANT_LOCAL=true ;;
+    --check-only) CHECK_ONLY=true ;;
+    *) echo "setup: unknown flag $arg" >&2; exit 2 ;;
+  esac
+done
+
+OS="$(og_os)"
+PM=""
+detect_pm() {
+  case "$OS" in
+    mac) command -v brew >/dev/null 2>&1 && PM=brew ;;
+    windows) for c in winget scoop choco; do command -v "$c" >/dev/null 2>&1 && { PM="$c"; break; }; done ;;
+    linux) for c in apt-get dnf pacman zypper; do command -v "$c" >/dev/null 2>&1 && { PM="$c"; break; }; done ;;
+  esac
+}
+detect_pm
+
+# install_cmd TOOL -> echoes the shell command to install TOOL with the detected PM,
+# or empty if we don't have a recipe for this OS/PM.
+install_cmd() {
+  local tool="$1"
+  case "$tool:$PM" in
+    yt-dlp:brew) echo "brew install yt-dlp" ;;
+    yt-dlp:winget) echo "winget install --silent --accept-package-agreements --accept-source-agreements yt-dlp.yt-dlp" ;;
+    yt-dlp:scoop) echo "scoop install yt-dlp" ;;
+    yt-dlp:choco) echo "choco install -y yt-dlp" ;;
+    yt-dlp:apt-get) echo "sudo apt-get update && sudo apt-get install -y pipx && pipx install yt-dlp" ;;
+    yt-dlp:dnf) echo "sudo dnf install -y yt-dlp" ;;
+    yt-dlp:pacman) echo "sudo pacman -S --noconfirm yt-dlp" ;;
+    yt-dlp:zypper) echo "sudo zypper install -y yt-dlp" ;;
+    ffmpeg:brew) echo "brew install ffmpeg" ;;
+    ffmpeg:winget) echo "winget install --silent --accept-package-agreements --accept-source-agreements Gyan.FFmpeg" ;;
+    ffmpeg:scoop) echo "scoop install ffmpeg" ;;
+    ffmpeg:choco) echo "choco install -y ffmpeg" ;;
+    ffmpeg:apt-get) echo "sudo apt-get update && sudo apt-get install -y ffmpeg" ;;
+    ffmpeg:dnf) echo "sudo dnf install -y ffmpeg" ;;
+    ffmpeg:pacman) echo "sudo pacman -S --noconfirm ffmpeg" ;;
+    ffmpeg:zypper) echo "sudo zypper install -y ffmpeg" ;;
+    whisper-cli:brew) echo "brew install whisper-cpp" ;;
+    *) echo "" ;;
+  esac
+}
+
+missing=()
+plan=()
+note_missing() {
+  local tool="$1"
+  og_find_tool "$tool" >/dev/null 2>&1 && return
+  missing+=("$tool")
+  local cmd; cmd="$(install_cmd "$tool")"
+  [ -n "$cmd" ] && plan+=("$cmd") || plan+=("# no auto-install recipe for $tool on $OS — see README")
+}
+
+echo "OmniGet skill setup — $OS${PM:+ (package manager: $PM)}"
+echo
+
+note_missing yt-dlp
+note_missing ffmpeg
+$WANT_LOCAL && note_missing whisper-cli
+
+if [ ${#missing[@]} -eq 0 ]; then
+  echo "Core tools present:"
+  for t in yt-dlp ffmpeg $([ "$WANT_LOCAL" = true ] && echo whisper-cli); do
+    printf '  %-12s %s\n' "$t" "$(og_tool_path "$t")"
+  done
+else
+  echo "Missing: ${missing[*]}"
+  if [ -z "$PM" ]; then
+    echo
+    case "$OS" in
+      mac) echo "Homebrew isn't installed. Install it first (one line), then re-run setup:"; echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"' ;;
+      windows) echo "No winget/scoop/choco found. Install winget (App Installer from the Microsoft Store) or scoop, then re-run." ;;
+      linux) echo "No supported package manager detected. Install yt-dlp and ffmpeg via your distro, then re-run." ;;
+    esac
+  else
+    echo "Planned install commands:"
+    for c in "${plan[@]}"; do echo "  $c"; done
+  fi
+fi
+echo
+
+run_installs() {
+  [ ${#missing[@]} -eq 0 ] && return 0
+  [ -z "$PM" ] && { echo "Can't auto-install without a package manager (see above)."; return 1; }
+  local i=0 tool cmd rc=0
+  for tool in "${missing[@]}"; do
+    cmd="${plan[$i]}"; i=$((i+1))
+    case "$cmd" in \#*) echo "Skipping $tool: $cmd"; continue ;; esac
+    echo ">>> $cmd"
+    if printf '%s' "$cmd" | grep -q 'sudo ' && [ ! -t 0 ]; then
+      echo "    needs sudo and there's no terminal here — run this line yourself:"
+      echo "    $cmd"
+      rc=1; continue
+    fi
+    if bash -c "$cmd"; then
+      og_find_tool "$tool" >/dev/null 2>&1 && echo "    ok: $tool -> $(og_tool_path "$tool")" || echo "    installed, but $tool still not on PATH — open a new shell and re-check"
+    else
+      echo "    failed to install $tool"; rc=1
+    fi
+  done
+  return $rc
+}
+
+if [ ${#missing[@]} -gt 0 ] && [ "$CHECK_ONLY" != true ]; then
+  do_install=false
+  if $ASSUME_YES; then
+    do_install=true
+  elif [ -t 0 ]; then
+    printf 'Install the %d missing tool(s) now? [y/N] ' "${#missing[@]}"
+    read -r ans
+    case "$ans" in y|Y|yes|YES) do_install=true ;; esac
+  else
+    echo "Re-run with --yes to install, or run the commands above yourself."
+  fi
+  $do_install && run_installs
+  echo
+fi
+
+if $WANT_LOCAL && og_find_tool whisper-cli >/dev/null 2>&1 && ! og_whisper_model >/dev/null 2>&1; then
+  echo "Local Whisper is installed but has no model."
+  if [ "$CHECK_ONLY" != true ] && { $ASSUME_YES || [ -t 0 ]; }; then
+    if $ASSUME_YES || { printf 'Download the default model (large-v3-turbo-q5_0, 547 MB)? [y/N] '; read -r m; case "$m" in y|Y|yes|YES) true ;; *) false ;; esac; }; then
+      "$here/get-model.sh" large-v3-turbo-q5_0 && echo "  model ready"
+    fi
+  else
+    echo "  get one with:  bash \"$here/get-model.sh\" large-v3-turbo-q5_0"
+  fi
+  echo
+fi
+
+# Transcription keys: report status, and point at the interactive setter (never run by Claude).
+echo "== Transcription API keys =="
+bash "$here/keys.sh" check
+echo
+echo "To add or change a key, run this in YOUR terminal (input is hidden, keys never leave your machine):"
+echo "  bash \"$here/keys.sh\" set"
+echo
+echo "Setup check complete. Run  bash \"$here/doctor.sh\"  any time for the full picture."

--- a/claude-plugin/omniget/scripts/setup.sh
+++ b/claude-plugin/omniget/scripts/setup.sh
@@ -16,12 +16,14 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=resolve-tools.sh
 . "$here/resolve-tools.sh"
 
-ASSUME_YES=false; WANT_LOCAL=false; CHECK_ONLY=false
+ASSUME_YES=false; WANT_LOCAL=false; CHECK_ONLY=false; WANT_CLI=true; DO_UPDATE=false
 for arg in "$@"; do
   case "$arg" in
     --yes|-y) ASSUME_YES=true ;;
     --local) WANT_LOCAL=true ;;
     --check-only) CHECK_ONLY=true ;;
+    --no-cli) WANT_CLI=false ;;
+    --update) DO_UPDATE=true; ASSUME_YES=true ;;
     *) echo "setup: unknown flag $arg" >&2; exit 2 ;;
   esac
 done
@@ -36,6 +38,28 @@ detect_pm() {
   esac
 }
 detect_pm
+
+if $DO_UPDATE; then
+  echo "Updating tools on $OS${PM:+ (via $PM)}"
+  echo
+  case "$PM" in
+    brew) echo ">>> brew upgrade yt-dlp ffmpeg"; brew upgrade yt-dlp ffmpeg 2>/dev/null || true ;;
+    winget) echo ">>> winget upgrade yt-dlp.yt-dlp Gyan.FFmpeg"; winget upgrade --silent yt-dlp.yt-dlp 2>/dev/null; winget upgrade --silent Gyan.FFmpeg 2>/dev/null || true ;;
+    scoop) echo ">>> scoop update yt-dlp ffmpeg"; scoop update yt-dlp ffmpeg 2>/dev/null || true ;;
+    apt-get) command -v pipx >/dev/null 2>&1 && { echo ">>> pipx upgrade yt-dlp"; pipx upgrade yt-dlp 2>/dev/null || true; } ;;
+    dnf|pacman|zypper) echo "Update yt-dlp/ffmpeg with your package manager; then re-run without --update." ;;
+    *) echo "No package manager detected; update yt-dlp/ffmpeg yourself." ;;
+  esac
+  echo
+  echo "== omniget-cli =="
+  install_omniget_cli
+  echo
+  echo "== Transcription API keys =="
+  bash "$here/keys.sh" check
+  echo
+  echo "Update complete."
+  exit 0
+fi
 
 # install_cmd TOOL -> echoes the shell command to install TOOL with the detected PM,
 # or empty if we don't have a recipe for this OS/PM.
@@ -101,6 +125,55 @@ else
 fi
 echo
 
+OMNIGET_REPO="${OMNIGET_REPO:-tonhowtf/omniget}"
+
+# Prebuilt omniget-cli asset triple for this machine, or empty if unsupported.
+cli_triple() {
+  case "$OS:$(og_arch)" in
+    mac:aarch64) echo "aarch64-apple-darwin:tar.gz" ;;
+    mac:x86_64) echo "x86_64-apple-darwin:tar.gz" ;;
+    windows:x86_64) echo "x86_64-pc-windows-msvc:zip" ;;
+    linux:x86_64) echo "x86_64-unknown-linux-gnu:tar.gz" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Download the prebuilt omniget-cli for this OS/arch into the skill bin dir.
+# omniget-cli carries OmniGet's native Instagram/X/Bilibili/Threads extractors, which
+# are more reliable than plain yt-dlp for those sites.
+install_omniget_cli() {
+  local triple ext tag ver asset url dest bindir tmp
+  triple="$(cli_triple)"
+  if [ -z "$triple" ]; then
+    echo "  omniget-cli: no prebuilt binary for $OS/$(og_arch) — the skill will use yt-dlp for every site."
+    return 1
+  fi
+  ext="${triple#*:}"; triple="${triple%%:*}"
+  tag="$(curl -fsSL -m 30 "https://api.github.com/repos/$OMNIGET_REPO/releases/latest"         | python3 -c 'import json,sys; print(json.load(sys.stdin).get("tag_name",""))' 2>/dev/null)"
+  [ -n "$tag" ] || { echo "  omniget-cli: couldn't resolve the latest release (offline?). Skipping."; return 1; }
+  ver="${tag#v}"
+  asset="omniget-cli-$ver-$triple.$ext"
+  url="https://github.com/$OMNIGET_REPO/releases/download/$tag/$asset"
+  bindir="$(og_skill_bin_dir)"; mkdir -p "$bindir"
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/omniget-cli.XXXXXX")"
+  echo "  omniget-cli: downloading $asset ..."
+  if ! curl -fSL --progress-bar -o "$tmp/pkg" "$url"; then
+    echo "  omniget-cli: download failed ($url)"; rm -rf "$tmp"; return 1
+  fi
+  ( cd "$tmp" && case "$ext" in tar.gz) tar xzf pkg ;; zip) unzip -oq pkg ;; esac )
+  local found; found="$(find "$tmp" -type f \( -name omniget-cli -o -name omniget-cli.exe \) | head -1)"
+  if [ -z "$found" ]; then echo "  omniget-cli: binary not found in archive"; rm -rf "$tmp"; return 1; fi
+  dest="$bindir/$(basename "$found")"
+  mv "$found" "$dest"; chmod +x "$dest"
+  [ "$OS" = mac ] && xattr -d com.apple.quarantine "$dest" 2>/dev/null
+  rm -rf "$tmp"
+  if "$dest" --version >/dev/null 2>&1; then
+    echo "  omniget-cli: installed ($tag) -> $dest"
+  else
+    echo "  omniget-cli: installed but did not run cleanly; the skill will fall back to yt-dlp"
+  fi
+}
+
 run_installs() {
   [ ${#missing[@]} -eq 0 ] && return 0
   [ -z "$PM" ] && { echo "Can't auto-install without a package manager (see above)."; return 1; }
@@ -135,6 +208,12 @@ if [ ${#missing[@]} -gt 0 ] && [ "$CHECK_ONLY" != true ]; then
     echo "Re-run with --yes to install, or run the commands above yourself."
   fi
   $do_install && run_installs
+  echo
+fi
+
+if $WANT_CLI && [ "$CHECK_ONLY" != true ] && ! og_find_tool omniget-cli >/dev/null 2>&1; then
+  echo "== omniget-cli (native Instagram / X / Bilibili / Threads extractors) =="
+  install_omniget_cli
   echo
 fi
 

--- a/claude-plugin/omniget/scripts/srt_tools.py
+++ b/claude-plugin/omniget/scripts/srt_tools.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""SRT/VTT helpers for the omniget skill.
+
+Subcommands:
+  to-md   <file> [--title T] [--source URL] [--backend B] [--model M] [--interval S]
+  to-text <file>
+  concat  --out merged.srt part.srt:OFFSET_SECONDS ...
+  stats   <file>            -> JSON {cues, chars, duration}
+
+Standard library only, Python 3.8+.
+"""
+import argparse
+import html
+import json
+import re
+import sys
+from dataclasses import dataclass
+from typing import List, Tuple
+
+TS_RE = re.compile(r"(?:(\d+):)?(\d{1,2}):(\d{2})[.,](\d{1,3})")
+TAG_RE = re.compile(r"<[^>]+>")
+WS_RE = re.compile(r"\s+")
+
+
+@dataclass
+class Cue:
+    start: float
+    end: float
+    text: str
+
+
+def parse_ts(raw: str) -> float:
+    m = TS_RE.search(raw)
+    if not m:
+        raise ValueError("bad timestamp: %r" % raw)
+    hours = int(m.group(1) or 0)
+    ms = m.group(4).ljust(3, "0")
+    return hours * 3600 + int(m.group(2)) * 60 + int(m.group(3)) + int(ms) / 1000.0
+
+
+def clean_text(raw: str) -> str:
+    text = html.unescape(TAG_RE.sub("", raw))
+    return WS_RE.sub(" ", text).strip()
+
+
+def parse_cues(content: str) -> List[Cue]:
+    """Parse SRT or VTT into cues.
+
+    Boundary-based on the `-->` lines rather than blank-line blocks, so output
+    that omits blank separators between cues (as some models emit) still parses.
+    The lone integer index that precedes the next cue is stripped from a cue's
+    trailing text.
+    """
+    lines = content.replace("\r", "").split("\n")
+    ts_lines = [i for i, l in enumerate(lines) if "-->" in l]
+    cues: List[Cue] = []
+    for k, i in enumerate(ts_lines):
+        left, _, right = lines[i].partition("-->")
+        try:
+            start = parse_ts(left)
+            end = parse_ts(right.split()[0] if right.split() else right)
+        except ValueError:
+            continue
+        stop = ts_lines[k + 1] if k + 1 < len(ts_lines) else len(lines)
+        text_lines = lines[i + 1:stop]
+        while text_lines and not text_lines[-1].strip():
+            text_lines.pop()
+        if k + 1 < len(ts_lines) and text_lines and text_lines[-1].strip().isdigit():
+            text_lines.pop()  # the next cue's index number, not caption text
+        cleaned = [clean_text(l) for l in text_lines]
+        cleaned = [c for c in cleaned if c]
+        if cleaned:
+            cues.append(Cue(start, end, "\n".join(cleaned)))
+    return cues
+
+def _merge_line(prev: str, line: str) -> Tuple[bool, str]:
+    """Collapse rolling captions. Returns (replace_previous, merged_text)."""
+    if line == prev:
+        return True, prev
+    if line.startswith(prev):
+        return True, line
+    pw = prev.split(" ")
+    lw = line.split(" ")
+    max_overlap = min(len(pw), len(lw)) - 1
+    for n in range(max_overlap, 1, -1):
+        if pw[-n:] == lw[:n]:
+            return True, " ".join(pw + lw[n:])
+    return False, line
+
+
+def dedupe(cues: List[Cue]) -> List[Tuple[float, str]]:
+    """Flatten cues into (start, line) pairs with rolling repeats removed."""
+    out: List[Tuple[float, str]] = []
+    for cue in cues:
+        for line in cue.text.split("\n"):
+            if out:
+                replace, merged = _merge_line(out[-1][1], line)
+                if replace:
+                    out[-1] = (out[-1][0], merged)
+                    continue
+            out.append((cue.start, line))
+    return out
+
+
+def to_text(cues: List[Cue]) -> str:
+    return " ".join(line for _, line in dedupe(cues))
+
+
+def fmt_marker(seconds: float) -> str:
+    total = int(seconds)
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return "%d:%02d:%02d" % (h, m, s)
+    return "%02d:%02d" % (m, s)
+
+
+def fmt_srt_ts(seconds: float) -> str:
+    total_ms = int(round(seconds * 1000))
+    h, rem = divmod(total_ms, 3600000)
+    m, rem = divmod(rem, 60000)
+    s, ms = divmod(rem, 1000)
+    return "%02d:%02d:%02d,%03d" % (h, m, s, ms)
+
+
+def to_markdown(cues: List[Cue], interval: float = 60.0) -> str:
+    paragraphs: List[str] = []
+    current: List[str] = []
+    para_start = None
+    for start, line in dedupe(cues):
+        if para_start is None:
+            para_start = start
+        elif start - para_start >= interval:
+            paragraphs.append("[%s] %s" % (fmt_marker(para_start), " ".join(current)))
+            current = []
+            para_start = start
+        current.append(line)
+    if current and para_start is not None:
+        paragraphs.append("[%s] %s" % (fmt_marker(para_start), " ".join(current)))
+    return "\n\n".join(paragraphs)
+
+
+def offset_cues(cues: List[Cue], seconds: float) -> List[Cue]:
+    return [Cue(c.start + seconds, c.end + seconds, c.text) for c in cues]
+
+
+def render_srt(cues: List[Cue]) -> str:
+    parts = []
+    for i, c in enumerate(cues, 1):
+        parts.append("%d\n%s --> %s\n%s\n" % (i, fmt_srt_ts(c.start), fmt_srt_ts(c.end), c.text))
+    return "\n".join(parts)
+
+
+def read(path: str) -> str:
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        return fh.read()
+
+
+def cmd_to_md(args) -> int:
+    cues = parse_cues(read(args.file))
+    body = to_markdown(cues, args.interval)
+    header = []
+    if args.title:
+        header.append("# %s" % args.title)
+        header.append("")
+    meta = []
+    if args.source:
+        meta.append("- Source: %s" % args.source)
+    if args.backend:
+        engine = args.backend + (" (%s)" % args.model if args.model else "")
+        meta.append("- Transcribed with: %s" % engine)
+    if cues:
+        meta.append("- Duration: %s" % fmt_marker(cues[-1].end))
+    if meta:
+        header.extend(meta)
+        header.append("")
+    sys.stdout.write("\n".join(header) + body + "\n")
+    return 0
+
+
+def cmd_to_text(args) -> int:
+    sys.stdout.write(to_text(parse_cues(read(args.file))) + "\n")
+    return 0
+
+
+def cmd_concat(args) -> int:
+    merged: List[Cue] = []
+    for spec in args.parts:
+        path, _, offset = spec.rpartition(":")
+        if not path:
+            path, offset = spec, "0"
+        merged.extend(offset_cues(parse_cues(read(path)), float(offset)))
+    merged.sort(key=lambda c: c.start)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write(render_srt(merged))
+    return 0
+
+
+def cmd_stats(args) -> int:
+    cues = parse_cues(read(args.file))
+    text = to_text(cues)
+    print(json.dumps({
+        "cues": len(cues),
+        "chars": len(text),
+        "duration": cues[-1].end if cues else 0.0,
+    }))
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("to-md")
+    p.add_argument("file")
+    p.add_argument("--title")
+    p.add_argument("--source")
+    p.add_argument("--backend")
+    p.add_argument("--model")
+    p.add_argument("--interval", type=float, default=60.0)
+    p.set_defaults(func=cmd_to_md)
+
+    p = sub.add_parser("to-text")
+    p.add_argument("file")
+    p.set_defaults(func=cmd_to_text)
+
+    p = sub.add_parser("concat")
+    p.add_argument("--out", required=True)
+    p.add_argument("parts", nargs="+", help="path.srt:offset_seconds")
+    p.set_defaults(func=cmd_concat)
+
+    p = sub.add_parser("stats")
+    p.add_argument("file")
+    p.set_defaults(func=cmd_stats)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-plugin/omniget/scripts/transcribe.sh
+++ b/claude-plugin/omniget/scripts/transcribe.sh
@@ -43,9 +43,15 @@ if og_is_url "$input"; then
   # One yt-dlp call fetches metadata and any captions. --print implies --skip-download.
   sub_langs="en.*,en,.*-orig"
   [ -n "$lang" ] && sub_langs="$lang.*,$lang,$sub_langs"
+  caperr="$tmp/yt.err"
   meta="$("$ytdlp" --no-warnings --no-playlist --write-subs --write-auto-subs \
       --sub-langs "$sub_langs" --convert-subs srt -o "$tmp/cap.%(ext)s" \
-      --print "%(id)s ||| %(duration)s ||| %(title)s" ${cookie_args[@]+${cookie_args[@]+"${cookie_args[@]}"}} "$input" | head -n 1)"
+      --print "%(id)s ||| %(duration)s ||| %(title)s" ${cookie_args[@]+"${cookie_args[@]}"} "$input" 2>"$caperr" | head -n 1)"
+  if [ -z "$meta" ] && grep -qiE "ERROR|empty media|HTTP Error" "$caperr" 2>/dev/null; then
+    cat "$caperr" >&2
+    hint="$(og_explain_error "$(cat "$caperr")")"; [ -n "$hint" ] && log "-> $hint"
+    exit 1
+  fi
   id="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $1}')"
   duration="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $2}')"
   [ -n "$title" ] || title="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $3}')"

--- a/claude-plugin/omniget/scripts/transcribe.sh
+++ b/claude-plugin/omniget/scripts/transcribe.sh
@@ -44,9 +44,9 @@ if og_is_url "$input"; then
   sub_langs="en.*,en,.*-orig"
   [ -n "$lang" ] && sub_langs="$lang.*,$lang,$sub_langs"
   caperr="$tmp/yt.err"
-  meta="$("$ytdlp" --no-warnings --no-playlist --write-subs --write-auto-subs \
+  meta="$(og_run_ytdlp "$input" "$caperr" --no-warnings --no-playlist --write-subs --write-auto-subs \
       --sub-langs "$sub_langs" --convert-subs srt -o "$tmp/cap.%(ext)s" \
-      --print "%(id)s ||| %(duration)s ||| %(title)s" ${cookie_args[@]+"${cookie_args[@]}"} "$input" 2>"$caperr" | head -n 1)"
+      --print "%(id)s ||| %(duration)s ||| %(title)s" | head -n 1)"
   if [ -z "$meta" ] && grep -qiE "ERROR|empty media|HTTP Error" "$caperr" 2>/dev/null; then
     cat "$caperr" >&2
     hint="$(og_explain_error "$(cat "$caperr")")"; [ -n "$hint" ] && log "-> $hint"
@@ -62,7 +62,7 @@ if og_is_url "$input"; then
     caption="$(ls -S "$tmp"/cap.*.srt "$tmp"/cap.*.vtt 2>/dev/null | head -n 1 || true)"
     if [ -z "$caption" ]; then
       "$ytdlp" --no-warnings --no-playlist --skip-download --write-subs --sub-langs all \
-        --convert-subs srt -o "$tmp/cap.%(ext)s" ${cookie_args[@]+${cookie_args[@]+"${cookie_args[@]}"}} "$input" >/dev/null 2>&1 || true
+        --convert-subs srt -o "$tmp/cap.%(ext)s" ${cookie_args[@]+"${cookie_args[@]}"} "$input" >/dev/null 2>&1 || true
       caption="$(ls -S "$tmp"/cap.*.srt "$tmp"/cap.*.vtt 2>/dev/null | head -n 1 || true)"
     fi
   fi
@@ -71,8 +71,15 @@ if og_is_url "$input"; then
   else
     [ "$backend" = captions ] && { log "no usable captions for $input"; exit 3; }
     log "no captions; downloading audio"
-    audio="$("$ytdlp" --no-warnings --no-playlist --no-simulate --quiet -f "bestaudio/best" \
-        -o "$tmp/audio.%(ext)s" --print "after_move:filepath" ${cookie_args[@]+${cookie_args[@]+"${cookie_args[@]}"}} "$input" | tail -n 1)"
+    auderr="$tmp/audio.err"
+    audio="$(og_run_ytdlp "$input" "$auderr" --no-warnings --no-playlist --no-simulate --quiet -f "bestaudio/best" \
+        -o "$tmp/audio.%(ext)s" --print "after_move:filepath" | tail -n 1)"
+    if [ -z "$audio" ]; then
+      cat "$auderr" >&2 2>/dev/null || true
+      hint="$(og_explain_error "$(cat "$auderr" 2>/dev/null)")"; [ -n "$hint" ] && log "-> $hint"
+      log "could not download audio for $input"
+      exit 1
+    fi
   fi
 else
   [ -f "$input" ] || { log "no such file: $input"; exit 1; }

--- a/claude-plugin/omniget/scripts/transcribe.sh
+++ b/claude-plugin/omniget/scripts/transcribe.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Produce a transcript for a media URL or local file. Prints one JSON line:
+# {transcript, srt?, backend, model?, title, duration?, chars, source}
+#
+# Ladder (backend=auto): platform captions -> whisper-cli (local) -> mlx_whisper (local, Apple Silicon)
+#                        -> Gemini (GEMINI_API_KEY) -> OpenAI (OPENAI_API_KEY)
+# Usage: transcribe.sh <url|file> [--backend auto|captions|local|mlx|gemini|openai]
+#                      [--model NAME] [--lang xx] [--out DIR] [--keep-audio] [--title T]
+set -eu
+set -o pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$here/resolve-tools.sh"
+
+input=""; backend="auto"; model=""; lang=""; out=""; keep_audio=false; title=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --backend) backend="$2"; shift ;;
+    --model) model="$2"; shift ;;
+    --lang) lang="$2"; shift ;;
+    --out) out="$2"; shift ;;
+    --title) title="$2"; shift ;;
+    --keep-audio) keep_audio=true ;;
+    -*) echo "transcribe: unknown flag $1" >&2; exit 2 ;;
+    *) input="$1" ;;
+  esac
+  shift
+done
+[ -n "$input" ] || { echo "usage: transcribe.sh <url|file> [--backend B] [--model M] [--lang xx] [--out DIR]" >&2; exit 2; }
+case "$backend" in auto|captions|local|mlx|gemini|openai) ;; *) echo "transcribe: bad --backend $backend" >&2; exit 2 ;; esac
+[ -n "$out" ] || out="$(og_output_dir)/transcripts"
+mkdir -p "$out"
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/omniget-transcribe.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+log() { echo "transcribe: $*" >&2; }
+
+id=""; duration=""; source="$input"; audio=""
+if og_is_url "$input"; then
+  ytdlp="$(og_tool_path yt-dlp)" || { log "yt-dlp not found; run doctor.sh"; exit 1; }
+  cookie_args=()
+  while IFS= read -r line; do cookie_args+=("$line"); done < <(og_cookie_args "$input")
+
+  # One yt-dlp call fetches metadata and any captions. --print implies --skip-download.
+  sub_langs="en.*,en,.*-orig"
+  [ -n "$lang" ] && sub_langs="$lang.*,$lang,$sub_langs"
+  meta="$("$ytdlp" --no-warnings --no-playlist --write-subs --write-auto-subs \
+      --sub-langs "$sub_langs" --convert-subs srt -o "$tmp/cap.%(ext)s" \
+      --print "%(id)s ||| %(duration)s ||| %(title)s" ${cookie_args[@]+${cookie_args[@]+"${cookie_args[@]}"}} "$input" | head -n 1)"
+  id="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $1}')"
+  duration="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $2}')"
+  [ -n "$title" ] || title="$(printf '%s' "$meta" | awk -F' \\|\\|\\| ' '{print $3}')"
+  [ "$duration" = "NA" ] && duration=""
+
+  caption=""
+  if [ "$backend" = auto ] || [ "$backend" = captions ]; then
+    caption="$(ls -S "$tmp"/cap.*.srt "$tmp"/cap.*.vtt 2>/dev/null | head -n 1 || true)"
+    if [ -z "$caption" ]; then
+      "$ytdlp" --no-warnings --no-playlist --skip-download --write-subs --sub-langs all \
+        --convert-subs srt -o "$tmp/cap.%(ext)s" ${cookie_args[@]+${cookie_args[@]+"${cookie_args[@]}"}} "$input" >/dev/null 2>&1 || true
+      caption="$(ls -S "$tmp"/cap.*.srt "$tmp"/cap.*.vtt 2>/dev/null | head -n 1 || true)"
+    fi
+  fi
+  if [ -n "$caption" ] && [ "$(python3 "$here/srt_tools.py" stats "$caption" | python3 -c 'import json,sys; print(json.load(sys.stdin)["chars"])')" -gt 20 ]; then
+    srt_src="$caption"; used="captions"; used_model="$(basename "$caption" | sed 's/^cap\.//; s/\.[a-z]*$//')"
+  else
+    [ "$backend" = captions ] && { log "no usable captions for $input"; exit 3; }
+    log "no captions; downloading audio"
+    audio="$("$ytdlp" --no-warnings --no-playlist --no-simulate --quiet -f "bestaudio/best" \
+        -o "$tmp/audio.%(ext)s" --print "after_move:filepath" ${cookie_args[@]+${cookie_args[@]+"${cookie_args[@]}"}} "$input" | tail -n 1)"
+  fi
+else
+  [ -f "$input" ] || { log "no such file: $input"; exit 1; }
+  audio="$input"
+  [ -n "$title" ] || title="$(basename "${input%.*}")"
+  source="$(cd "$(dirname "$input")" && pwd)/$(basename "$input")"
+  [ "$backend" = captions ] && { log "--backend captions needs a URL"; exit 2; }
+fi
+
+if [ -n "$audio" ]; then
+  ffmpeg="$(og_tool_path ffmpeg)" || { log "ffmpeg not found; run doctor.sh"; exit 1; }
+  if [ -z "$duration" ] && ffprobe="$(og_tool_path ffprobe)"; then
+    duration="$("$ffprobe" -v error -show_entries format=duration -of csv=p=0 "$audio" 2>/dev/null || true)"
+  fi
+
+  if [ "$backend" = auto ]; then
+    if og_find_tool whisper-cli >/dev/null && og_whisper_model >/dev/null; then backend=local
+    elif og_find_tool mlx_whisper >/dev/null; then backend=mlx
+    elif og_has_key GEMINI_API_KEY; then backend=gemini
+    elif og_has_key OPENAI_API_KEY; then backend=openai
+    else
+      log "no transcription backend available: install whisper-cli + a model, mlx-whisper, or set GEMINI_API_KEY / OPENAI_API_KEY (see doctor.sh)"
+      exit 4
+    fi
+  fi
+  log "backend: $backend"
+
+  case "$backend" in
+    local)
+      cli="$(og_tool_path whisper-cli)" || { log "whisper-cli not found (brew install whisper-cpp)"; exit 4; }
+      if [ -n "$model" ]; then
+        [ -f "$model" ] || model="$("$here/get-model.sh" "$model")"
+      else
+        model="$(og_whisper_model)" || { log "no whisper model; run get-model.sh large-v3-turbo-q5_0"; exit 4; }
+      fi
+      "$ffmpeg" -v error -y -i "$audio" -ac 1 -ar 16000 -c:a pcm_s16le "$tmp/a16.wav"
+      threads="$( (sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4) )"
+      [ "$threads" -gt 8 ] && threads=8
+      "$cli" -m "$model" -f "$tmp/a16.wav" -l "${lang:-auto}" -t "$threads" -osrt -of "$tmp/out" -np -pp 1>&2
+      srt_src="$tmp/out.srt"; used=local; used_model="$(basename "$model")"
+      ;;
+    mlx)
+      mlx="$(og_tool_path mlx_whisper)" || { log "mlx_whisper not found (uv tool install mlx-whisper)"; exit 4; }
+      [ -n "$model" ] || model="mlx-community/whisper-large-v3-turbo"
+      "$ffmpeg" -v error -y -i "$audio" -ac 1 -ar 16000 -c:a pcm_s16le "$tmp/a16.wav"
+      "$mlx" "$tmp/a16.wav" --model "$model" --output-dir "$tmp" --output-name out --output-format srt \
+        ${lang:+--language "$lang"} 1>&2
+      srt_src="$tmp/out.srt"; used=mlx; used_model="$model"
+      ;;
+    gemini)
+      og_load_keys
+      [ -n "$model" ] || model="gemini-2.5-flash"
+      "$ffmpeg" -v error -y -i "$audio" -ac 1 -ar 16000 -b:a 32k "$tmp/a16.mp3"
+      result="$(python3 "$here/gemini_transcribe.py" "$tmp/a16.mp3" --out "$tmp/out.srt" --model "$model" ${lang:+--lang "$lang"})"
+      used=gemini; used_model="$model"
+      case "$result" in *.srt) srt_src="$result" ;; *) text_src="$result" ;; esac
+      ;;
+    openai)
+      og_load_keys
+      [ -n "$model" ] || model="whisper-1"
+      "$ffmpeg" -v error -y -i "$audio" -ac 1 -ar 16000 -b:a 32k "$tmp/a16.mp3"
+      result="$("$here/openai_transcribe.sh" "$tmp/a16.mp3" --out "$tmp/out.srt" --model "$model" ${lang:+--lang "$lang"})"
+      used=openai; used_model="$model"
+      case "$result" in *.srt) srt_src="$result" ;; *) text_src="$result" ;; esac
+      ;;
+  esac
+fi
+
+slug="$(og_slug "$title")"
+[ -n "$id" ] && slug="$slug-$id"
+md="$out/$slug.md"
+srt=""
+if [ -n "${srt_src:-}" ]; then
+  srt="$out/$slug.srt"
+  cp "$srt_src" "$srt"
+  python3 "$here/srt_tools.py" to-md "$srt" --title "$title" --source "$source" --backend "$used" --model "$used_model" > "$md"
+else
+  {
+    printf '# %s\n\n- Source: %s\n- Transcribed with: %s (%s)\n\n' "$title" "$source" "$used" "$used_model"
+    cat "$text_src"
+  } > "$md"
+fi
+
+kept=""
+if $keep_audio && [ -n "$audio" ] && og_is_url "$input"; then
+  kept="$out/$slug.${audio##*.}"
+  cp "$audio" "$kept"
+fi
+
+chars="$(python3 -c 'import sys; print(len(open(sys.argv[1], encoding="utf-8").read()))' "$md")"
+og_json transcript="$md" srt="$srt" backend="$used" model="$used_model" title="$title" duration:n="$duration" chars:n="$chars" source="$source" audio="$kept"

--- a/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
+++ b/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
@@ -59,6 +59,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh" --check-keys
 
 On failure the scripts print a plain-language `-> hint` line classifying the cause (rate-limit / login / DRM). If a site that used to work now fails for everyone, the fix is usually stale tools: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" --update`.
 
+**Automatic login retry.** When a fetch is blocked by a login wall or rate-limit, the scripts retry once on their own using the browser you're logged into (auto-detected: Chrome/Brave/Edge/Firefox/Safari). No flag needed. Two things to know: on macOS the first browser-cookie read raises a one-time Keychain prompt (allow it, or choose Always Allow); and if your browser has several profiles and the default one isn't logged in, pin the right one — `OMNIGET_COOKIES_FROM_BROWSER=chrome:"Profile 3"`. If it's still blocked after the retry, it's a hard rate-limit — wait a few minutes.
+
 ## Rules
 
 - Downloads happen only when the user asked for the media. A bare URL with a question

--- a/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
+++ b/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
@@ -28,11 +28,23 @@ Scripts live in `${CLAUDE_PLUGIN_ROOT}/scripts/`.
 3. If the user only wants to know what the media says, use the `omniget-transcribe` skill
    instead of downloading video.
 
+## First run / missing tools
+
+If `fetch.sh` reports `yt-dlp not found` (or a fresh machine has nothing set up),
+do not hand the user raw install commands. Offer one step:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh"
+```
+It detects the OS, lists what is missing, and installs it after a single confirmation
+(Mac via brew, Windows via winget/scoop; Linux runs the distro manager when it can, else
+prints the commands). Pass `--yes` to skip the prompt. If OmniGet (the desktop app) is
+installed, `yt-dlp` and `ffmpeg` are already managed and nothing needs installing.
+
 ## When something fails
 
 Run the doctor first, then act on what it reports:
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh" --check-keys
 ```
 
 | Symptom in stderr | Meaning | Action |

--- a/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
+++ b/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
@@ -52,9 +52,12 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh" --check-keys
 | `yt-dlp not found` | no engine available | show the doctor's install lines and ask before installing anything |
 | `Sign in to confirm`, `login required`, `Private video`, HTTP 401/403 | platform wants a session | use OmniGet's cookies (automatic when the app has an account for that site) or set `OMNIGET_COOKIES_FROM_BROWSER=chrome` and retry |
 | HTTP 429, `rate-limit` | too many requests | wait 30 s and retry once; then stop and tell the user |
+| `empty media response`, `HTTP 400` (Instagram/X) | rate-limited or login-gated | wait a few minutes and retry; if private, provide cookies (see below). `omniget-cli` (installed by setup) handles these sites better than raw yt-dlp |
 | `DRM`, `SAMPLE-AES`, `Widevine` | protected stream | stop; explain that OmniGet does not bypass DRM |
 | `Unsupported URL` | no extractor | say so; suggest the page's direct media link if the user has one |
 | `Requested format is not available` | quality cap too strict | retry without `--quality` |
+
+On failure the scripts print a plain-language `-> hint` line classifying the cause (rate-limit / login / DRM). If a site that used to work now fails for everyone, the fix is usually stale tools: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" --update`.
 
 ## Rules
 

--- a/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
+++ b/claude-plugin/omniget/skills/omniget-fetch/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: omniget-fetch
+description: This skill should be used when the user pastes a video, audio or social-post URL (YouTube, TikTok, Instagram, X/Twitter, Reddit, Vimeo, Twitch, Bilibili, Threads, Pinterest, direct .mp4/.m3u8 links) and asks to "download this", "get this video", "save the audio", "grab this reel", "fetch this clip", "pull the mp4", or otherwise wants the media file on disk. Also covers "what tools do I have for downloading" and "why did the download fail".
+version: 0.1.0
+---
+
+# Fetching media with OmniGet's tooling
+
+Download media through the plugin's scripts instead of hand-writing yt-dlp
+invocations. The scripts reuse whatever the user already has, in this order:
+`omniget-cli` on PATH, the binaries OmniGet manages inside its app-data folder,
+then system `yt-dlp`/`ffmpeg`. Every script prints one JSON line on success.
+
+Scripts live in `${CLAUDE_PLUGIN_ROOT}/scripts/`.
+
+## Workflow
+
+1. Run the download. Quote the URL.
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/fetch.sh" "<url>" [--audio] [--quality 720] [--out DIR]
+   ```
+   Output: `{"file","title","duration","size","platform","engine","id"}`.
+   - Default output directory is `~/Downloads/omniget` (override with `OMNIGET_DIR` or `--out`).
+   - `--audio` keeps only the audio track as `.m4a`. `--quality N` caps the video height.
+   - Instagram, Threads, X and Bilibili links go through `omniget-cli` when it is installed,
+     which brings OmniGet's native extractors and cookie accounts.
+2. Report the file path, size and duration in one or two sentences. Do not paste the JSON.
+3. If the user only wants to know what the media says, use the `omniget-transcribe` skill
+   instead of downloading video.
+
+## When something fails
+
+Run the doctor first, then act on what it reports:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh"
+```
+
+| Symptom in stderr | Meaning | Action |
+|---|---|---|
+| `yt-dlp not found` | no engine available | show the doctor's install lines and ask before installing anything |
+| `Sign in to confirm`, `login required`, `Private video`, HTTP 401/403 | platform wants a session | use OmniGet's cookies (automatic when the app has an account for that site) or set `OMNIGET_COOKIES_FROM_BROWSER=chrome` and retry |
+| HTTP 429, `rate-limit` | too many requests | wait 30 s and retry once; then stop and tell the user |
+| `DRM`, `SAMPLE-AES`, `Widevine` | protected stream | stop; explain that OmniGet does not bypass DRM |
+| `Unsupported URL` | no extractor | say so; suggest the page's direct media link if the user has one |
+| `Requested format is not available` | quality cap too strict | retry without `--quality` |
+
+## Rules
+
+- Downloads happen only when the user asked for the media. A bare URL with a question
+  about its content is a transcription request, not a download request.
+- Never run an install command (brew, winget, apt, pip, uv) without the user's explicit yes;
+  the doctor prints the commands, the user decides.
+- Cookies files and API keys are never printed, copied or committed.
+- Prefer `--audio` for podcasts, talks and anything the user will only listen to or transcribe.
+
+## Environment variables
+
+`OMNIGET_DIR` (output), `OMNIGET_DATA_DIR` (OmniGet app data, auto-detected per OS),
+`OMNIGET_TOOL_YT_DLP` / `OMNIGET_TOOL_FFMPEG` (explicit binaries),
+`OMNIGET_COOKIES_FROM_BROWSER` (chrome, firefox, safari, edge).

--- a/claude-plugin/omniget/skills/omniget-transcribe/SKILL.md
+++ b/claude-plugin/omniget/skills/omniget-transcribe/SKILL.md
@@ -53,7 +53,7 @@ Keys are read from the environment or `~/.config/ai-keys.env`. Never print them.
 |---|---|---|
 | 3 | `--backend captions` and the platform has none | rerun with `--backend auto` |
 | 4 | no local engine and no key | offer `setup.sh` (installs tools, confirm once) and tell the user to add a key with `keys.sh set` in their own terminal; `get-model.sh large-v3-turbo-q5_0` fetches a local model (547 MB) |
-| 1 | tool missing or download failed | run `doctor.sh`; for login errors see the `omniget-fetch` skill's error table |
+| 1 | tool missing or download failed | read the `-> hint` the script printed (rate-limit / login / DRM); run `doctor.sh`, or `setup.sh --update` if a site broke; for login errors see the `omniget-fetch` error table |
 
 ## Rules
 

--- a/claude-plugin/omniget/skills/omniget-transcribe/SKILL.md
+++ b/claude-plugin/omniget/skills/omniget-transcribe/SKILL.md
@@ -45,14 +45,14 @@ Choose deliberately when the user states a preference:
 - Known language: pass `--lang en` (or `pt`, `es`, ...) to every backend; it speeds up and sharpens results.
 - Recording longer than two hours: say so and confirm before a cloud backend runs.
 
-Keys are read from the environment or `~/.config/ai-keys.env`. Never print them.
+Keys are read from the environment or `~/.config/ai-keys.env`. Never print them. To add one, the user runs `bash "${CLAUDE_PLUGIN_ROOT}/scripts/keys.sh" set` in their own terminal (hidden input); never ask them to paste a key here. `keys.sh check` (or `doctor.sh --check-keys`) reports which keys work.
 
 ## Exit codes and what to do
 
 | Exit | Meaning | Action |
 |---|---|---|
 | 3 | `--backend captions` and the platform has none | rerun with `--backend auto` |
-| 4 | no local engine and no key | run `doctor.sh`, show the install lines, ask before installing; `get-model.sh large-v3-turbo-q5_0` fetches the model (547 MB) |
+| 4 | no local engine and no key | offer `setup.sh` (installs tools, confirm once) and tell the user to add a key with `keys.sh set` in their own terminal; `get-model.sh large-v3-turbo-q5_0` fetches a local model (547 MB) |
 | 1 | tool missing or download failed | run `doctor.sh`; for login errors see the `omniget-fetch` skill's error table |
 
 ## Rules

--- a/claude-plugin/omniget/skills/omniget-transcribe/SKILL.md
+++ b/claude-plugin/omniget/skills/omniget-transcribe/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: omniget-transcribe
+description: This skill should be used when the user shares a video, audio, podcast or social-post URL or a local media file and asks "what does this video say", "transcribe this", "summarize this video", "get the transcript", "what is this reel about", "research this post", "pull the caption", "turn this talk into notes", "quote the part where", "translate what they say", or wants to analyze spoken content from a link. Covers YouTube, TikTok, Instagram, X/Twitter, Reddit, Vimeo, Twitch, Bilibili, Threads and any local .mp4/.mp3/.wav/.m4a.
+version: 0.1.0
+---
+
+# Transcribing and researching media
+
+Turn a link or file into text with `${CLAUDE_PLUGIN_ROOT}/scripts/`, then read the
+transcript and answer. Claude cannot hear audio, so a speech-to-text step always runs first.
+Each script prints one JSON line on success; progress goes to stderr.
+
+## Pipeline
+
+1. **Describe the source** (URL only, no download):
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/research.sh" "<url>"
+   ```
+   Returns `title`, `platform`, `uploader`, `duration`, `has_captions`, and `caption`
+   (the post text or description) when the platform provides one. Skip this step for local files.
+2. **Get the transcript**:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/transcribe.sh" "<url-or-file>" [--backend auto|captions|local|mlx|gemini|openai] [--model NAME] [--lang xx] [--out DIR]
+   ```
+   Returns `transcript` (Markdown with `[mm:ss]` markers), `srt` when timestamps exist,
+   `backend`, `model`, `duration`, `chars`. Files land in `~/Downloads/omniget/transcripts`
+   unless `--out` or `OMNIGET_DIR` says otherwise.
+3. **Read the `.md` file** and do what was asked: summarize, extract key points, quote with
+   timestamps, translate, or write a research note that combines the caption and the transcript.
+   Cite moments as `[mm:ss]`. Do not paste the whole transcript back unless asked.
+
+## Backend ladder (`--backend auto`)
+
+| Order | Backend | Needs | Cost | Notes |
+|---|---|---|---|---|
+| 1 | `captions` | platform subtitles | free, seconds | tried first for every URL; auto-captions are rough but usable |
+| 2 | `local` | `whisper-cli` + a ggml model | free, private | CPU/Metal; `large-v3-turbo-q5_0` is the default model choice |
+| 3 | `mlx` | `mlx_whisper` (Apple Silicon) | free, private | faster than whisper-cli on M-series Macs |
+| 4 | `gemini` | `GEMINI_API_KEY` | cents per hour | audio-native; good for long recordings |
+| 5 | `openai` | `OPENAI_API_KEY` | about $0.006 per minute | `whisper-1` returns timestamps; `--model gpt-4o-transcribe` is more accurate but text-only |
+
+Choose deliberately when the user states a preference:
+- "most accurate" with an OpenAI key: `--backend openai --model gpt-4o-transcribe`.
+- "free" or "offline" or "private": `--backend local` (or `mlx` on a Mac).
+- Known language: pass `--lang en` (or `pt`, `es`, ...) to every backend; it speeds up and sharpens results.
+- Recording longer than two hours: say so and confirm before a cloud backend runs.
+
+Keys are read from the environment or `~/.config/ai-keys.env`. Never print them.
+
+## Exit codes and what to do
+
+| Exit | Meaning | Action |
+|---|---|---|
+| 3 | `--backend captions` and the platform has none | rerun with `--backend auto` |
+| 4 | no local engine and no key | run `doctor.sh`, show the install lines, ask before installing; `get-model.sh large-v3-turbo-q5_0` fetches the model (547 MB) |
+| 1 | tool missing or download failed | run `doctor.sh`; for login errors see the `omniget-fetch` skill's error table |
+
+## Rules
+
+- Never start an install or a model download without the user's explicit yes.
+- Summaries state which backend produced the transcript when accuracy matters (auto-captions vs. Whisper).
+- Keep `.srt` and `.md` next to each other; the user may open the SRT in OmniGet's Subtitle Workshop.

--- a/claude-plugin/omniget/tests/test_gemini_norm.py
+++ b/claude-plugin/omniget/tests/test_gemini_norm.py
@@ -1,0 +1,44 @@
+import importlib.util
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(__file__)
+SCRIPTS = os.path.join(HERE, "..", "scripts")
+sys.path.insert(0, SCRIPTS)
+
+import srt_tools  # noqa: E402
+
+spec = importlib.util.spec_from_file_location("gemini_transcribe", os.path.join(SCRIPTS, "gemini_transcribe.py"))
+gemini = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gemini)
+
+
+class NormalizeTests(unittest.TestCase):
+    def _first(self, raw):
+        cues = srt_tools.parse_cues(gemini.normalize_srt_timestamps(raw))
+        self.assertTrue(cues, "no cue parsed from %r" % raw)
+        return srt_tools.fmt_srt_ts(cues[0].start), srt_tools.fmt_srt_ts(cues[0].end)
+
+    def test_mm_ss_ms_with_colon(self):
+        self.assertEqual(self._first("1\n00:17:200 --> 00:18:400\nx\n"), ("00:00:17,200", "00:00:18,400"))
+
+    def test_dot_millis(self):
+        self.assertEqual(self._first("1\n00:00:01.500 --> 00:00:03.000\nx\n"), ("00:00:01,500", "00:00:03,000"))
+
+    def test_no_millis_hms(self):
+        self.assertEqual(self._first("1\n01:02:03 --> 01:02:05\nx\n"), ("01:02:03,000", "01:02:05,000"))
+
+    def test_bare_mm_ss(self):
+        self.assertEqual(self._first("1\n00:05 --> 00:09\nx\n"), ("00:00:05,000", "00:00:09,000"))
+
+    def test_correct_form_untouched(self):
+        self.assertEqual(self._first("1\n00:00:17,200 --> 00:00:18,400\nx\n"), ("00:00:17,200", "00:00:18,400"))
+
+    def test_non_timestamp_lines_survive(self):
+        raw = "WEBVTT stays\n1\n00:00:01,000 --> 00:00:02,000\nhello\n"
+        self.assertIn("hello", gemini.normalize_srt_timestamps(raw))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/claude-plugin/omniget/tests/test_keys.sh
+++ b/claude-plugin/omniget/tests/test_keys.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tests for keys.sh _upsert_env: it must set/replace one var while preserving the rest.
+set -u
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fail=0
+check() { if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "FAIL: $1 — expected [$3], got [$2]"; fail=1; fi; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export OMNIGET_KEYS_FILE="$tmp/ai-keys.env"
+# seed with unrelated keys that must survive
+printf 'REPLICATE_API_KEY=keep-me\nANTHROPIC_API_KEY=also-keep\n' > "$OMNIGET_KEYS_FILE"
+
+# shellcheck source=../scripts/keys.sh
+. "$here/../scripts/keys.sh"
+
+printf 'sk-openai-1' | _upsert_env OPENAI_API_KEY
+printf 'gem-1'       | _upsert_env GEMINI_API_KEY
+printf 'sk-openai-2' | _upsert_env OPENAI_API_KEY   # replace, not append
+
+get() { grep -E "^$1=" "$OMNIGET_KEYS_FILE" | tail -1 | cut -d= -f2-; }
+count() { grep -cE "^$1=" "$OMNIGET_KEYS_FILE"; }
+
+check "unrelated key preserved (replicate)" "$(get REPLICATE_API_KEY)" "keep-me"
+check "unrelated key preserved (anthropic)" "$(get ANTHROPIC_API_KEY)" "also-keep"
+check "openai replaced not duplicated"      "$(count OPENAI_API_KEY)" "1"
+check "openai has latest value"             "$(get OPENAI_API_KEY)" "sk-openai-2"
+check "gemini set"                          "$(get GEMINI_API_KEY)" "gem-1"
+perm="$(stat -f '%Lp' "$OMNIGET_KEYS_FILE" 2>/dev/null || stat -c '%a' "$OMNIGET_KEYS_FILE")"
+check "keys file is chmod 600"              "$perm" "600"
+
+exit $fail

--- a/claude-plugin/omniget/tests/test_retry.sh
+++ b/claude-plugin/omniget/tests/test_retry.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Tests og_run_ytdlp's one-shot cookie retry using a stub yt-dlp, so no network is needed.
+set -u
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fail=0
+check() { if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "FAIL: $1 — expected [$3] got [$2]"; fail=1; fi; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+# stub yt-dlp: fails with a rate-limit error unless --cookies-from-browser is passed.
+cat > "$tmp/yt-dlp" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do [ "$a" = "--cookies-from-browser" ] && { echo "OK title ||| 12 ||| Some Title"; exit 0; }; done
+echo "ERROR: Instagram sent an empty media response" >&2
+exit 1
+STUB
+chmod +x "$tmp/yt-dlp"
+
+# stub that always fails (even with cookies) -> block persists.
+cat > "$tmp/yt-dlp-hardfail" <<'STUB'
+#!/usr/bin/env bash
+echo "ERROR: Instagram sent an empty media response" >&2
+exit 1
+STUB
+chmod +x "$tmp/yt-dlp-hardfail"
+
+# stub that fails with a NON-retryable error (DRM) -> must NOT retry.
+cat > "$tmp/yt-dlp-drm" <<'STUB'
+#!/usr/bin/env bash
+echo "ERROR: HLS uses SAMPLE-AES (FairPlay DRM), cannot decrypt" >&2
+exit 1
+STUB
+chmod +x "$tmp/yt-dlp-drm"
+
+export OMNIGET_KEYS_FILE="$tmp/none.env"   # keep key loading inert
+# shellcheck source=../scripts/resolve-tools.sh
+. "$here/../scripts/resolve-tools.sh"
+
+url="https://www.instagram.com/reel/TESTTEST/"
+
+# 1) retry succeeds when cookies help
+export OMNIGET_TOOL_YT_DLP="$tmp/yt-dlp"
+err="$tmp/e1"; out="$(og_run_ytdlp "$url" "$err" --print x 2>"$tmp/notice1")"; rc=$?
+check "retry: exit 0 when cookies unblock" "$rc" "0"
+check "retry: returns stub stdout"         "$out" "OK title ||| 12 ||| Some Title"
+grep -q "retrying with" "$tmp/notice1" && echo "ok: retry: printed the retry notice" || { echo "FAIL: retry notice missing"; fail=1; }
+
+# 2) hard-fail: one retry, then give up non-zero (no infinite loop)
+export OMNIGET_TOOL_YT_DLP="$tmp/yt-dlp-hardfail"
+err="$tmp/e2"; out="$(og_run_ytdlp "$url" "$err" --print x 2>/dev/null)"; rc=$?
+check "hardfail: exit non-zero"            "$rc" "1"
+check "hardfail: empty stdout"             "$out" ""
+grep -qi "empty media" "$err" && echo "ok: hardfail: error captured to errfile" || { echo "FAIL: errfile empty"; fail=1; }
+
+# 3) non-retryable error (DRM) must NOT trigger a cookie retry
+export OMNIGET_TOOL_YT_DLP="$tmp/yt-dlp-drm"
+err="$tmp/e3"; og_run_ytdlp "$url" "$err" --print x >/dev/null 2>"$tmp/notice3"; rc=$?
+check "drm: exit non-zero"                 "$rc" "1"
+if grep -q "retrying with" "$tmp/notice3"; then echo "FAIL: drm should not retry"; fail=1; else echo "ok: drm: no retry attempted"; fi
+
+exit $fail

--- a/claude-plugin/omniget/tests/test_srt_tools.py
+++ b/claude-plugin/omniget/tests/test_srt_tools.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import srt_tools  # noqa: E402
+
+SRT = """1
+00:00:00,000 --> 00:00:02,500
+Hello <b>world</b> &amp; friends
+
+2
+00:00:02,500 --> 00:00:05,000
+second line
+"""
+
+VTT = """WEBVTT
+Kind: captions
+Language: en
+
+00:00:00.000 --> 00:00:02.500 align:start position:0%
+Hello world
+
+00:00:02.500 --> 00:00:05.000
+second line
+"""
+
+ROLLING = """1
+00:00:00,000 --> 00:00:01,000
+Hello world
+
+2
+00:00:01,000 --> 00:00:02,000
+Hello world this is
+
+3
+00:00:02,000 --> 00:00:03,000
+this is a test
+"""
+
+
+class ParseTests(unittest.TestCase):
+    def test_parses_srt_and_strips_markup(self):
+        cues = srt_tools.parse_cues(SRT)
+        self.assertEqual(len(cues), 2)
+        self.assertEqual(cues[0].start, 0.0)
+        self.assertEqual(cues[0].end, 2.5)
+        self.assertEqual(cues[0].text, "Hello world & friends")
+        self.assertEqual(cues[1].text, "second line")
+
+    def test_parses_vtt_with_cue_settings(self):
+        cues = srt_tools.parse_cues(VTT)
+        self.assertEqual(len(cues), 2)
+        self.assertEqual(cues[0].text, "Hello world")
+        self.assertEqual(cues[1].start, 2.5)
+
+    def test_hours_are_parsed(self):
+        cues = srt_tools.parse_cues("1\n01:02:03,004 --> 01:02:04,000\nx\n")
+        self.assertAlmostEqual(cues[0].start, 3723.004)
+
+
+    def test_parses_cues_without_blank_separators(self):
+        # Some models emit consecutive cues with no blank line between blocks.
+        raw = ("1\n00:00:00,000 --> 00:00:02,000\nfirst line\n"
+               "2\n00:00:02,000 --> 00:00:04,000\nsecond line\n")
+        cues = srt_tools.parse_cues(raw)
+        self.assertEqual(len(cues), 2)
+        self.assertEqual(cues[0].text, "first line")
+        self.assertEqual(cues[1].text, "second line")
+
+    def test_final_numeric_caption_is_kept(self):
+        raw = "1\n00:00:01,000 --> 00:00:02,000\n2024\n"
+        cues = srt_tools.parse_cues(raw)
+        self.assertEqual(cues[0].text, "2024")
+
+
+class TranscriptTests(unittest.TestCase):
+    def test_rolling_captions_are_deduplicated(self):
+        cues = srt_tools.parse_cues(ROLLING)
+        self.assertEqual(srt_tools.to_text(cues), "Hello world this is a test")
+
+    def test_markdown_has_time_markers_per_interval(self):
+        cues = [
+            srt_tools.Cue(0.0, 2.0, "one"),
+            srt_tools.Cue(30.0, 32.0, "two"),
+            srt_tools.Cue(70.0, 72.0, "three"),
+        ]
+        md = srt_tools.to_markdown(cues, interval=60)
+        self.assertIn("[00:00] one two", md)
+        self.assertIn("[01:10] three", md)
+
+    def test_markdown_marker_uses_hours_when_needed(self):
+        cues = [srt_tools.Cue(3725.0, 3726.0, "late")]
+        self.assertIn("[1:02:05] late", srt_tools.to_markdown(cues, interval=60))
+
+
+class ConcatTests(unittest.TestCase):
+    def test_offset_and_render_round_trip(self):
+        cues = srt_tools.parse_cues(SRT)
+        shifted = srt_tools.offset_cues(cues, 1200.0)
+        srt = srt_tools.render_srt(shifted)
+        again = srt_tools.parse_cues(srt)
+        self.assertEqual(again[0].start, 1200.0)
+        self.assertEqual(again[1].end, 1205.0)
+        self.assertIn("00:20:00,000 --> 00:20:02,500", srt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an OmniGet **Claude Code plugin** (agent skill): paste a video/post URL into any
Claude Code session and it downloads the media, pulls the caption, and transcribes the
audio — ready to summarize, quote, or research. It's the standalone skill from #315.

It's a thin layer over the tools OmniGet already manages: it resolves `omniget-cli` first
(native Instagram/X/Bilibili/Threads extractors), then OmniGet's managed `yt-dlp`/`ffmpeg`,
then system `PATH`. With the desktop app installed the good path is automatic; without it,
`/omniget:setup` installs what's missing.

**This PR adds only `claude-plugin/` — no changes to the Rust app or the frontend**, so it
can't affect the build.

## What's in it

- **Skills**: `omniget-fetch`, `omniget-transcribe` (auto-trigger on a pasted URL).
- **Commands**: `/omniget:fetch`, `/omniget:transcribe`, `/omniget:research`,
  `/omniget:setup`, `/omniget:doctor`.
- **Transcription ladder**: platform captions → local `whisper.cpp`/`mlx_whisper` →
  Gemini → OpenAI. Captions cover the post description; comments are out of scope.
  (OpenRouter is intentionally excluded — it has no speech-to-text endpoint.)
- **One-step setup** (`setup.sh`): installs `yt-dlp`/`ffmpeg` (brew / winget-scoop /
  apt-dnf-pacman), downloads the prebuilt `omniget-cli` for the OS/arch, and reports key
  status. `--update` refreshes them.
- **Keys** (`keys.sh`): interactive `set` (hidden input, `~/.config/ai-keys.env`, 600) and
  live `check` for OpenAI/Gemini. Keys never pass through the model.
- **Reliability**: on a login/rate-limit block, fetches auto-retry once with the browser
  login; SHA-256-verified model downloads; plain-language error hints (rate-limit vs login
  vs DRM).
- **Docs**: `INSTALL.md` (per-OS, updating, honest handling of private/Instagram content).
- **Tests**: SRT/VTT parsing + dedupe + timestamp normalization; key-file merge; the
  cookie-retry logic (stubbed, no network). `python3 -m unittest discover -s tests`,
  `bash tests/test_keys.sh`, `bash tests/test_retry.sh`.

## Placement is your call (#315)

I filed #315 to agree where this should live before assuming — in this repo under
`claude-plugin/`, in `tonhowtf/omniget-plugins`, or as a linked standalone repo. This PR
puts it in-repo so the code is concrete to look at; I'm happy to relocate it wherever you
prefer, or to close this in favour of one of the other homes.

Related: #314 (local transcription as a managed dependency in the app itself).
